### PR TITLE
fix(cache+adapter): mass-property calls returned stale results mid-build

### DIFF
--- a/src/solidworks_mcp/adapters/intelligent_router.py
+++ b/src/solidworks_mcp/adapters/intelligent_router.py
@@ -68,9 +68,12 @@ class IntelligentRouter:
             "list_configurations",
             "get_file_properties",
             "get_dimension",
-            # Analysis operations (expensive, often repeated)
-            "get_mass_properties",
-            "calculate_mass_properties",
+            # Analysis operations — NOT cached: model state changes with
+            # every feature-creation tool call and the router has no
+            # automatic invalidation. Caching these produced stale
+            # volumes mid-build.
+            # "get_mass_properties",
+            # "calculate_mass_properties",
             "get_material_properties",
             "analyze_geometry",
             "check_interference",

--- a/src/solidworks_mcp/adapters/pywin32_adapter.py
+++ b/src/solidworks_mcp/adapters/pywin32_adapter.py
@@ -1892,6 +1892,13 @@ class PyWin32Adapter(SolidWorksAdapter):
             Raises:
                 Exception: Failed to get mass properties.
             """
+            # Force a rebuild first — otherwise the IMassProperty reflects
+            # the geometry from the last rebuild checkpoint, which can be
+            # stale after a sequence of feature-creation calls within a
+            # single MCP session.
+            self._attempt(
+                lambda: self.currentModel.ForceRebuild3(False), default=None
+            )
             mass_props = self._attempt(
                 lambda: self.currentModel.Extension.CreateMassProperty(), default=None
             )


### PR DESCRIPTION
## Summary

Two coupled bugs cause `calculate_mass_properties` / `get_mass_properties`
to return stale results when called repeatedly in a single MCP session:

1. **Cache without invalidation** — `IntelligentRouter._cacheable_operations`
   includes both mass-property ops. The cache has no feature-creation hook,
   so the first mid-build call populates it and every subsequent call returns
   the stale cached volume regardless of new features landing in the tree.

2. **No explicit rebuild** — even without the cache, on some SW builds the
   `IMassProperty` object reflects the geometry from the last rebuild
   checkpoint, not the current feature tree.

This PR removes mass-property ops from the default cacheable set and adds
an explicit `ForceRebuild3(False)` call at the start of
`_mass_props_operation`.

## Reproducer

```python
# Active document: SW part in memory
adapter = PyWin32Adapter(); await adapter.connect()
await adapter.create_part(name="mp_test")
await adapter.create_sketch("Front")
await adapter.add_rectangle(-50, -50, 50, 50)
await adapter.exit_sketch()
await adapter.create_extrusion(sketch_name="Sketch1", depth=5.0)
r1 = await adapter.calculate_mass_properties()    # → 50 000 mm³  ✓

# Add a cut
await adapter.create_sketch("Front")
await adapter.add_circle(0, 0, 29.5)
await adapter.exit_sketch()
await adapter.create_cut_extrude(sketch_name="Sketch2", depth=4.0)

r2 = await adapter.calculate_mass_properties()
# Before:  50 000 mm³  (stale — cached)
# After:   39 064 mm³  (correct)
```

## Test plan

- [x] Manual repro on SW 2024 — mid-build volumes now reflect new cuts.
- [x] Existing 11/11 MCP regression still passes (`scripts/run_all_mcp_tests.py`).
- [x] Hand-calc verification on a scripted build
      (`scripts/build_square_plate_with_pocket_and_holes.py`): volumes
      now track: 50 000 → 49 000 (corner chamfers) → 38 064 (pocket) →
      37 671 (through-holes) → 37 587 (hole countersinks), all within
      0.002 % of analytic expectations.

## Why commenting out instead of deleting the cache entries

Kept `get_mass_properties` and `calculate_mass_properties` as commented-out
entries rather than removing them, so the commit history shows they were
deliberately excluded — a future reviewer considering whether to re-enable
the cache can read the inline note explaining the invalidation gap.

## Alternatives considered

- **Invalidate cache on every feature-creation tool call.** Rejected —
  the router doesn't have a clean hook to enumerate "feature-creation
  ops" without an explicit registry, and the invalidation cost across
  the workflow exceeds the caching benefit for mass-props specifically.
- **Only add `ForceRebuild3`**, leave cache alone. Rejected — the cache
  bypasses the adapter entirely on repeat calls, so the rebuild never
  runs. Must disable the cache for this op class to fix the bug.

## Related

Investigation trail: `docs/known-issues.md` RUNTIME ISSUE 018 in the
workspace that produced this patch.
