### PR TITLE
feat(sketch): implement add_sketch_constraint via ISketchRelationManager.AddRelation

### DIFF
--- a/docs/user-guide/tool-catalog/sketching.md
+++ b/docs/user-guide/tool-catalog/sketching.md
@@ -265,6 +265,7 @@ Add a geometric constraint/relation between sketch entities.
 |-----------|------|----------|---------|-------------|
 | `entity1` | `str` | ✅ | `` | First entity name or ID |
 | `entity2` | `str?` | — | `None` | Second entity name or ID (for two-entity relations) |
+| `entity3` | `str?` | — | `None` | Third entity name or ID. **Required only for `symmetric`** (the centerline of symmetry, e.g. `"Centerline_5"`); must be `None` for all other relations |
 | `relation_type` | `str` | ✅ | `` | One of the supported relation names (see below) |
 
 **Supported `relation_type` values (case-insensitive):**
@@ -279,10 +280,11 @@ Add a geometric constraint/relation between sketch entities.
 | `coincident` | 2 | Two points (or point on entity) share location |
 | `concentric` | 2 | Two arcs/circles share center |
 | `equal` | 2 | Equal length (lines) or equal radius (arcs/circles) — maps to `swConstraintType_SAMELENGTH` |
+| `symmetric` | 3 | Two entities about a centerline; `entity3` must be the centerline ID returned by `add_centerline` |
 | `collinear` | 2 | Two lines on the same infinite line |
 | `fix` | 1 | Pin the entity in place |
 
-> **`symmetric` is not currently exposed.** The SolidWorks symmetric relation needs three selections (two entities + a centerline), but the `AddRelationInput` schema only accepts `entity1` and `entity2`. Tracked for a follow-up that extends the schema with a third entity slot.
+> **`entity3` is only used by `symmetric`.** All other relation types reject a non-null `entity3` with a clear error.
 
 **Sample call (two-entity perpendicular):**
 
@@ -291,6 +293,17 @@ Add a geometric constraint/relation between sketch entities.
   "entity1": "Line_1",
   "entity2": "Line_2",
   "relation_type": "perpendicular"
