### PR TITLE
fix(sketch): make pythoncom import lazy so Linux CI passes

### DIFF
--- a/src/solidworks_mcp/adapters/solidworks/sketch.py
+++ b/src/solidworks_mcp/adapters/solidworks/sketch.py
@@ -991,18 +991,24 @@ def _add_sketch_constraint_impl(
             )
 
         # pywin32 won't auto-marshal a Python list of CDispatch entities to a
-        # SAFEARRAY. The VT_ARRAY|VT_DISPATCH variant is the shape SolidWorks
-        # accepts. Import is lazy so the module still imports in mock/CI
-        # environments without pywin32.
+        # SAFEARRAY — the VT_ARRAY|VT_DISPATCH variant is the shape SolidWorks
+        # accepts. Mirror the lazy-import dance used for sw_type_info above so
+        # non-Windows CI (where pywin32 isn't installed) still exercises this
+        # call path; fake adapters used in unit tests accept any sequence.
         try:
             import pythoncom as _pythoncom
             from win32com.client import VARIANT as _VARIANT
-        except ImportError as exc:  # pragma: no cover
-            raise Exception(
-                "pywin32 is required for add_sketch_constraint on a real adapter"
-            ) from exc
+        except ImportError:
+            _pythoncom = None  # type: ignore[assignment]
+            _VARIANT = None  # type: ignore[assignment]
 
-        ents_variant = _VARIANT(_pythoncom.VT_ARRAY | _pythoncom.VT_DISPATCH, entities)
+        ents_variant: Any
+        if _pythoncom is not None and _VARIANT is not None:
+            ents_variant = _VARIANT(
+                _pythoncom.VT_ARRAY | _pythoncom.VT_DISPATCH, entities
+            )
+        else:
+            ents_variant = entities
         sketch_relation, add_err = adapter._attempt_with_error(
             lambda: relmgr.AddRelation(ents_variant, relation_type_enum)
         )

--- a/src/solidworks_mcp/adapters/solidworks/sketch.py
+++ b/src/solidworks_mcp/adapters/solidworks/sketch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import time
 from typing import Any, cast
 
@@ -1007,7 +1008,17 @@ def _add_sketch_constraint_impl(
             ents_variant = _VARIANT(
                 _pythoncom.VT_ARRAY | _pythoncom.VT_DISPATCH, entities
             )
+        elif sys.platform == "win32":
+            # On Windows the real adapter feeds entities to a live COM method
+            # that requires the SAFEARRAY shape — fail clearly rather than let
+            # AddRelation surface a low-level "server threw an exception" COM
+            # error from an unwrappable list argument.
+            raise Exception(
+                "pywin32 is required for add_sketch_constraint on Windows"
+            )
         else:
+            # Non-Windows: this branch is exercised only by mocked unit tests
+            # whose fake AddRelation accepts any sequence.
             ents_variant = entities
         sketch_relation, add_err = adapter._attempt_with_error(
             lambda: relmgr.AddRelation(ents_variant, relation_type_enum)

--- a/tests/solidworks_mcp/adapters/solidworks/test_sketch.py
+++ b/tests/solidworks_mcp/adapters/solidworks/test_sketch.py
@@ -361,8 +361,9 @@ def test_add_sketch_constraint_symmetric_happy_path() -> None:
     ents_arg, rt_arg = add_relation.call_args.args
     assert rt_arg == 11  # swConstraintType_SYMMETRIC
     # Three-element entity list, in order: entity1, entity2, entity3.
-    # On Windows the impl wraps entities in a VARIANT(value=[...]); on
-    # non-Windows CI without pywin32 it falls back to a plain list.
+    # When pywin32 is available (real Windows runs) the impl wraps
+    # entities in a VARIANT(value=[...]); when it is not (Linux CI) the
+    # non-Windows branch passes the entities through as a plain list.
     entities_seq = getattr(ents_arg, "value", ents_arg)
     assert len(entities_seq) == 3
 

--- a/tests/solidworks_mcp/adapters/solidworks/test_sketch.py
+++ b/tests/solidworks_mcp/adapters/solidworks/test_sketch.py
@@ -360,8 +360,11 @@ def test_add_sketch_constraint_symmetric_happy_path() -> None:
     assert adapter._sketch_entities[result.data] is constraint_obj
     ents_arg, rt_arg = add_relation.call_args.args
     assert rt_arg == 11  # swConstraintType_SYMMETRIC
-    # Three-element entity list, in order: entity1, entity2, entity3
-    assert len(ents_arg.value) == 3
+    # Three-element entity list, in order: entity1, entity2, entity3.
+    # On Windows the impl wraps entities in a VARIANT(value=[...]); on
+    # non-Windows CI without pywin32 it falls back to a plain list.
+    entities_seq = getattr(ents_arg, "value", ents_arg)
+    assert len(entities_seq) == 3
 
 
 def test_add_sketch_constraint_symmetric_missing_entity3_returns_error() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #17. Five new unit tests in `tests/solidworks_mcp/adapters/solidworks/test_sketch.py` fail on Linux CI with `pywin32 is required for add_sketch_constraint on a real adapter`, because the eager `pythoncom` / `win32com.client.VARIANT` import inside `_add_sketch_constraint_impl` raised regardless of whether the adapter under test was real or mocked.

The closure intent was to wrap the entity list in a SAFEARRAY VARIANT (the shape SolidWorks's late-bound `ISketchRelationManager.AddRelation` accepts). On Windows + pywin32 the wrap is correct; on Linux CI the ImportError fired and the closure aborted before reaching the fake `AddRelation` that the unit tests provide.

## Fix

- Mirror the lazy-import dance already used for `sw_type_info` a few lines above: `try`/`except ImportError`, set `_pythoncom = None` and `_VARIANT = None`, branch the VARIANT wrap on availability.
- When pywin32 is absent (CI / non-Windows dev environments), fall back to passing the plain entity list. The fake `AddRelation` in `_make_constraint_adapter` is a `Mock` that doesn't inspect the wrapper type, and the real Windows path is unchanged.
- Update `test_add_sketch_constraint_symmetric_happy_path` so its length assertion handles both the `VARIANT(value=[...])` shape (Windows) and the plain-list fallback (Linux CI): `entities_seq = getattr(ents_arg, "value", ents_arg)`.

## Verification

| Environment | Result | Compared to previous |
|---|---|---|
| Windows venv with pywin32 (this machine) | **1164 passed**, 61 skipped, 32 deselected | unchanged |
| WSL Ubuntu 24.04 venv without pywin32 | **1155 passed**, 65 skipped, 37 deselected | was 1150 passed + 5 failed on CI |

The 5 previously-failing tests are now green on actual Linux:
- `test_add_sketch_constraint_two_entity_happy_path`
- `test_add_sketch_constraint_single_entity_horizontal`
- `test_add_sketch_constraint_sw_rejection_returns_error`
- `test_add_sketch_constraint_add_relation_returns_none_is_error`
- `test_add_sketch_constraint_symmetric_happy_path`

## Test plan

- [x] `ruff check` clean on the two edited files (the broader 122 ruff errors elsewhere are pre-existing and out of scope).
- [x] `ruff format --check` clean.
- [x] Full unit suite green on Windows.
- [x] Full unit suite (CI-equivalent `pytest tests/ -m "not solidworks_only and not smoke"`) green in WSL Ubuntu 24.04 with the same dependency set CI installs (`pip install -e ".[dev,docs,ui]"`).
- [ ] Re-running the live SW regression suite is not required — the changed code path is hit by the live tests as well, but they run only on Windows + pywin32 where the behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)