### PR TITLE
fix(adapter): resolve default plane names on Spanish SolidWorks installs

### DIFF
--- a/src/solidworks_mcp/adapters/pywin32_adapter.py
+++ b/src/solidworks_mcp/adapters/pywin32_adapter.py
@@ -1112,6 +1112,19 @@ class PyWin32Adapter(SolidWorksAdapter):
                 "YZ": "Right Plane",
             }
 
+            # Spanish-UI SolidWorks names default planes "Alzado"/"Planta"/
+            # "Vista lateral". Map each semantic name to its locale variants
+            # so the feature lookup below finds the right plane regardless
+            # of install language.
+            semantic_plane_aliases = {
+                "Top": ["Top Plane", "Planta"],
+                "Front": ["Front Plane", "Alzado"],
+                "Right": ["Right Plane", "Vista lateral"],
+                "XY": ["Top Plane", "Planta"],
+                "XZ": ["Front Plane", "Alzado"],
+                "YZ": ["Right Plane", "Vista lateral"],
+            }
+
             actual_plane = plane_name_map.get(plane, plane)
 
             selected = False
@@ -1119,11 +1132,15 @@ class PyWin32Adapter(SolidWorksAdapter):
 
             # Prefer direct feature lookup to avoid SelectByID2 variant mismatch.
             plane_candidates = [
+                *semantic_plane_aliases.get(plane, []),
                 actual_plane,
                 plane,
                 "Top Plane",
                 "Front Plane",
                 "Right Plane",
+                "Planta",
+                "Alzado",
+                "Vista lateral",
             ]
             for candidate in plane_candidates:
                 if not candidate:


### PR DESCRIPTION
## Summary

`create_sketch` fails on Spanish-UI SolidWorks installs with
`DISP_E_TYPEMISMATCH` because the three default reference planes are
named `Alzado` (Front), `Planta` (Top), and `Vista lateral` (Right) —
not the English `Front Plane` / `Top Plane` / `Right Plane`. The
existing `plane_name_map` only knows English names, so
`FeatureByName("Front Plane")` returns None and the SelectByID2
fallback also fails.

This PR adds a `semantic_plane_aliases` map that returns all language
variants for each semantic name, and extends the `plane_candidates`
list to also try the Spanish plane names. English installs see their
English names tried first (original order preserved); Spanish installs
get the extra candidates appended.

## Repro (on a Spanish-UI SW 2024 workstation)

```python
from solidworks_mcp.adapters.pywin32_adapter import PyWin32Adapter
adapter = PyWin32Adapter()
await adapter.connect()
await adapter.create_part(name="Test")
result = await adapter.create_sketch(plane="Front")
# Before: result.status == ERROR, error mentions
#   'Failed to select plane: Front Plane ((-2147352571, ...))'
# After:  result.status == SUCCESS
```

## Test plan

- [x] Spanish-UI SW 2024: `create_sketch("Front")` succeeds on Alzado
- [x] Spanish-UI SW 2024: full smoke (`create_part → create_sketch →
      add_rectangle → exit_sketch → create_extrusion`) succeeds
- [ ] English-UI SolidWorks (not available on the contributor's
      workstation — please validate): English names still resolve, order
      unchanged

## Alternatives considered

- **Gate on SolidWorks UI locale at runtime** — rejected: requires an
  extra COM call per `create_sketch`, and the brute-force candidate
  list is O(6) with zero runtime cost on English installs (first match
  wins).
- **Normalise via `GetFeatureByName` on the TypeName** — rejected:
  the typename for a reference plane is locale-invariant
  (`RefPlane`), but iterating the feature tree to find the nth
  RefPlane is more brittle than the name list.

## Related

- See workspace `docs/known-issues.md` RUNTIME ISSUE 014 for the full
  investigation trail (including ruling out a pywin32 gen_py /
  VARIANT(VT_DISPATCH, None) false lead).