+}
+```
+
+**Sample call (three-entity symmetric):**
+
+```json
+{
+  "entity1": "Line_1",
+  "entity2": "Line_2",
+  "entity3": "Centerline_5",
+  "relation_type": "symmetric"
 }
 ```
 

--- a/docs/user-guide/tool-catalog/sketching.md
+++ b/docs/user-guide/tool-catalog/sketching.md
@@ -279,9 +279,10 @@ Add a geometric constraint/relation between sketch entities.
 | `coincident` | 2 | Two points (or point on entity) share location |
 | `concentric` | 2 | Two arcs/circles share center |
 | `equal` | 2 | Equal length (lines) or equal radius (arcs/circles) — maps to `swConstraintType_SAMELENGTH` |
-| `symmetric` | 3 | Two entities about a centerline (selection order: ent, ent, centerline) |
 | `collinear` | 2 | Two lines on the same infinite line |
 | `fix` | 1 | Pin the entity in place |
+
+> **`symmetric` is not currently exposed.** The SolidWorks symmetric relation needs three selections (two entities + a centerline), but the `AddRelationInput` schema only accepts `entity1` and `entity2`. Tracked for a follow-up that extends the schema with a third entity slot.
 
 **Sample call (two-entity perpendicular):**
 

--- a/docs/user-guide/tool-catalog/sketching.md
+++ b/docs/user-guide/tool-catalog/sketching.md
@@ -257,20 +257,62 @@ Add a geometric constraint/relation between sketch entities.
 
 **Prerequisite:** Active sketch edit mode with named entities
 
+**SolidWorks automation note:** Implemented via `ISketchRelationManager.AddRelation(entities, swConstraintType_e)`. Entities must be IDs returned from a previous `add_line` / `add_circle` / `add_arc` call (e.g. `"Line_1"`).
+
 **Parameters:**
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `entity1` | `str` | ✅ | `` | First entity name or ID |
-| `entity2` | `str?` | — | `None` | Second entity name or ID (if required) |
-| `relation_type` | `str` | ✅ | `` | Relation type (parallel, perpendicular, tangent, coincident, etc.) |
+| `entity2` | `str?` | — | `None` | Second entity name or ID (for two-entity relations) |
+| `relation_type` | `str` | ✅ | `` | One of the supported relation names (see below) |
 
-**Sample call:**
+**Supported `relation_type` values (case-insensitive):**
+
+| Name | Entity arity | Notes |
+|------|--------------|-------|
+| `horizontal` | 1 or 2 | Line(s) horizontal; with 2 endpoints aligns them horizontally |
+| `vertical` | 1 or 2 | Line(s) vertical; with 2 endpoints aligns them vertically |
+| `parallel` | 2 | Two lines parallel |
+| `perpendicular` | 2 | Two lines at 90° |
+| `tangent` | 2 | Line ↔ arc/circle, or arc ↔ arc |
+| `coincident` | 2 | Two points (or point on entity) share location |
+| `concentric` | 2 | Two arcs/circles share center |
+| `equal` | 2 | Equal length (lines) or equal radius (arcs/circles) — maps to `swConstraintType_SAMELENGTH` |
+| `symmetric` | 3 | Two entities about a centerline (selection order: ent, ent, centerline) |
+| `collinear` | 2 | Two lines on the same infinite line |
+| `fix` | 1 | Pin the entity in place |
+
+**Sample call (two-entity perpendicular):**
 
 ```json
 {
-  "entity1": "Line1",
+  "entity1": "Line_1",
+  "entity2": "Line_2",
   "relation_type": "perpendicular"
+}
+```
+
+**Sample call (single-entity horizontal):**
+
+```json
+{
+  "entity1": "Line_1",
+  "relation_type": "horizontal"
+}
+```
+
+**Response shape on success:**
+
+```json
+{
+  "status": "success",
+  "constraint": {
+    "id": "Constraint_3",
+    "type": "perpendicular",
+    "entity1": "Line_1",
+    "entity2": "Line_2"
+  }
 }
 ```
 

--- a/src/solidworks_mcp/adapters/base.py
+++ b/src/solidworks_mcp/adapters/base.py
@@ -715,7 +715,11 @@ class SolidWorksAdapter(ABC):
         )
 
     async def add_sketch_constraint(
-        self, entity1: str, entity2: str | None, relation_type: str
+        self,
+        entity1: str,
+        entity2: str | None,
+        relation_type: str,
+        entity3: str | None = None,
     ) -> AdapterResult[str]:
         """Apply a geometric constraint between sketch entities.
 
@@ -723,6 +727,9 @@ class SolidWorksAdapter(ABC):
             entity1 (str): The entity1 value.
             entity2 (str | None): The entity2 value.
             relation_type (str): The relation type value.
+            entity3 (str | None): Third entity ID — only used by the
+                ``symmetric`` relation (the centerline of symmetry). All
+                other relation types reject a non-null ``entity3``.
 
         Returns:
             AdapterResult[str]: The result produced by the operation.

--- a/src/solidworks_mcp/adapters/mock_adapter.py
+++ b/src/solidworks_mcp/adapters/mock_adapter.py
@@ -933,7 +933,11 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         )
 
     async def add_sketch_constraint(
-        self, entity1: str, entity2: str | None, relation_type: str
+        self,
+        entity1: str,
+        entity2: str | None,
+        relation_type: str,
+        entity3: str | None = None,
     ) -> AdapterResult[str]:
         """Mock adding a geometric constraint between sketch entities.
 
@@ -942,17 +946,22 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
             entity2 (str | None): Secondary sketch-entity ID, or None for
                 single-entity relations (horizontal, vertical, fix).
             relation_type (str): Constraint name (see RELATION_NAME_MAP).
+            entity3 (str | None): Third entity ID — only used by the
+                ``symmetric`` relation (the centerline of symmetry). All
+                other relation types reject a non-null ``entity3``.
 
         Returns:
             AdapterResult[str]: SUCCESS with a placeholder constraint ID, or
-                ERROR if no active sketch or the relation_type is unsupported.
+                ERROR if no active sketch, the relation_type is unsupported,
+                arity is wrong, or an entity ID is unknown.
         """
         if not self._current_sketch:
             return AdapterResult(
                 status=AdapterResultStatus.ERROR, error="No active sketch"
             )
 
-        if (relation_type or "").strip().lower() not in RELATION_NAME_MAP:
+        rt_norm = (relation_type or "").strip().lower()
+        if rt_norm not in RELATION_NAME_MAP:
             supported = ", ".join(sorted(RELATION_NAME_MAP))
             return AdapterResult(
                 status=AdapterResultStatus.ERROR,
@@ -962,25 +971,37 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
                 ),
             )
 
+        # Arity validation — mirror the real adapter
+        if rt_norm == "symmetric":
+            if entity2 is None or entity3 is None:
+                return AdapterResult(
+                    status=AdapterResultStatus.ERROR,
+                    error=(
+                        f"Relation '{relation_type}' requires entity1, "
+                        "entity2, and entity3 (the centerline of symmetry)"
+                    ),
+                )
+        elif entity3 is not None:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    f"Relation '{relation_type}' does not accept entity3 — "
+                    "only 'symmetric' takes a third entity (the centerline)"
+                ),
+            )
+
         # Validate entity IDs against the in-process sketch-entity registry
         # so the mock surfaces the same "Unknown sketch entity" error as the
         # real adapter (which checks adapter._sketch_entities).
-        if entity1 not in self._sketch_entity_ids:
-            return AdapterResult(
-                status=AdapterResultStatus.ERROR,
-                error=(
-                    f"Unknown sketch entity '{entity1}'. Use IDs returned by "
-                    "add_line/add_arc/add_circle."
-                ),
-            )
-        if entity2 is not None and entity2 not in self._sketch_entity_ids:
-            return AdapterResult(
-                status=AdapterResultStatus.ERROR,
-                error=(
-                    f"Unknown sketch entity '{entity2}'. Use IDs returned by "
-                    "add_line/add_arc/add_circle."
-                ),
-            )
+        for ent in (entity1, entity2, entity3):
+            if ent is not None and ent not in self._sketch_entity_ids:
+                return AdapterResult(
+                    status=AdapterResultStatus.ERROR,
+                    error=(
+                        f"Unknown sketch entity '{ent}'. Use IDs returned by "
+                        "add_line/add_arc/add_circle."
+                    ),
+                )
 
         await asyncio.sleep(self._delays["sketch_operation"] / 2)
         self._operation_count += 1

--- a/src/solidworks_mcp/adapters/mock_adapter.py
+++ b/src/solidworks_mcp/adapters/mock_adapter.py
@@ -27,6 +27,7 @@ from .base import (
     SolidWorksModel,
     SweepParameters,
 )
+from .solidworks.sketch import RELATION_NAME_MAP
 
 
 class _BoolCallable:
@@ -921,6 +922,47 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
             status=AdapterResultStatus.SUCCESS,
             data=rect_id,
             execution_time=self._delays["sketch_operation"],
+        )
+
+    async def add_sketch_constraint(
+        self, entity1: str, entity2: str | None, relation_type: str
+    ) -> AdapterResult[str]:
+        """Mock adding a geometric constraint between sketch entities.
+
+        Args:
+            entity1 (str): Primary sketch-entity ID.
+            entity2 (str | None): Secondary sketch-entity ID, or None for
+                single-entity relations (horizontal, vertical, fix).
+            relation_type (str): Constraint name (see RELATION_NAME_MAP).
+
+        Returns:
+            AdapterResult[str]: SUCCESS with a placeholder constraint ID, or
+                ERROR if no active sketch or the relation_type is unsupported.
+        """
+        if not self._current_sketch:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR, error="No active sketch"
+            )
+
+        if (relation_type or "").strip().lower() not in RELATION_NAME_MAP:
+            supported = ", ".join(sorted(RELATION_NAME_MAP))
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    f"Unsupported relation type '{relation_type}'. "
+                    f"Supported: {supported}"
+                ),
+            )
+
+        await asyncio.sleep(self._delays["sketch_operation"] / 2)
+        self._operation_count += 1
+
+        constraint_id = f"Constraint_{relation_type}_{random.randint(1000, 9999)}"
+
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data=constraint_id,
+            execution_time=self._delays["sketch_operation"] / 2,
         )
 
     async def exit_sketch(self) -> AdapterResult[None]:

--- a/src/solidworks_mcp/adapters/mock_adapter.py
+++ b/src/solidworks_mcp/adapters/mock_adapter.py
@@ -99,6 +99,10 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         self._features: dict[str, SolidWorksFeature] = {}
         self._sketches: dict[str, str] = {}
         self._current_sketch: str | None = None
+        # Tracks IDs returned by add_line/add_circle/add_centerline/add_rectangle
+        # so add_sketch_constraint can validate entity1/entity2 the same way
+        # the real adapter validates against its sketch-entity registry.
+        self._sketch_entity_ids: set[str] = set()
         self._dimensions: dict[str, float] = {}
         self._operation_count = 0
 
@@ -828,6 +832,7 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         self._operation_count += 1
 
         line_id = f"Line{random.randint(1000, 9999)}"
+        self._sketch_entity_ids.add(line_id)
 
         return AdapterResult(
             status=AdapterResultStatus.SUCCESS,
@@ -858,6 +863,7 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         self._operation_count += 1
 
         centerline_id = f"Centerline{random.randint(1000, 9999)}"
+        self._sketch_entity_ids.add(centerline_id)
 
         return AdapterResult(
             status=AdapterResultStatus.SUCCESS,
@@ -887,6 +893,7 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         self._operation_count += 1
 
         circle_id = f"Circle{random.randint(1000, 9999)}"
+        self._sketch_entity_ids.add(circle_id)
 
         return AdapterResult(
             status=AdapterResultStatus.SUCCESS,
@@ -917,6 +924,7 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         self._operation_count += 1
 
         rect_id = f"Rectangle{random.randint(1000, 9999)}"
+        self._sketch_entity_ids.add(rect_id)
 
         return AdapterResult(
             status=AdapterResultStatus.SUCCESS,
@@ -951,6 +959,26 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
                 error=(
                     f"Unsupported relation type '{relation_type}'. "
                     f"Supported: {supported}"
+                ),
+            )
+
+        # Validate entity IDs against the in-process sketch-entity registry
+        # so the mock surfaces the same "Unknown sketch entity" error as the
+        # real adapter (which checks adapter._sketch_entities).
+        if entity1 not in self._sketch_entity_ids:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    f"Unknown sketch entity '{entity1}'. Use IDs returned by "
+                    "add_line/add_arc/add_circle."
+                ),
+            )
+        if entity2 is not None and entity2 not in self._sketch_entity_ids:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    f"Unknown sketch entity '{entity2}'. Use IDs returned by "
+                    "add_line/add_arc/add_circle."
                 ),
             )
 

--- a/src/solidworks_mcp/adapters/pywin32_adapter.py
+++ b/src/solidworks_mcp/adapters/pywin32_adapter.py
@@ -20,6 +20,7 @@ from .base import (
     AdapterResultStatus,
     SolidWorksAdapter,
 )
+from . import sw_type_info
 from .solidworks import (
     SolidWorksFeaturesMixin,
     SolidWorksIOMixin,
@@ -31,6 +32,7 @@ try:
     import pythoncom
     import pywintypes
     import win32com.client
+    from win32com.client import dynamic as _dynamic_module
 
     PYWIN32_AVAILABLE = True
 except ImportError:  # pragma: no cover
@@ -38,7 +40,22 @@ except ImportError:  # pragma: no cover
     pythoncom = SimpleNamespace()
     pywintypes = SimpleNamespace(com_error=Exception)
     win32com = SimpleNamespace(client=SimpleNamespace())
+    _dynamic_module = SimpleNamespace(Dispatch=lambda *_a, **_kw: None)
     PYWIN32_AVAILABLE = False
+
+
+def _dynamic_dispatch(arg: Any) -> Any:
+    """Forward to ``win32com.client.dynamic.Dispatch`` via the imported
+    module reference. Forces late binding so VARIANT pass-by-ref params
+    used by ``OpenDoc6`` keep working even when the makepy ``gen_py``
+    wrapper is loaded.
+
+    Tests that need to stub dispatch should monkeypatch
+    ``win32com.client.dynamic.Dispatch`` directly — the monkeypatch
+    propagates through this module reference because Python modules
+    are singletons.
+    """
+    return _dynamic_module.Dispatch(arg)
 
 
 from loguru import logger  # noqa: E402
@@ -153,9 +170,13 @@ class _ComSessionCoordinator:
         """
         self._adapter.swApp = None
         last_error: Exception | None = None
+        # Force late binding (dynamic.Dispatch) — the gen_py wrapper provides
+        # method-name lookup for flag_methods but early-bound dispatches
+        # reject VARIANT pass-by-ref params used by OpenDoc6 and friends.
         for _ in range(8):
             try:
-                app = win32com.client.GetActiveObject("SldWorks.Application")
+                raw = win32com.client.GetActiveObject("SldWorks.Application")
+                app = _dynamic_dispatch(raw) if raw is not None else None
                 if app is not None:
                     self._adapter.swApp = app
                     return app
@@ -163,7 +184,7 @@ class _ComSessionCoordinator:
                 last_error = active_error
 
             try:
-                app = win32com.client.Dispatch("SldWorks.Application")
+                app = _dynamic_dispatch("SldWorks.Application")
                 if app is not None:
                     self._adapter.swApp = app
                     return app
@@ -267,6 +288,9 @@ class _ComSessionCoordinator:
         try:
             self.initialize_com_apartment()
             app = await self.acquire_solidworks_application()
+            self._adapter._attempt(
+                lambda: sw_type_info.flag_methods(app, "ISldWorks"), default=0
+            )
             await self.wait_for_server_ready(app)
             app.Visible = True
             self.set_automation_preferences(app, interactive=False)

--- a/src/solidworks_mcp/adapters/solidworks/io.py
+++ b/src/solidworks_mcp/adapters/solidworks/io.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 from ..base import AdapterResult, AdapterResultStatus, MassProperties, SolidWorksModel
+from .. import sw_type_info as _sw_type_info
 
 try:
     import pythoncom
@@ -142,6 +143,10 @@ class SolidWorksIOMixin:
             if not model:
                 raise Exception(f"Failed to open model: {resolved_path}")
 
+            adapter._attempt(
+                lambda: _sw_type_info.flag_doc(model, int(doc_type)), default=0
+            )
+
             adapter.currentModel = model
             title = self._read_model_title(model)
             active_config = adapter._attempt(lambda: model.GetActiveConfiguration())
@@ -244,6 +249,7 @@ class SolidWorksIOMixin:
             if not model:
                 raise Exception("Failed to create new part")
 
+            adapter._attempt(lambda: _sw_type_info.flag_doc(model, 1), default=0)
             adapter.currentModel = model
             title = self._read_model_title(model)
             return SolidWorksModel(
@@ -298,6 +304,7 @@ class SolidWorksIOMixin:
             if not model:
                 raise Exception("Failed to create new assembly")
 
+            adapter._attempt(lambda: _sw_type_info.flag_doc(model, 2), default=0)
             adapter.currentModel = model
             title = self._read_model_title(model)
             return SolidWorksModel(
@@ -348,6 +355,7 @@ class SolidWorksIOMixin:
             if not model:
                 raise Exception("Failed to create new drawing")
 
+            adapter._attempt(lambda: _sw_type_info.flag_doc(model, 3), default=0)
             adapter.currentModel = model
             title = self._read_model_title(model)
             return SolidWorksModel(

--- a/src/solidworks_mcp/adapters/solidworks/io.py
+++ b/src/solidworks_mcp/adapters/solidworks/io.py
@@ -7,8 +7,8 @@ from datetime import datetime
 from types import SimpleNamespace
 from typing import Any, cast
 
-from ..base import AdapterResult, AdapterResultStatus, MassProperties, SolidWorksModel
 from .. import sw_type_info as _sw_type_info
+from ..base import AdapterResult, AdapterResultStatus, MassProperties, SolidWorksModel
 
 try:
     import pythoncom

--- a/src/solidworks_mcp/adapters/solidworks/sketch.py
+++ b/src/solidworks_mcp/adapters/solidworks/sketch.py
@@ -20,10 +20,13 @@ RELATION_NAME_MAP: dict[str, int] = {
     "perpendicular": 8,
     "coincident": 9,
     "concentric": 10,
-    "symmetric": 11,
     "equal": 14,  # swConstraintType_SAMELENGTH
     "fix": 17,  # swConstraintType_FIXED
     "collinear": 27,  # swConstraintType_COLINEAR (single-l spelling)
+    # NOTE: swConstraintType_SYMMETRIC (11) is intentionally omitted — it
+    # requires a third selection (the centerline of symmetry) and the
+    # AddRelationInput schema only carries entity1/entity2. A future API
+    # extension that accepts a centerline ID can add it back.
 }
 
 

--- a/src/solidworks_mcp/adapters/solidworks/sketch.py
+++ b/src/solidworks_mcp/adapters/solidworks/sketch.py
@@ -7,7 +7,6 @@ from typing import Any, cast
 
 from ..base import AdapterResult, AdapterResultStatus
 
-
 # swConstraintType_e values per the official SolidWorks API enum docs
 # (SolidWorks.Interop.swconst). The legacy IModelDoc2.SketchAddConstraints
 # API takes string identifiers but on SW 2026/3DEXPERIENCE silently no-ops
@@ -23,7 +22,7 @@ RELATION_NAME_MAP: dict[str, int] = {
     "concentric": 10,
     "symmetric": 11,
     "equal": 14,  # swConstraintType_SAMELENGTH
-    "fix": 17,    # swConstraintType_FIXED
+    "fix": 17,  # swConstraintType_FIXED
     "collinear": 27,  # swConstraintType_COLINEAR (single-l spelling)
 }
 
@@ -923,9 +922,7 @@ def _add_sketch_constraint_impl(
             _sw_type_info = None  # type: ignore[assignment]
         if _sw_type_info is not None:
             adapter._attempt(
-                lambda: _sw_type_info.flag_methods(
-                    adapter.currentModel, "IModelDoc2"
-                ),
+                lambda: _sw_type_info.flag_methods(adapter.currentModel, "IModelDoc2"),
                 default=0,
             )
 
@@ -964,9 +961,7 @@ def _add_sketch_constraint_impl(
                 "pywin32 is required for add_sketch_constraint on a real adapter"
             ) from exc
 
-        ents_variant = _VARIANT(
-            _pythoncom.VT_ARRAY | _pythoncom.VT_DISPATCH, entities
-        )
+        ents_variant = _VARIANT(_pythoncom.VT_ARRAY | _pythoncom.VT_DISPATCH, entities)
         sketch_relation, add_err = adapter._attempt_with_error(
             lambda: relmgr.AddRelation(ents_variant, relation_type_enum)
         )

--- a/src/solidworks_mcp/adapters/solidworks/sketch.py
+++ b/src/solidworks_mcp/adapters/solidworks/sketch.py
@@ -20,14 +20,15 @@ RELATION_NAME_MAP: dict[str, int] = {
     "perpendicular": 8,
     "coincident": 9,
     "concentric": 10,
+    "symmetric": 11,  # swConstraintType_SYMMETRIC — requires entity3 (centerline)
     "equal": 14,  # swConstraintType_SAMELENGTH
     "fix": 17,  # swConstraintType_FIXED
     "collinear": 27,  # swConstraintType_COLINEAR (single-l spelling)
-    # NOTE: swConstraintType_SYMMETRIC (11) is intentionally omitted — it
-    # requires a third selection (the centerline of symmetry) and the
-    # AddRelationInput schema only carries entity1/entity2. A future API
-    # extension that accepts a centerline ID can add it back.
 }
+
+# Relations that take a third entity (the centerline of symmetry for now).
+# All other relations reject a non-null ``entity3``.
+_THREE_ENTITY_RELATIONS: frozenset[str] = frozenset({"symmetric"})
 
 
 class SolidWorksSketchMixin:
@@ -144,9 +145,15 @@ class SolidWorksSketchMixin:
         return _add_ellipse_impl(self, center_x, center_y, major_axis, minor_axis)
 
     async def add_sketch_constraint(
-        self, entity1: str, entity2: str | None, relation_type: str
+        self,
+        entity1: str,
+        entity2: str | None,
+        relation_type: str,
+        entity3: str | None = None,
     ) -> AdapterResult[str]:
-        return _add_sketch_constraint_impl(self, entity1, entity2, relation_type)
+        return _add_sketch_constraint_impl(
+            self, entity1, entity2, relation_type, entity3
+        )
 
     async def add_sketch_dimension(
         self, entity1: str, entity2: str | None, dimension_type: str, value: float
@@ -689,10 +696,13 @@ def _add_centerline_impl(
         return AdapterResult(status=AdapterResultStatus.ERROR, error="No active sketch")
 
     def _centerline_operation() -> str:
-        """Inner COM closure that calls CreateCenterLine.
+        """Inner COM closure that calls CreateCenterLine and registers
+        the resulting entity so it can be referenced by subsequent
+        dimension and constraint calls (e.g. as the centerline of a
+        ``symmetric`` relation).
 
         Returns:
-            str: Timestamped unique ID string.
+            str: Registered entity ID (e.g. ``"Centerline_3"``).
 
         Raises:
             Exception: If ``CreateCenterLine`` returns ``None``.
@@ -702,7 +712,7 @@ def _add_centerline_impl(
         )
         if not centerline:
             raise Exception("Failed to create centerline")
-        return f"Centerline_{int(time.time() * 1000) % 10000}"
+        return cast(str, adapter._register_sketch_entity("Centerline", centerline))
 
     return cast(
         AdapterResult[str],
@@ -851,11 +861,12 @@ def _add_sketch_constraint_impl(
     entity1: str,
     entity2: str | None,
     relation_type: str,
+    entity3: str | None = None,
 ) -> AdapterResult[str]:
     """Add a geometric relation (constraint) between sketch entities.
 
-    Resolves ``entity1`` (and ``entity2`` if provided) against the adapter's
-    sketch-entity registry, then calls
+    Resolves ``entity1`` (and ``entity2``/``entity3`` if provided) against the
+    adapter's sketch-entity registry, then calls
     ``ISketchRelationManager.AddRelation(entities, relation_type_enum)`` on
     the active sketch. Entity handles are passed as a
     ``VARIANT(VT_ARRAY | VT_DISPATCH, [...])`` — pywin32 will not marshal a
@@ -871,6 +882,10 @@ def _add_sketch_constraint_impl(
     ``"coincident"``, ``"concentric"``, ``"equal"``, ``"symmetric"``,
     ``"collinear"``, ``"fix"``.
 
+    ``"symmetric"`` is the only relation that takes a third entity
+    (``entity3`` — the centerline of symmetry). All other relations reject
+    a non-null ``entity3``.
+
     Args:
         adapter: A ``PyWin32Adapter`` with an open sketch and a valid
             ``currentModel``.
@@ -879,6 +894,10 @@ def _add_sketch_constraint_impl(
         entity2: Registered entity ID of the secondary sketch entity, or
             ``None`` for single-entity relations (horizontal, vertical, fix).
         relation_type: Constraint type string (see above).
+        entity3: Registered ID of a third entity. Only meaningful for
+            ``"symmetric"`` — pass the centerline ID (from ``add_centerline``)
+            as the line of symmetry. Must be ``None`` for every other
+            relation type.
 
     Returns:
         AdapterResult[str]: On success, ``data`` is the registered entity ID
@@ -892,13 +911,25 @@ def _add_sketch_constraint_impl(
         if not adapter.currentModel:
             raise Exception("No active model")
 
-        relation_type_enum = RELATION_NAME_MAP.get(
-            (relation_type or "").strip().lower()
-        )
+        rt_norm = (relation_type or "").strip().lower()
+        relation_type_enum = RELATION_NAME_MAP.get(rt_norm)
         if relation_type_enum is None:
             supported = ", ".join(sorted(RELATION_NAME_MAP))
             raise Exception(
                 f"Unsupported relation type '{relation_type}'. Supported: {supported}"
+            )
+
+        # Arity validation per relation type
+        if rt_norm in _THREE_ENTITY_RELATIONS:
+            if entity2 is None or entity3 is None:
+                raise Exception(
+                    f"Relation '{relation_type}' requires entity1, entity2, "
+                    "and entity3 (the centerline of symmetry)"
+                )
+        elif entity3 is not None:
+            raise Exception(
+                f"Relation '{relation_type}' does not accept entity3 — only "
+                "'symmetric' takes a third entity (the centerline)"
             )
 
         entity1_obj = adapter._sketch_entities.get(entity1)
@@ -915,6 +946,13 @@ def _add_sketch_constraint_impl(
                     f"Unknown sketch entity '{entity2}'. Use IDs returned by add_line/add_arc/add_circle."
                 )
             entities.append(entity2_obj)
+        if entity3:
+            entity3_obj = adapter._sketch_entities.get(entity3)
+            if entity3_obj is None:
+                raise Exception(
+                    f"Unknown sketch entity '{entity3}'. Use IDs returned by add_line/add_arc/add_circle."
+                )
+            entities.append(entity3_obj)
 
         # Flag IModelDoc2 + ISketch + ISketchRelationManager so late-binding
         # resolves GetActiveSketch2, RelationManager, and AddRelation as

--- a/src/solidworks_mcp/adapters/solidworks/sketch.py
+++ b/src/solidworks_mcp/adapters/solidworks/sketch.py
@@ -8,6 +8,26 @@ from typing import Any, cast
 from ..base import AdapterResult, AdapterResultStatus
 
 
+# swConstraintType_e values per the official SolidWorks API enum docs
+# (SolidWorks.Interop.swconst). The legacy IModelDoc2.SketchAddConstraints
+# API takes string identifiers but on SW 2026/3DEXPERIENCE silently no-ops
+# without adding the relation. ISketchRelationManager.AddRelation takes
+# these integer enum values and works reliably.
+RELATION_NAME_MAP: dict[str, int] = {
+    "horizontal": 4,
+    "vertical": 5,
+    "tangent": 6,
+    "parallel": 7,
+    "perpendicular": 8,
+    "coincident": 9,
+    "concentric": 10,
+    "symmetric": 11,
+    "equal": 14,  # swConstraintType_SAMELENGTH
+    "fix": 17,    # swConstraintType_FIXED
+    "collinear": 27,  # swConstraintType_COLINEAR (single-l spelling)
+}
+
+
 class SolidWorksSketchMixin:
     """Expose sketch creation and editing methods via mixin-local implementation."""
 
@@ -832,60 +852,135 @@ def _add_sketch_constraint_impl(
 ) -> AdapterResult[str]:
     """Add a geometric relation (constraint) between sketch entities.
 
-    .. note::
-        This function currently builds the relation-type constant map but does
-        not invoke the SolidWorks ``AddConstraint`` API.  It returns a
-        placeholder ID.  Full implementation is tracked as a future work item.
+    Resolves ``entity1`` (and ``entity2`` if provided) against the adapter's
+    sketch-entity registry, then calls
+    ``ISketchRelationManager.AddRelation(entities, relation_type_enum)`` on
+    the active sketch. Entity handles are passed as a
+    ``VARIANT(VT_ARRAY | VT_DISPATCH, [...])`` — pywin32 will not marshal a
+    plain Python list of CDispatch objects to a SAFEARRAY by itself.
 
-    Supported ``relation_type`` strings (case-insensitive):
-    ``"parallel"``, ``"perpendicular"``, ``"tangent"``, ``"coincident"``,
-    ``"concentric"``, ``"horizontal"``, ``"vertical"``, ``"equal"``,
-    ``"symmetric"``, ``"collinear"``.
+    The legacy ``IModelDoc2.SketchAddConstraints`` API silently no-ops on
+    SW 2026/3DEXPERIENCE despite accepting the call, so this implementation
+    uses the modern ``ISketchRelationManager.AddRelation`` per the official
+    SolidWorks API docs.
+
+    Supported ``relation_type`` strings (case-insensitive): ``"horizontal"``,
+    ``"vertical"``, ``"parallel"``, ``"perpendicular"``, ``"tangent"``,
+    ``"coincident"``, ``"concentric"``, ``"equal"``, ``"symmetric"``,
+    ``"collinear"``, ``"fix"``.
 
     Args:
-        adapter: A ``PyWin32Adapter`` with an open sketch.
+        adapter: A ``PyWin32Adapter`` with an open sketch and a valid
+            ``currentModel``.
         entity1: Registered entity ID of the primary sketch entity (from a
             prior ``add_line`` / ``add_circle`` call).
         entity2: Registered entity ID of the secondary sketch entity, or
-            ``None`` for single-entity relations (horizontal, vertical …).
+            ``None`` for single-entity relations (horizontal, vertical, fix).
         relation_type: Constraint type string (see above).
 
     Returns:
-        AdapterResult[str]: On success, ``data`` is a descriptive placeholder
-        ID (e.g. ``"Constraint_tangent_5678"``).  On failure, ``status`` is
-        ``ERROR``.
-
-    Example::
-
-        result = pywin32_sketch_ops.add_sketch_constraint(
-            adapter, "Line_1", "Circle_2", "tangent"
-        )
-        print(result.data)  # "Constraint_tangent_5678"
+        AdapterResult[str]: On success, ``data`` is the registered entity ID
+        of the new constraint object (e.g. ``"Constraint_3"``). On failure,
+        ``status`` is ``ERROR``.
     """
-    _ = entity1, entity2
     if not adapter.currentSketchManager:
         return AdapterResult(status=AdapterResultStatus.ERROR, error="No active sketch")
 
     def _constraint_operation() -> str:
-        """Inner COM closure that resolves the relation constant and returns a placeholder ID.
+        if not adapter.currentModel:
+            raise Exception("No active model")
 
-        Returns:
-            str: A descriptive placeholder constraint ID.
-        """
-        relation_map = {
-            "parallel": adapter.constants.get("swConstraintType_PARALLEL", 0),
-            "perpendicular": adapter.constants.get("swConstraintType_PERPENDICULAR", 1),
-            "tangent": adapter.constants.get("swConstraintType_TANGENT", 2),
-            "coincident": adapter.constants.get("swConstraintType_COINCIDENT", 3),
-            "concentric": adapter.constants.get("swConstraintType_CONCENTRIC", 4),
-            "horizontal": adapter.constants.get("swConstraintType_HORIZONTAL", 5),
-            "vertical": adapter.constants.get("swConstraintType_VERTICAL", 6),
-            "equal": adapter.constants.get("swConstraintType_EQUAL", 7),
-            "symmetric": adapter.constants.get("swConstraintType_SYMMETRIC", 8),
-            "collinear": adapter.constants.get("swConstraintType_COLLINEAR", 9),
-        }
-        relation_map.get(relation_type.lower(), 0)
-        return f"Constraint_{relation_type}_{int(time.time() * 1000) % 10000}"
+        relation_type_enum = RELATION_NAME_MAP.get(
+            (relation_type or "").strip().lower()
+        )
+        if relation_type_enum is None:
+            supported = ", ".join(sorted(RELATION_NAME_MAP))
+            raise Exception(
+                f"Unsupported relation type '{relation_type}'. Supported: {supported}"
+            )
+
+        entity1_obj = adapter._sketch_entities.get(entity1)
+        if entity1_obj is None:
+            raise Exception(
+                f"Unknown sketch entity '{entity1}'. Use IDs returned by add_line/add_arc/add_circle."
+            )
+
+        entities = [entity1_obj]
+        if entity2:
+            entity2_obj = adapter._sketch_entities.get(entity2)
+            if entity2_obj is None:
+                raise Exception(
+                    f"Unknown sketch entity '{entity2}'. Use IDs returned by add_line/add_arc/add_circle."
+                )
+            entities.append(entity2_obj)
+
+        # Flag IModelDoc2 + ISketch + ISketchRelationManager so late-binding
+        # resolves GetActiveSketch2, RelationManager, and AddRelation as
+        # methods/properties correctly.
+        try:
+            from .. import sw_type_info as _sw_type_info
+        except ImportError:
+            _sw_type_info = None  # type: ignore[assignment]
+        if _sw_type_info is not None:
+            adapter._attempt(
+                lambda: _sw_type_info.flag_methods(
+                    adapter.currentModel, "IModelDoc2"
+                ),
+                default=0,
+            )
+
+        active_sketch = adapter._attempt(
+            lambda: adapter.currentModel.GetActiveSketch2(), default=None
+        )
+        if active_sketch is None:
+            raise Exception(
+                "No active sketch on the model — create_sketch first or "
+                "open the existing sketch for edit."
+            )
+        if _sw_type_info is not None:
+            adapter._attempt(
+                lambda: _sw_type_info.flag_methods(active_sketch, "ISketch"),
+                default=0,
+            )
+
+        relmgr = adapter._attempt(lambda: active_sketch.RelationManager, default=None)
+        if relmgr is None:
+            raise Exception("Active sketch has no RelationManager")
+        if _sw_type_info is not None:
+            adapter._attempt(
+                lambda: _sw_type_info.flag_methods(relmgr, "ISketchRelationManager"),
+                default=0,
+            )
+
+        # pywin32 won't auto-marshal a Python list of CDispatch entities to a
+        # SAFEARRAY. The VT_ARRAY|VT_DISPATCH variant is the shape SolidWorks
+        # accepts. Import is lazy so the module still imports in mock/CI
+        # environments without pywin32.
+        try:
+            import pythoncom as _pythoncom
+            from win32com.client import VARIANT as _VARIANT
+        except ImportError as exc:  # pragma: no cover
+            raise Exception(
+                "pywin32 is required for add_sketch_constraint on a real adapter"
+            ) from exc
+
+        ents_variant = _VARIANT(
+            _pythoncom.VT_ARRAY | _pythoncom.VT_DISPATCH, entities
+        )
+        sketch_relation, add_err = adapter._attempt_with_error(
+            lambda: relmgr.AddRelation(ents_variant, relation_type_enum)
+        )
+        if add_err is not None or sketch_relation is None:
+            target = f"'{entity1}'" + (f" and '{entity2}'" if entity2 else "")
+            detail = f": {add_err}" if add_err else ""
+            raise Exception(
+                f"SolidWorks rejected '{relation_type}' relation on {target}{detail}"
+            )
+
+        return cast(
+            str,
+            adapter._register_sketch_entity("Constraint", sketch_relation),
+        )
 
     return cast(
         AdapterResult[str],

--- a/src/solidworks_mcp/adapters/sw_type_info.py
+++ b/src/solidworks_mcp/adapters/sw_type_info.py
@@ -72,9 +72,9 @@ def _load_wrapper() -> None:
     if not PYWIN32_AVAILABLE:
         return
 
-    # Try version numbers from newest to oldest. SW 2025 reports as 33,
-    # SW 2024 = 32, SW 2023 = 31, SW 2022 = 30.
-    for major in (33, 32, 31, 30):
+    # Try version numbers from newest to oldest. SW 3DEXPERIENCE R2026x = 34,
+    # SW 2025 = 33, SW 2024 = 32, SW 2023 = 31, SW 2022 = 30.
+    for major in (35, 34, 33, 32, 31, 30):
         try:
             mod = gencache.GetModuleForTypelib(SW_TLB_IID, 0, major, 0)
         except Exception:
@@ -85,7 +85,7 @@ def _load_wrapper() -> None:
 
     if _wrapper_module is None:
         # Gen_py wrapper not generated yet — try to generate now.
-        for major in (33, 32, 31, 30):
+        for major in (35, 34, 33, 32, 31, 30):
             try:
                 gencache.EnsureModule(SW_TLB_IID, 0, major, 0)
                 _wrapper_module = gencache.GetModuleForTypelib(

--- a/src/solidworks_mcp/adapters/sw_type_info.py
+++ b/src/solidworks_mcp/adapters/sw_type_info.py
@@ -88,9 +88,7 @@ def _load_wrapper() -> None:
         for major in (35, 34, 33, 32, 31, 30):
             try:
                 gencache.EnsureModule(SW_TLB_IID, 0, major, 0)
-                _wrapper_module = gencache.GetModuleForTypelib(
-                    SW_TLB_IID, 0, major, 0
-                )
+                _wrapper_module = gencache.GetModuleForTypelib(SW_TLB_IID, 0, major, 0)
                 if _wrapper_module is not None:
                     break
             except Exception:
@@ -101,7 +99,7 @@ def _load_wrapper() -> None:
             "SolidWorks gen_py wrapper not available; method flagging "
             "disabled. Zero-arg SW methods may raise TypeError. To fix, "
             "run: python -m win32com.client.makepy "
-            "\"C:\\Program Files\\SOLIDWORKS Corp\\SOLIDWORKS\\sldworks.tlb\""
+            '"C:\\Program Files\\SOLIDWORKS Corp\\SOLIDWORKS\\sldworks.tlb"'
         )
         return
 

--- a/src/solidworks_mcp/tools/sketching.py
+++ b/src/solidworks_mcp/tools/sketching.py
@@ -249,12 +249,22 @@ class AddRelationInput(BaseModel):
     Attributes:
         entity1 (str): The entity1 value.
         entity2 (str | None): The entity2 value.
+        entity3 (str | None): Third entity ID — only used by the ``symmetric``
+            relation (the centerline of symmetry). All other relation types
+            reject a non-null ``entity3``.
         relation_type (str): The relation type value.
     """
 
     entity1: str = Field(description="First entity name or ID")
     entity2: str | None = Field(
         default=None, description="Second entity name or ID (if required)"
+    )
+    entity3: str | None = Field(
+        default=None,
+        description=(
+            "Third entity ID. Required for 'symmetric' (the centerline of "
+            "symmetry); must be null for all other relations."
+        ),
     )
     relation_type: str = Field(
         description="Relation type (parallel, perpendicular, tangent, coincident, etc.)"
@@ -1101,7 +1111,10 @@ async def register_sketching_tools(
         """
         try:
             result = await adapter.add_sketch_constraint(
-                input_data.entity1, input_data.entity2, input_data.relation_type
+                input_data.entity1,
+                input_data.entity2,
+                input_data.relation_type,
+                input_data.entity3,
             )
 
             if result.is_success:
@@ -1114,6 +1127,7 @@ async def register_sketching_tools(
                         "type": input_data.relation_type,
                         "entity1": input_data.entity1,
                         "entity2": input_data.entity2,
+                        "entity3": input_data.entity3,
                     },
                     "execution_time": result.execution_time,
                 }

--- a/tests/solidworks_mcp/adapters/solidworks/test_sketch.py
+++ b/tests/solidworks_mcp/adapters/solidworks/test_sketch.py
@@ -318,9 +318,7 @@ def test_add_sketch_constraint_sw_rejection_returns_error() -> None:
     adapter, *_ = _make_constraint_adapter(
         add_relation_raises=RuntimeError("incompatible geometry"),
     )
-    result = sketch._add_sketch_constraint_impl(
-        adapter, "Line_1", "Line_2", "parallel"
-    )
+    result = sketch._add_sketch_constraint_impl(adapter, "Line_1", "Line_2", "parallel")
     assert result.status == AdapterResultStatus.ERROR
     msg = result.error or ""
     assert "rejected" in msg and "parallel" in msg

--- a/tests/solidworks_mcp/adapters/solidworks/test_sketch.py
+++ b/tests/solidworks_mcp/adapters/solidworks/test_sketch.py
@@ -242,7 +242,12 @@ def _make_constraint_adapter(
     adapter.currentSketchManager = object()
     line1 = SimpleNamespace()
     line2 = SimpleNamespace()
-    adapter._sketch_entities = {"Line_1": line1, "Line_2": line2}
+    centerline = SimpleNamespace()
+    adapter._sketch_entities = {
+        "Line_1": line1,
+        "Line_2": line2,
+        "Centerline_3": centerline,
+    }
 
     def _add_rel(_entities, _rt):
         if add_relation_raises is not None:
@@ -338,6 +343,65 @@ def test_add_sketch_constraint_add_relation_returns_none_is_error() -> None:
     result = sketch._add_sketch_constraint_impl(adapter, "Line_1", None, "fix")
     assert result.status == AdapterResultStatus.ERROR
     assert "rejected" in (result.error or "")
+
+
+def test_add_sketch_constraint_symmetric_happy_path() -> None:
+    constraint_obj = SimpleNamespace(Name="Sym1")
+    adapter, add_relation, _sk = _make_constraint_adapter(
+        add_relation_returns=constraint_obj
+    )
+
+    result = sketch._add_sketch_constraint_impl(
+        adapter, "Line_1", "Line_2", "symmetric", "Centerline_3"
+    )
+
+    assert result.status == AdapterResultStatus.SUCCESS
+    assert result.data.startswith("Constraint_")
+    assert adapter._sketch_entities[result.data] is constraint_obj
+    ents_arg, rt_arg = add_relation.call_args.args
+    assert rt_arg == 11  # swConstraintType_SYMMETRIC
+    # Three-element entity list, in order: entity1, entity2, entity3
+    assert len(ents_arg.value) == 3
+
+
+def test_add_sketch_constraint_symmetric_missing_entity3_returns_error() -> None:
+    adapter, *_ = _make_constraint_adapter()
+    result = sketch._add_sketch_constraint_impl(
+        adapter, "Line_1", "Line_2", "symmetric", None
+    )
+    assert result.status == AdapterResultStatus.ERROR
+    msg = result.error or ""
+    assert "symmetric" in msg
+    assert "entity3" in msg
+
+
+def test_add_sketch_constraint_symmetric_missing_entity2_returns_error() -> None:
+    adapter, *_ = _make_constraint_adapter()
+    result = sketch._add_sketch_constraint_impl(
+        adapter, "Line_1", None, "symmetric", "Centerline_3"
+    )
+    assert result.status == AdapterResultStatus.ERROR
+    assert "entity2" in (result.error or "")
+
+
+def test_add_sketch_constraint_entity3_rejected_for_non_symmetric() -> None:
+    adapter, *_ = _make_constraint_adapter()
+    result = sketch._add_sketch_constraint_impl(
+        adapter, "Line_1", "Line_2", "perpendicular", "Centerline_3"
+    )
+    assert result.status == AdapterResultStatus.ERROR
+    msg = result.error or ""
+    assert "does not accept entity3" in msg
+    assert "perpendicular" in msg
+
+
+def test_add_sketch_constraint_unknown_entity3_returns_error() -> None:
+    adapter, *_ = _make_constraint_adapter()
+    result = sketch._add_sketch_constraint_impl(
+        adapter, "Line_1", "Line_2", "symmetric", "CL_99"
+    )
+    assert result.status == AdapterResultStatus.ERROR
+    assert "Unknown sketch entity 'CL_99'" in (result.error or "")
 
 
 def test_exit_sketch_warning_and_success_paths() -> None:

--- a/tests/solidworks_mcp/adapters/solidworks/test_sketch.py
+++ b/tests/solidworks_mcp/adapters/solidworks/test_sketch.py
@@ -203,11 +203,10 @@ def test_spline_error_when_create_returns_none() -> None:
     assert "Failed to create spline" in (result.error or "")
 
 
-def test_constraint_and_pattern_placeholders() -> None:
+def test_pattern_placeholders() -> None:
     adapter = _FakeSketchAdapter()
     adapter.currentSketchManager = object()
 
-    constraint = sketch._add_sketch_constraint_impl(adapter, "Line_1", None, "unknown")
     linear_pattern = sketch._sketch_linear_pattern_impl(
         adapter, ["Line_1"], 1, 0, 5.0, 3
     )
@@ -217,7 +216,6 @@ def test_constraint_and_pattern_placeholders() -> None:
     mirror = sketch._sketch_mirror_impl(adapter, ["Line_1"], "Centerline_1")
     offset = sketch._sketch_offset_impl(adapter, ["Line_1"], 2.5, True)
 
-    assert constraint.is_success and constraint.data.startswith("Constraint_unknown_")
     assert linear_pattern.is_success and linear_pattern.data.startswith(
         "LinearPattern_3x5.0_"
     )
@@ -226,6 +224,122 @@ def test_constraint_and_pattern_placeholders() -> None:
     )
     assert mirror.is_success and mirror.data.startswith("Mirror_Centerline_1_")
     assert offset.is_success and "_inward_" in offset.data
+
+
+def _make_constraint_adapter(
+    *,
+    add_relation_raises: Exception | None = None,
+    add_relation_returns: object = "sentinel-relation-obj",
+    no_active_sketch: bool = False,
+) -> tuple[_FakeSketchAdapter, Mock, Mock]:
+    """Build a fake adapter wired for the constraint code path.
+
+    The rewritten impl uses
+    ``ISketchRelationManager.AddRelation([entities], relation_type_enum)``
+    so the fake exposes ``currentModel.GetActiveSketch2().RelationManager``.
+    """
+    adapter = _FakeSketchAdapter()
+    adapter.currentSketchManager = object()
+    line1 = SimpleNamespace()
+    line2 = SimpleNamespace()
+    adapter._sketch_entities = {"Line_1": line1, "Line_2": line2}
+
+    def _add_rel(_entities, _rt):
+        if add_relation_raises is not None:
+            raise add_relation_raises
+        return add_relation_returns
+
+    add_relation = Mock(side_effect=_add_rel)
+    relmgr = SimpleNamespace(AddRelation=add_relation)
+    sketch_obj = SimpleNamespace(RelationManager=relmgr)
+    adapter.currentModel = SimpleNamespace(
+        GetActiveSketch2=lambda: None if no_active_sketch else sketch_obj,
+    )
+    return adapter, add_relation, sketch_obj
+
+
+def test_add_sketch_constraint_requires_active_sketch() -> None:
+    adapter = _FakeSketchAdapter()
+    result = sketch._add_sketch_constraint_impl(adapter, "Line_1", None, "parallel")
+    assert result.status == AdapterResultStatus.ERROR
+    assert "No active sketch" in (result.error or "")
+
+
+def test_add_sketch_constraint_requires_active_model() -> None:
+    adapter = _FakeSketchAdapter()
+    adapter.currentSketchManager = object()
+    result = sketch._add_sketch_constraint_impl(adapter, "Line_1", None, "parallel")
+    assert result.status == AdapterResultStatus.ERROR
+    assert "No active model" in (result.error or "")
+
+
+def test_add_sketch_constraint_unsupported_relation_type() -> None:
+    adapter, *_ = _make_constraint_adapter()
+    result = sketch._add_sketch_constraint_impl(adapter, "Line_1", "Line_2", "unknown")
+    assert result.status == AdapterResultStatus.ERROR
+    assert "Unsupported relation type 'unknown'" in (result.error or "")
+
+
+def test_add_sketch_constraint_unknown_entity_returns_error() -> None:
+    adapter, *_ = _make_constraint_adapter()
+    result = sketch._add_sketch_constraint_impl(adapter, "L99", None, "horizontal")
+    assert result.status == AdapterResultStatus.ERROR
+    assert "Unknown sketch entity 'L99'" in (result.error or "")
+
+
+def test_add_sketch_constraint_two_entity_happy_path() -> None:
+    constraint_obj = SimpleNamespace(Name="Perp1")
+    adapter, add_relation, _sk = _make_constraint_adapter(
+        add_relation_returns=constraint_obj
+    )
+
+    result = sketch._add_sketch_constraint_impl(
+        adapter, "Line_1", "Line_2", "perpendicular"
+    )
+
+    assert result.status == AdapterResultStatus.SUCCESS
+    assert result.data.startswith("Constraint_")
+    assert adapter._sketch_entities[result.data] is constraint_obj
+    # AddRelation is called with the VARIANT entity array and PERPENDICULAR=8
+    assert add_relation.call_count == 1
+    _ents_arg, rt_arg = add_relation.call_args.args
+    assert rt_arg == 8
+
+
+def test_add_sketch_constraint_single_entity_horizontal() -> None:
+    adapter, add_relation, _sk = _make_constraint_adapter()
+    result = sketch._add_sketch_constraint_impl(adapter, "Line_1", None, "Horizontal")
+    assert result.status == AdapterResultStatus.SUCCESS
+    _ents_arg, rt_arg = add_relation.call_args.args
+    assert rt_arg == 4  # swConstraintType_HORIZONTAL
+
+
+def test_add_sketch_constraint_sw_rejection_returns_error() -> None:
+    adapter, *_ = _make_constraint_adapter(
+        add_relation_raises=RuntimeError("incompatible geometry"),
+    )
+    result = sketch._add_sketch_constraint_impl(
+        adapter, "Line_1", "Line_2", "parallel"
+    )
+    assert result.status == AdapterResultStatus.ERROR
+    msg = result.error or ""
+    assert "rejected" in msg and "parallel" in msg
+    assert "Line_1" in msg and "Line_2" in msg
+    assert "incompatible geometry" in msg
+
+
+def test_add_sketch_constraint_no_active_sketch_returns_error() -> None:
+    adapter, *_ = _make_constraint_adapter(no_active_sketch=True)
+    result = sketch._add_sketch_constraint_impl(adapter, "Line_1", None, "fix")
+    assert result.status == AdapterResultStatus.ERROR
+    assert "No active sketch" in (result.error or "")
+
+
+def test_add_sketch_constraint_add_relation_returns_none_is_error() -> None:
+    adapter, *_ = _make_constraint_adapter(add_relation_returns=None)
+    result = sketch._add_sketch_constraint_impl(adapter, "Line_1", None, "fix")
+    assert result.status == AdapterResultStatus.ERROR
+    assert "rejected" in (result.error or "")
 
 
 def test_exit_sketch_warning_and_success_paths() -> None:

--- a/tests/solidworks_mcp/adapters/test_adapters.py
+++ b/tests/solidworks_mcp/adapters/test_adapters.py
@@ -832,6 +832,7 @@ class TestPyWin32AdapterBranches:
         )
 
         import win32com.client.dynamic as _win32_dynamic
+
         monkeypatch.setattr(_win32_dynamic, "Dispatch", Mock(return_value=fake_app))
 
         await adapter.connect()

--- a/tests/solidworks_mcp/adapters/test_adapters.py
+++ b/tests/solidworks_mcp/adapters/test_adapters.py
@@ -619,7 +619,9 @@ class TestPyWin32AdapterBranches:
 
         adapter.currentSketchManager = SimpleNamespace(InsertSketch=Mock())
 
-        assert (await adapter.add_sketch_constraint("L1", None, "unknown")).is_success
+        # Unknown relation types now error out — the placeholder that always
+        # returned success was replaced by a real SketchAddConstraints call.
+        assert (await adapter.add_sketch_constraint("L1", None, "unknown")).is_error
         assert (
             await adapter.add_sketch_dimension("L1", None, "linear", 10.0)
         ).is_success
@@ -2435,6 +2437,14 @@ class TestPyWin32AdapterBranches:
             SimpleNamespace(client=fake_client),
             raising=False,
         )
+        # Late binding goes through win32com.client.dynamic.Dispatch — must
+        # also stub it or the call will hit the real COM (which connects on
+        # any box with SolidWorks installed).
+        monkeypatch.setattr(
+            "src.solidworks_mcp.adapters.pywin32_adapter._dynamic_module",
+            SimpleNamespace(Dispatch=Mock(return_value=None)),
+            raising=False,
+        )
 
         with pytest.raises(SolidWorksMCPError, match="instance is None"):
             await adapter.connect()
@@ -2658,6 +2668,13 @@ class TestPyWin32AdapterBranches:
                     Dispatch=Mock(side_effect=RuntimeError("dispatch fail")),
                 )
             ),
+            raising=False,
+        )
+        # Acquire path now routes through win32com.client.dynamic.Dispatch —
+        # stub it so the retry loop sees the same RuntimeError surface.
+        monkeypatch.setattr(
+            "src.solidworks_mcp.adapters.pywin32_adapter._dynamic_module",
+            SimpleNamespace(Dispatch=Mock(side_effect=RuntimeError("dispatch fail"))),
             raising=False,
         )
 

--- a/tests/test_live_sw_regression.py
+++ b/tests/test_live_sw_regression.py
@@ -333,6 +333,48 @@ async def test_add_sketch_constraint_perpendicular_and_horizontal(
         await adapter.close_model(save=False)
 
 
+async def test_add_sketch_constraint_symmetric_with_centerline(
+    connected_adapter,
+) -> None:
+    """End-to-end check that the three-entity symmetric relation works.
+
+    Creates a fresh part + sketch, draws a centerline plus two lines on
+    either side, then applies ``symmetric`` with the centerline as
+    ``entity3``. Verifies SolidWorks accepts the relation.
+    """
+    adapter = connected_adapter
+
+    part_result = await adapter.create_part()
+    assert part_result.is_success, f"create_part failed: {part_result.error}"
+
+    try:
+        sketch_result = await adapter.create_sketch("Front")
+        assert sketch_result.is_success, f"create_sketch failed: {sketch_result.error}"
+
+        # Centerline along Y axis at x=25 — the line of symmetry.
+        centerline = await adapter.add_centerline(25.0, -50.0, 25.0, 50.0)
+        # Two horizontal lines, mirrored about x=25
+        left = await adapter.add_line(0.0, 10.0, 20.0, 10.0)
+        right = await adapter.add_line(30.0, 10.0, 50.0, 10.0)
+        assert centerline.is_success and left.is_success and right.is_success, (
+            f"setup failed: {centerline.error} / {left.error} / {right.error}"
+        )
+
+        sym = await adapter.add_sketch_constraint(
+            left.data, right.data, "symmetric", centerline.data
+        )
+        assert sym.is_success, f"symmetric constraint failed: {sym.error}"
+        assert sym.data.startswith("Constraint_")
+
+        # Calling symmetric without entity3 must produce a clear arity error
+        # (no SW call should reach AddRelation).
+        bad = await adapter.add_sketch_constraint(left.data, right.data, "symmetric")
+        assert bad.is_error
+        assert "entity3" in (bad.error or "")
+    finally:
+        await adapter.close_model(save=False)
+
+
 async def test_add_sketch_constraint_unsupported_relation(connected_adapter) -> None:
     """Unsupported relation types must produce an error without touching SW."""
     adapter = connected_adapter

--- a/tests/test_live_sw_regression.py
+++ b/tests/test_live_sw_regression.py
@@ -292,3 +292,72 @@ async def test_get_model_info_works_from_worker_thread(
         f"{worker_result['error']!r}"
     )
     assert worker_result.get("title", "").endswith(".SLDASM")
+
+
+# ---- add_sketch_constraint live regression ----
+
+
+async def test_add_sketch_constraint_perpendicular_and_horizontal(
+    connected_adapter,
+) -> None:
+    """End-to-end check that add_sketch_constraint actually constrains
+    SolidWorks geometry.
+
+    Creates a fresh part + sketch, draws two right-angle lines, applies a
+    perpendicular relation between them, then a horizontal relation on the
+    first line, and verifies SolidWorks accepts both calls. SolidWorks
+    silently accepts redundant relations, so we don't assert error on
+    duplicates — instead we use ``IGetRelations.GetRelations`` to confirm
+    the first line gained an extra relation after each call.
+    """
+    adapter = connected_adapter
+
+    part_result = await adapter.create_part()
+    assert part_result.is_success, f"create_part failed: {part_result.error}"
+
+    try:
+        sketch_result = await adapter.create_sketch("Front")
+        assert sketch_result.is_success, (
+            f"create_sketch failed: {sketch_result.error}"
+        )
+
+        line1 = await adapter.add_line(0.0, 0.0, 50.0, 0.0)
+        line2 = await adapter.add_line(50.0, 0.0, 50.0, 50.0)
+        assert line1.is_success and line2.is_success, (
+            f"add_line failed: {line1.error} / {line2.error}"
+        )
+
+        perp = await adapter.add_sketch_constraint(
+            line1.data, line2.data, "perpendicular"
+        )
+        assert perp.is_success, (
+            f"perpendicular constraint failed: {perp.error}"
+        )
+        assert perp.data.startswith("Constraint_"), (
+            f"unexpected constraint id: {perp.data!r}"
+        )
+
+        horiz = await adapter.add_sketch_constraint(line1.data, None, "horizontal")
+        assert horiz.is_success, f"horizontal constraint failed: {horiz.error}"
+        assert horiz.data.startswith("Constraint_")
+    finally:
+        await adapter.close_model(save=False)
+
+
+async def test_add_sketch_constraint_unsupported_relation(connected_adapter) -> None:
+    """Unsupported relation types must produce an error without touching SW."""
+    adapter = connected_adapter
+
+    part_result = await adapter.create_part()
+    assert part_result.is_success
+    try:
+        sketch_result = await adapter.create_sketch("Front")
+        assert sketch_result.is_success
+        line1 = await adapter.add_line(0.0, 0.0, 25.0, 0.0)
+        assert line1.is_success
+
+        bogus = await adapter.add_sketch_constraint(line1.data, None, "diagonal")
+        assert bogus.is_error
+        assert "Unsupported relation type" in (bogus.error or "")
+    finally:
+        await adapter.close_model(save=False)

--- a/tests/test_live_sw_regression.py
+++ b/tests/test_live_sw_regression.py
@@ -55,8 +55,7 @@ pytestmark = [
     pytest.mark.skipif(
         not _REAL_ENABLED,
         reason=(
-            f"set {_REAL_FLAG}=1 to run tests that require a live "
-            "SolidWorks install"
+            f"set {_REAL_FLAG}=1 to run tests that require a live SolidWorks install"
         ),
     ),
     pytest.mark.skipif(
@@ -209,8 +208,7 @@ async def test_open_model_succeeds(connected_adapter) -> None:
     test_assy = _test_assembly_path()
     if not test_assy or not os.path.exists(test_assy):
         pytest.skip(
-            f"set {_TEST_ASSEMBLY_ENV_VAR} to a local .SLDASM path "
-            "to run this test"
+            f"set {_TEST_ASSEMBLY_ENV_VAR} to a local .SLDASM path to run this test"
         )
 
     result = await connected_adapter.open_model(test_assy)
@@ -229,8 +227,7 @@ async def test_get_model_info_fields_populate(connected_adapter) -> None:
     test_assy = _test_assembly_path()
     if not test_assy or not os.path.exists(test_assy):
         pytest.skip(
-            f"set {_TEST_ASSEMBLY_ENV_VAR} to a local .SLDASM path "
-            "to run this test"
+            f"set {_TEST_ASSEMBLY_ENV_VAR} to a local .SLDASM path to run this test"
         )
 
     await connected_adapter.open_model(test_assy)
@@ -238,9 +235,7 @@ async def test_get_model_info_fields_populate(connected_adapter) -> None:
 
     assert result.is_success, f"get_model_info failed: {result.error}"
     info = result.data
-    assert isinstance(info["title"], str) and info["title"].endswith(
-        ".SLDASM"
-    )
+    assert isinstance(info["title"], str) and info["title"].endswith(".SLDASM")
     assert isinstance(info["path"], str)
     assert info["type"] == "Assembly"
     assert isinstance(info["configuration"], str)
@@ -263,8 +258,7 @@ async def test_get_model_info_works_from_worker_thread(
     test_assy = _test_assembly_path()
     if not test_assy or not os.path.exists(test_assy):
         pytest.skip(
-            f"set {_TEST_ASSEMBLY_ENV_VAR} to a local .SLDASM path "
-            "to run this test"
+            f"set {_TEST_ASSEMBLY_ENV_VAR} to a local .SLDASM path to run this test"
         )
 
     await connected_adapter.open_model(test_assy)
@@ -288,8 +282,7 @@ async def test_get_model_info_works_from_worker_thread(
     assert not t.is_alive(), "worker thread hung"
 
     assert worker_result["error"] is None, (
-        f"cross-thread get_model_info surfaced an error: "
-        f"{worker_result['error']!r}"
+        f"cross-thread get_model_info surfaced an error: {worker_result['error']!r}"
     )
     assert worker_result.get("title", "").endswith(".SLDASM")
 
@@ -317,9 +310,7 @@ async def test_add_sketch_constraint_perpendicular_and_horizontal(
 
     try:
         sketch_result = await adapter.create_sketch("Front")
-        assert sketch_result.is_success, (
-            f"create_sketch failed: {sketch_result.error}"
-        )
+        assert sketch_result.is_success, f"create_sketch failed: {sketch_result.error}"
 
         line1 = await adapter.add_line(0.0, 0.0, 50.0, 0.0)
         line2 = await adapter.add_line(50.0, 0.0, 50.0, 50.0)
@@ -330,9 +321,7 @@ async def test_add_sketch_constraint_perpendicular_and_horizontal(
         perp = await adapter.add_sketch_constraint(
             line1.data, line2.data, "perpendicular"
         )
-        assert perp.is_success, (
-            f"perpendicular constraint failed: {perp.error}"
-        )
+        assert perp.is_success, f"perpendicular constraint failed: {perp.error}"
         assert perp.data.startswith("Constraint_"), (
             f"unexpected constraint id: {perp.data!r}"
         )


### PR DESCRIPTION
## Summary

- Replaces the `add_sketch_constraint` placeholder (which returned synthetic IDs without touching SolidWorks) with a real implementation that drives `ISketchRelationManager.AddRelation(entities, swConstraintType_e)` per the official SW API docs.
- Wires up the `sw_type_info.flag_methods` infrastructure that `CLAUDE.md` documented but the codebase never actually invoked — without it, late-bound SW dispatches mis-resolve zero-arg methods as properties (runbook #2/#5).
- Verified end-to-end against a live SOLIDWORKS 3DEXPERIENCE R2026x session: the perpendicular ⟂ icon appears at the shared vertex and `Line_2` turns black after dimensions are added.

## Why the rewrite

The previous placeholder at `adapters/solidworks/sketch.py:827` returned a synthetic `Constraint_<type>_<ms>` ID. Every downstream call that expected a real relation silently behaved as if the sketch were under-defined.

The first rewrite tried the legacy `IModelDoc2.SketchAddConstraints("sgPERPENDICULAR2D")` API. It accepts the call, returns nothing, and silently no-ops on SW 2026 — visible in the SW UI as a still-blue `Line_2` after the call.

Per the official SolidWorks API docs, the modern path is `ISketchRelationManager.AddRelation(entities, RelationType)`, where `RelationType` is an integer from `swConstraintType_e`. That call works — but only when entities are passed as a `VARIANT(VT_ARRAY | VT_DISPATCH, [...])`; plain Python lists raise `com_error(-2147417851, 'The server threw an exception.')`.

## Changes

### Sketch-constraint implementation (the headline change)
- `src/solidworks_mcp/adapters/solidworks/sketch.py` — rewrote `_add_sketch_constraint_impl`:
  - `RELATION_NAME_MAP: dict[str, int]` now holds canonical `swConstraintType_e` integer values (`PERPENDICULAR=8`, `HORIZONTAL=4`, `PARALLEL=7`, …, `COLINEAR=27`).
  - Resolves entities from the registry, gets `currentModel.GetActiveSketch2().RelationManager`, calls `relmgr.AddRelation(VARIANT(VT_ARRAY|VT_DISPATCH, entities), enum)`.
  - Flags `IModelDoc2`, `ISketch`, and `ISketchRelationManager` inline so late-binding resolves correctly.
- `src/solidworks_mcp/adapters/mock_adapter.py` — added mock `add_sketch_constraint` override sharing the same `RELATION_NAME_MAP` so the mock and real paths can't drift on supported names.

### Adjacent infrastructure fixes (needed for the live path)
- `src/solidworks_mcp/adapters/sw_type_info.py` — added SW 2026 (major 34) and 35 to the gen_py wrapper-lookup version probe.
- `src/solidworks_mcp/adapters/pywin32_adapter.py` — force late binding via `win32com.client.dynamic.Dispatch` (the gen_py wrapper otherwise auto-upgrades to early binding and breaks `OpenDoc6`'s VARIANT pass-by-ref params); call `flag_methods(app, "ISldWorks")` after acquiring the application.
- `src/solidworks_mcp/adapters/solidworks/io.py` — call `flag_doc(model, doc_type)` in `open_model`, `create_part`, `create_assembly`, `create_drawing` so method-vs-property resolution works on freshly acquired model dispatches.

### Documentation
- `docs/user-guide/tool-catalog/sketching.md` — expanded the `add_sketch_constraint` entry with the supported relation_type values, entity arity, and response payload shape.

### Tests
- `tests/solidworks_mcp/adapters/solidworks/test_sketch.py` — 7 new unit tests against a fake adapter: happy two-entity, single-entity, unknown entity, unsupported relation, SW rejection, no active sketch, AddRelation returns None.
- `tests/test_live_sw_regression.py` — 2 new live-SW integration tests (perpendicular + horizontal happy path; unsupported relation error path). Both run under `SOLIDWORKS_MCP_RUN_REAL_INTEGRATION=1`.
- `tests/solidworks_mcp/adapters/test_adapters.py` — updated 3 connect-mock tests to also stub `_dynamic_module.Dispatch` now that the connect path uses dynamic binding.

## Test plan

Per [CONTRIBUTING.md](https://github.com/andrewbartels1/SolidworksMCP-python/blob/main/CONTRIBUTING.md) lint/tests/docs build:

- [x] `ruff format` + `ruff check` on edited files — clean. (Pre-existing `I001` warnings in unrelated files left alone.)
- [x] `pytest tests/ -m "not solidworks_only and not smoke"` — **1158 passed, 56 skipped**.
- [x] `SOLIDWORKS_MCP_RUN_REAL_INTEGRATION=1 pytest tests/test_live_sw_regression.py` against running SW 3DEXPERIENCE R2026x — **8 passed, 3 skipped** without `SOLIDWORKS_MCP_TEST_ASSEMBLY`.
- [x] `mkdocs build --clean` — documentation built in ~33s with only pre-existing griffe warnings.
- [x] Manual MCP-tool smoke test through `register_sketching_tools` against the live SW session — `Constraint_3` and `Constraint_4` register as live `CDispatch` `ISketchRelation` objects, perpendicular icon visible at (50,0), `Line_2` turns black after a length dimension.
- [x] **Reviewer concern #1 verified**: the four `flag_doc` insertions in `io.py` do not regress `open_model`. Drove `open_model("summing-lever.SLDPRT")` end-to-end against a live SW R2026x session — returned `SolidWorksModel(name='summing-lever.SLDPRT', type='Part', configuration='Default', is_active=True)`. `model.GetTitle()` and `model.FeatureManager.GetFeatureCount(False)` (both zero-arg methods that pywin32 mis-resolves as properties without `flag_doc`) returned `'summing-lever.SLDPRT'` and `37`. See PR comment for the run log.
- [x] **Reviewer concern #2 verified**: `dynamic.Dispatch` switch holds. `type(adapter.swApp).__name__ == 'CDispatch'` after connect, confirming the runtime is late-bound; `OpenDoc6` with VARIANT pass-by-ref `errors` / `warnings` out-params succeeded against `summing-lever.SLDPRT`. This is the same scenario runbook item #1 fixes.

## Out-of-scope failures observed during reviewer verification (separate issues)

When running `tests/test_live_sw_regression.py` with `SOLIDWORKS_MCP_TEST_ASSEMBLY` set, two pre-existing tests fail. Neither is caused by this PR — they were just never exercised before:

1. `test_get_model_info_fields_populate` → `Error in get_model_info: <unknown>.GetName`. `get_model_info` (and `open_model` config-name reading) still calls `IConfiguration.GetName()`; on SW 2026 only the `IConfiguration.Name` property exists. Runbook #3 already describes the fix.
2. `test_get_model_info_works_from_worker_thread` → `CoInitialize has not been called`. `_handle_com_operation` runs the closure on the caller thread; the `ComExecutor` STA worker described in CLAUDE.md isn't actually wired up (only the class is defined).

Worth tracking separately — not blocking on this PR.

## Prerequisite for the live path

The SolidWorks gen_py wrapper has to be generated once per SW version:

```powershell
python -m win32com.client.makepy "C:\Program Files\Dassault Systemes\SOLIDWORKS 3DEXPERIENCE R2026x\SOLIDWORKS\sldworks.tlb"
```

Without it, `flag_methods` is a no-op and SW methods that look like properties to pywin32's heuristic (e.g. `GetActiveSketch2`, `SketchAddConstraints`) mis-dispatch. Worth wiring into `dev-install` in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)