### PR TITLE
fix: restore cut-extrude fallback chain and mass-properties dual-path broken by #25

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,8 @@ This repository is Python-first and centered on SolidWorks MCP tooling plus opti
 1. Fork the repo and create a branch from `main`.
 2. Make focused changes with tests/docs updates where relevant.
 3. Run lint/tests/docs build locally.
-4. Open a pull request with a concise summary.
+4. **Run the local CI check** (see below) and confirm it passes before opening a PR.
+5. Open a pull request with a concise summary.
 
 ## Local Setup
 
@@ -20,6 +21,34 @@ cd SolidworksMCP-python
 python -m venv .venv
 .\.venv\Scripts\python.exe -m pip install --upgrade pip setuptools wheel
 .\.venv\Scripts\python.exe -m pip install -e ".[dev,test,docs]"
+```
+
+## Local CI Check (required before PRs)
+
+Before opening a pull request, run the local CI script to reproduce the same test environment used in GitHub Actions:
+
+```powershell
+.\run-ci-local.ps1
+```
+
+This builds a Docker image from `.ci/Dockerfile` and runs `make test` inside it — the exact command GitHub CI executes. A clean pass here means your PR will not fail CI on test issues.
+
+If Docker is not available, run the full local test suite instead and confirm it passes:
+
+```powershell
+.\dev-commands.ps1 dev-test
+```
+
+### First run
+
+The first invocation builds the Docker image (a few minutes). Subsequent runs reuse the cached image unless you pass `-NoBuild`:
+
+```powershell
+# Force image rebuild
+.\run-ci-local.ps1
+
+# Skip rebuild (faster after first run)
+.\run-ci-local.ps1 -NoBuild
 ```
 
 ## Recommended Commands
@@ -61,6 +90,7 @@ Current docs structure:
 
 ## Pull Request Guidelines
 
+- Run `.\run-ci-local.ps1` and confirm it passes before opening a PR (see above).
 - Use concise commit messages that describe intent.
 - Keep unrelated generated/local artifacts out of commits.
 - Include validation notes (tests/docs build) in the PR description.

--- a/src/solidworks_mcp/adapters/solidworks/features.py
+++ b/src/solidworks_mcp/adapters/solidworks/features.py
@@ -558,46 +558,111 @@ def _create_cut_extrude_impl(
 
         feature = None
         fallback_errors: list[str] = []
-
-        # FeatureCut3 via IFeatureManager (SW2010+, 27 params).
-        # Signature: Sd, Flip, Dir, T1, T2, D1, D2, Dchk1, Dchk2, Ddir1, Ddir2,
-        #   Dang1, Dang2, OffsetReverse1, OffsetReverse2, TranslateSurface1,
-        #   TranslateSurface2, NormalCut, UseFeatScope, UseAutoSelect,
-        #   AssemblyFeatureScope, AutoSelectComponents, PropagateFeatureToParts,
-        #   T0, StartOffset, FlipStartOffset
         is_through = end_condition in {"throughall", "through all", "through_all"}
-        feature, cut3_error = adapter._attempt_with_error(
-            lambda: feature_manager.FeatureCut3(
-                is_through,                      # Sd: True=through-all
-                normalized.reverse_direction,     # Flip
-                False,                            # Dir
-                t1,                               # T1
-                0,                                # T2 (ignored when Sd=True)
-                normalized.depth / 1000.0,        # D1 (meters)
-                normalized.depth / 1000.0,        # D2 (meters)
-                False,                            # Dchk1
-                False,                            # Dchk2
-                False,                            # Ddir1
-                False,                            # Ddir2
-                normalized.draft_angle * 3.14159 / 180.0,  # Dang1
-                0.0,                              # Dang2
-                False,                            # OffsetReverse1
-                False,                            # OffsetReverse2
-                False,                            # TranslateSurface1
-                False,                            # TranslateSurface2
-                False,                            # NormalCut
-                normalized.feature_scope,         # UseFeatScope
-                normalized.auto_select,           # UseAutoSelect
-                False,                            # AssemblyFeatureScope
-                False,                            # AutoSelectComponents
-                False,                            # PropagateFeatureToParts
-                t0,                               # T0
-                0.0,                              # StartOffset
-                False,                            # FlipStartOffset
+
+        # 1. FeatureCut4 (SW 2015+, 27 params)
+        feature, cut4_error = adapter._attempt_with_error(
+            lambda: feature_manager.FeatureCut4(
+                True,
+                False,
+                normalized.reverse_direction,
+                t1,
+                adapter.constants["swEndCondBlind"],
+                depth_m,
+                0.0,
+                False,
+                False,
+                False,
+                False,
+                normalized.draft_angle * 3.14159 / 180.0,
+                0.0,
+                False,
+                False,
+                False,
+                False,
+                False,
+                normalized.feature_scope,
+                normalized.auto_select,
+                False,
+                False,
+                False,
+                t0,
+                0.0,
+                False,
+                False,
             )
         )
-        if cut3_error is not None:
-            fallback_errors.append(f"FeatureCut3: {cut3_error}")
+        if cut4_error is not None:
+            fallback_errors.append(f"FeatureCut4: {cut4_error}")
+
+        if not feature:
+            # 2. FeatureCut3 modern (SW 2010+, 26 params, corrected for SW 2022)
+            # Signature: Sd, Flip, Dir, T1, T2, D1, D2, Dchk1, Dchk2, Ddir1, Ddir2,
+            #   Dang1, Dang2, OffsetReverse1, OffsetReverse2, TranslateSurface1,
+            #   TranslateSurface2, NormalCut, UseFeatScope, UseAutoSelect,
+            #   AssemblyFeatureScope, AutoSelectComponents, PropagateFeatureToParts,
+            #   T0, StartOffset, FlipStartOffset
+            feature, cut3_modern_error = adapter._attempt_with_error(
+                lambda: feature_manager.FeatureCut3(
+                    is_through,
+                    normalized.reverse_direction,
+                    False,
+                    t1,
+                    0,
+                    normalized.depth / 1000.0,
+                    normalized.depth / 1000.0,
+                    False,
+                    False,
+                    False,
+                    False,
+                    normalized.draft_angle * 3.14159 / 180.0,
+                    0.0,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    normalized.feature_scope,
+                    normalized.auto_select,
+                    False,
+                    False,
+                    False,
+                    t0,
+                    0.0,
+                    False,
+                )
+            )
+            if cut3_modern_error is not None:
+                fallback_errors.append(f"FeatureCut3 modern: {cut3_modern_error}")
+
+        if not feature:
+            # 3. FeatureCut3 legacy (older installs, alternate arg order)
+            feature, cut3_legacy_error = adapter._attempt_with_error(
+                lambda: feature_manager.FeatureCut3(
+                    True,
+                    False,
+                    normalized.reverse_direction,
+                    adapter.constants["swEndCondBlind"],
+                    adapter.constants["swEndCondBlind"],
+                    False,
+                    False,
+                    False,
+                    False,
+                    normalized.draft_angle * 3.14159 / 180.0,
+                    0.0,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    normalized.feature_scope,
+                    normalized.auto_select,
+                    normalized.depth / 1000.0,
+                    0.0,
+                )
+            )
+            if cut3_legacy_error is not None:
+                fallback_errors.append(f"FeatureCut3 legacy: {cut3_legacy_error}")
 
         if not feature:
             if fallback_errors:

--- a/src/solidworks_mcp/adapters/solidworks/io.py
+++ b/src/solidworks_mcp/adapters/solidworks/io.py
@@ -622,26 +622,76 @@ class SolidWorksIOMixin:
 
         def _get() -> MassProperties:
             """Get mass properties."""
-            # Primary: GetMassProperties (array API, always works)
-            raw = adapter._attempt(
-                lambda: adapter.currentModel.GetMassProperties(), default=None
+            adapter._attempt(
+                lambda: adapter.currentModel.ForceRebuild3(False), default=None
             )
-            if isinstance(raw, (list, tuple)) and len(raw) >= 6:
-                return MassProperties(
-                    volume=raw[3] * 1e9,
-                    surface_area=raw[4] * 1e6,
-                    mass=raw[5],
-                    center_of_mass=[raw[0] * 1000.0, raw[1] * 1000.0, raw[2] * 1000.0],
-                    moments_of_inertia={
-                        "Ixx": raw[6] if len(raw) > 6 else 0.0,
-                        "Iyy": raw[7] if len(raw) > 7 else 0.0,
-                        "Izz": raw[8] if len(raw) > 8 else 0.0,
-                        "Ixy": raw[9] if len(raw) > 9 else 0.0,
-                        "Ixz": raw[11] if len(raw) > 11 else 0.0,
-                        "Iyz": raw[10] if len(raw) > 10 else 0.0,
-                    },
+
+            # Primary: Extension.CreateMassProperty() object API (most detailed)
+            mass_props = adapter._attempt(
+                lambda: adapter.currentModel.Extension.CreateMassProperty(),
+                default=None,
+            )
+
+            if mass_props:
+                volume = mass_props.Volume * 1e9
+                surface_area = mass_props.SurfaceArea * 1e6
+                mass = mass_props.Mass
+
+                center_of_mass = [0.0, 0.0, 0.0]
+                com = adapter._attempt(lambda: mass_props.CenterOfMass, default=None)
+                if isinstance(com, (list, tuple)) and len(com) >= 3:
+                    center_of_mass = [com[0] * 1000, com[1] * 1000, com[2] * 1000]
+
+                moi = adapter._attempt(
+                    lambda: mass_props.GetMomentOfInertia(0), default=None
                 )
-            raise Exception("Failed to get mass properties")
+                if not isinstance(moi, (list, tuple)) or len(moi) < 9:
+                    moi = [0.0] * 9
+            else:
+                # Fallback: GetMassProperties as attribute (tuple) or callable (SW 2022)
+                gmp = getattr(adapter.currentModel, "GetMassProperties", None)
+                if callable(gmp):
+                    raw = adapter._attempt(gmp, default=None)
+                elif isinstance(gmp, (list, tuple)):
+                    raw = gmp
+                else:
+                    raw = None
+
+                if not isinstance(raw, (list, tuple)) or len(raw) < 6:
+                    raise Exception("Failed to get mass properties")
+
+                center_of_mass = [
+                    raw[0] * 1000.0,
+                    raw[1] * 1000.0,
+                    raw[2] * 1000.0,
+                ]
+                volume = raw[3] * 1e9
+                surface_area = raw[4] * 1e6
+                mass = raw[5]
+
+                moi = [0.0] * 9
+                if len(raw) >= 12:
+                    moi[0] = raw[6]
+                    moi[4] = raw[7]
+                    moi[8] = raw[8]
+                    moi[1] = raw[9]
+                    moi[5] = raw[10]
+                    moi[2] = raw[11]
+
+            return MassProperties(
+                volume=volume,
+                surface_area=surface_area,
+                mass=mass,
+                center_of_mass=center_of_mass,
+                moments_of_inertia={
+                    "Ixx": moi[0],
+                    "Iyy": moi[4],
+                    "Izz": moi[8],
+                    "Ixy": moi[1],
+                    "Ixz": moi[2],
+                    "Iyz": moi[5],
+                },
+            )
 
         return cast(
             AdapterResult[MassProperties],


### PR DESCRIPTION
## Summary

- **Root cause**: PR #25 (SW 2022 compatibility) simplified `_create_cut_extrude_impl` to a single `FeatureCut3` call and `get_mass_properties` to call-only `GetMassProperties()`, breaking four CI tests.
- **`_create_cut_extrude_impl`**: Restored the `FeatureCut4` → `FeatureCut3 modern` → `FeatureCut3 legacy` fallback chain. The FeatureCut3 modern path keeps PR #25's corrected 26-parameter signature for SW 2022 compatibility.
- **`get_mass_properties`**: Restored the dual-path approach — tries `Extension.CreateMassProperty()` object API first, then falls back to `GetMassProperties` handled as either a callable or a tuple attribute (a real COM quirk where the property is pre-computed).
- **`CONTRIBUTING.md`**: Added a mandatory `.\run-ci-local.ps1` step before opening any PR so this class of regression is caught locally.

## Test plan

- [x] `test_create_cut_extrude_collects_all_fallback_errors` — passes (FeatureCut4/FeatureCut3 modern/legacy error labels present)
- [x] `test_sketch_geometry_feature_and_mass_property_paths` — passes (CreateMassProperty object path)
- [x] `test_feature_id_and_mass_properties_tuple_fallback` — passes (GetMassProperties tuple attribute path)
- [x] `test_sketch_and_mass_property_guard_and_fallback_errors` — passes (both list-attribute and short-list error paths)
- [x] Full suite (`pytest tests -m "not solidworks_only"`) — 1281 passed, 0 failed