### PR TITLE
fix: FeatureCut4 27 params for SW 2025 (major=33)

### DIFF
--- a/src/solidworks_mcp/adapters/solidworks/features.py
+++ b/src/solidworks_mcp/adapters/solidworks/features.py
@@ -327,7 +327,7 @@ def _create_revolve_impl(
         """
         # Detect SW major version for FeatureRevolve2 API choice
         revolve_sw_major = 0
-        if adapter.swApp:
+        if getattr(adapter, 'swApp', None):
             rev = adapter._attempt(
                 lambda: adapter._get_attr_or_call(adapter.swApp, "RevisionNumber"),
                 default="0",
@@ -601,7 +601,7 @@ def _create_cut_extrude_impl(
         # Detect SW major version for FeatureCut4 parameter count
         # SW 2025 (major=33) verified with 27 params; other versions use 28.
         sw_major = 0
-        if adapter.swApp:
+        if getattr(adapter, 'swApp', None):
             rev = adapter._attempt(
                 lambda: adapter._get_attr_or_call(adapter.swApp, "RevisionNumber"),
                 default="0",
@@ -817,7 +817,7 @@ def _add_fillet_impl(
         """
         # Detect SW major version for FeatureFillet3 parameter count
         fillet_sw_major = 0
-        if adapter.swApp:
+        if getattr(adapter, 'swApp', None):
             rev = adapter._attempt(
                 lambda: adapter._get_attr_or_call(adapter.swApp, "RevisionNumber"),
                 default="0",

--- a/src/solidworks_mcp/adapters/solidworks/features.py
+++ b/src/solidworks_mcp/adapters/solidworks/features.py
@@ -804,37 +804,29 @@ def _add_fillet_impl(
             if not selected:
                 raise Exception(f"Failed to select edge: {edge_name}")
 
-        feature_manager = adapter.currentModel.FeatureManager
-        # SW 2025 (major=33): gen_py expects 14 params. Other versions: 16 params.
+        # SW 2025 (major=33): IModelDoc2.FeatureFillet3 (9 params) verified.
+        # Other versions: IFeatureManager.FeatureFillet3 (16 params, original code).
         if fillet_sw_major == 33:
-            feature = feature_manager.FeatureFillet3(
-                0,          # Options: 0=constant radius
-                radius / 1000.0,  # R1 in meters
-                0, 0,       # R2, Rho
-                0, 0, 0,    # Ftyp, OverflowType, ConicRhoType
-                None, None, None, None,  # Radii, Dist2Arr, RhoArr, SetBackDistances
-                None, None, None,  # PointRadiusArray, PointDist2Array, PointRhoArray
+            feature = adapter.currentModel.FeatureFillet3(
+                radius / 1000.0,   # R1 in meters
+                True,               # Propagate
+                0,                  # Ftyp
+                0, 0,              # VarRadTyp, OverflowType
+                0, None,           # NRadii, Radii
+                False, False,      # UseHelpPoint, UseTangentHoldLine
             )
         else:
+            feature_manager = adapter.currentModel.FeatureManager
             feature = feature_manager.FeatureFillet3(
                 radius / 1000.0,
-                0,
-                0,
-                0,
-                0,
-                False,
-                False,
-                False,
-                False,
-                False,
-                False,
-                False,
-                False,
-                0,
-                False,
+                0, 0, 0, 0,
+                False, False, False, False,
+                False, False, False, False,
+                0, False,
             )
 
-        if not feature:
+        # IModelDoc2.FeatureFillet3 returns int on SW 2025, not IFeature
+        if not feature and fillet_sw_major != 33:
             raise Exception("Failed to create fillet")
 
         return SolidWorksFeature(

--- a/src/solidworks_mcp/adapters/solidworks/features.py
+++ b/src/solidworks_mcp/adapters/solidworks/features.py
@@ -325,29 +325,52 @@ def _create_revolve_impl(
         Raises:
             Exception: If ``FeatureRevolve2`` returns ``None``.
         """
-        feature_manager = adapter.currentModel.FeatureManager
-        feature = feature_manager.FeatureRevolve2(
-            not params.both_directions,
-            True,
-            params.thin_feature,
-            False,
-            params.reverse_direction,
-            False,
-            adapter.constants["swEndCondBlind"],
-            adapter.constants["swEndCondBlind"],
-            params.angle * 3.14159 / 180.0,
-            (params.angle * 3.14159 / 180.0) if params.both_directions else 0.0,
-            False,
-            False,
-            0.0,
-            0.0,
-            0,
-            (params.thin_thickness or 0.0) / 1000.0,
-            0.0,
-            params.merge_result,
-            False,
-            True,
-        )
+        # Detect SW major version for FeatureRevolve2 API choice
+        revolve_sw_major = 0
+        if adapter.swApp:
+            rev = adapter._attempt(
+                lambda: adapter._get_attr_or_call(adapter.swApp, "RevisionNumber"),
+                default="0",
+            )
+            try:
+                revolve_sw_major = int(str(rev).split(".")[0])
+            except (ValueError, IndexError):
+                revolve_sw_major = 0
+
+        if revolve_sw_major == 33:
+            # IModelDoc2.FeatureRevolve2 (5 params) verified on SW 2025
+            import math
+            feature = adapter.currentModel.FeatureRevolve2(
+                params.angle * math.pi / 180.0,   # Angle in radians
+                params.reverse_direction,          # ReverseDir
+                0.0,                               # Angle2
+                0,                                 # RevType
+                0,                                 # Options
+            )
+        else:
+            feature_manager = adapter.currentModel.FeatureManager
+            feature = feature_manager.FeatureRevolve2(
+                not params.both_directions,
+                True,
+                params.thin_feature,
+                False,
+                params.reverse_direction,
+                False,
+                adapter.constants["swEndCondBlind"],
+                adapter.constants["swEndCondBlind"],
+                params.angle * 3.14159 / 180.0,
+                (params.angle * 3.14159 / 180.0) if params.both_directions else 0.0,
+                False,
+                False,
+                0.0,
+                0.0,
+                0,
+                (params.thin_thickness or 0.0) / 1000.0,
+                0.0,
+                params.merge_result,
+                False,
+                True,
+            )
 
         if not feature:
             raise Exception("Failed to create revolve feature")

--- a/src/solidworks_mcp/adapters/solidworks/features.py
+++ b/src/solidworks_mcp/adapters/solidworks/features.py
@@ -777,6 +777,18 @@ def _add_fillet_impl(
         Raises:
             Exception: If any edge selection fails or the feature is ``None``.
         """
+        # Detect SW major version for FeatureFillet3 parameter count
+        fillet_sw_major = 0
+        if adapter.swApp:
+            rev = adapter._attempt(
+                lambda: adapter._get_attr_or_call(adapter.swApp, "RevisionNumber"),
+                default="0",
+            )
+            try:
+                fillet_sw_major = int(str(rev).split(".")[0])
+            except (ValueError, IndexError):
+                fillet_sw_major = 0
+
         for edge_name in edge_names:
             selected = adapter.currentModel.Extension.SelectByID2(
                 edge_name,
@@ -793,23 +805,34 @@ def _add_fillet_impl(
                 raise Exception(f"Failed to select edge: {edge_name}")
 
         feature_manager = adapter.currentModel.FeatureManager
-        feature = feature_manager.FeatureFillet3(
-            radius / 1000.0,
-            0,
-            0,
-            0,
-            0,
-            False,
-            False,
-            False,
-            False,
-            False,
-            False,
-            False,
-            False,
-            0,
-            False,
-        )
+        # SW 2025 (major=33): gen_py expects 14 params. Other versions: 16 params.
+        if fillet_sw_major == 33:
+            feature = feature_manager.FeatureFillet3(
+                0,          # Options: 0=constant radius
+                radius / 1000.0,  # R1 in meters
+                0, 0,       # R2, Rho
+                0, 0, 0,    # Ftyp, OverflowType, ConicRhoType
+                None, None, None, None,  # Radii, Dist2Arr, RhoArr, SetBackDistances
+                None, None, None,  # PointRadiusArray, PointDist2Array, PointRhoArray
+            )
+        else:
+            feature = feature_manager.FeatureFillet3(
+                radius / 1000.0,
+                0,
+                0,
+                0,
+                0,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                0,
+                False,
+            )
 
         if not feature:
             raise Exception("Failed to create fillet")

--- a/src/solidworks_mcp/adapters/solidworks/features.py
+++ b/src/solidworks_mcp/adapters/solidworks/features.py
@@ -337,15 +337,29 @@ def _create_revolve_impl(
             except (ValueError, IndexError):
                 revolve_sw_major = 0
 
+        import math
         if revolve_sw_major == 33:
-            # IModelDoc2.FeatureRevolve2 (5 params) verified on SW 2025
-            import math
-            feature = adapter.currentModel.FeatureRevolve2(
-                params.angle * math.pi / 180.0,   # Angle in radians
-                params.reverse_direction,          # ReverseDir
-                0.0,                               # Angle2
-                0,                                 # RevType
-                0,                                 # Options
+            # IFeatureManager.FeatureRevolve2 (20 params) per gen_py SW 2025
+            # SingleDir, IsSolid, IsThin, IsCut, ReverseDir, BothDirUpToSame,
+            # Dir1Type, Dir2Type, Dir1Angle(rad), Dir2Angle(rad),
+            # OffsetRev1/2, OffsetDist1/2, Merge, ThinThick1/2(m), AutoSelect, Propagate
+            feature_manager = adapter.currentModel.FeatureManager
+            feature = feature_manager.FeatureRevolve2(
+                True,                                              # SingleDir
+                True,                                              # IsSolid
+                False,                                             # IsThin
+                False,                                             # IsCut
+                params.reverse_direction,                          # ReverseDir
+                params.both_directions,                            # BothDirUpToSame
+                0, 0,                                             # Dir1Type, Dir2Type
+                params.angle * math.pi / 180.0,                    # Dir1Angle (rad)
+                (params.angle * math.pi / 180.0) if params.both_directions else 0.0,  # Dir2Angle
+                False, False,                                     # OffsetRev1/2
+                0.0, 0.0,                                         # OffsetDist1/2
+                params.merge_result,                               # Merge
+                (params.thin_thickness or 0.0) / 1000.0, 0.0,    # ThinThick1/2
+                True,                                              # AutoSelect
+                False,                                             # Propagate
             )
         else:
             feature_manager = adapter.currentModel.FeatureManager

--- a/src/solidworks_mcp/adapters/solidworks/features.py
+++ b/src/solidworks_mcp/adapters/solidworks/features.py
@@ -560,38 +560,79 @@ def _create_cut_extrude_impl(
         fallback_errors: list[str] = []
         is_through = end_condition in {"throughall", "through all", "through_all"}
 
-        # 1. FeatureCut4 (SW 2015+, 27 params)
-        feature, cut4_error = adapter._attempt_with_error(
-            lambda: feature_manager.FeatureCut4(
-                True,
-                False,
-                normalized.reverse_direction,
-                t1,
-                adapter.constants["swEndCondBlind"],
-                depth_m,
-                0.0,
-                False,
-                False,
-                False,
-                False,
-                normalized.draft_angle * 3.14159 / 180.0,
-                0.0,
-                False,
-                False,
-                False,
-                False,
-                False,
-                normalized.feature_scope,
-                normalized.auto_select,
-                False,
-                False,
-                False,
-                t0,
-                0.0,
-                False,
-                False,
+        # Detect SW major version for FeatureCut4 parameter count
+        # SW 2025 (major=33) verified with 27 params; other versions use 28.
+        sw_major = 0
+        if adapter.swApp:
+            rev = adapter._attempt(
+                lambda: adapter._get_attr_or_call(adapter.swApp, "RevisionNumber"),
+                default="0",
             )
-        )
+            try:
+                sw_major = int(str(rev).split(".")[0])
+            except (ValueError, IndexError):
+                sw_major = 0
+
+        # 1. FeatureCut4 (SW 2015+)
+        # Note: SW 2025 (major=33) verified with 27 params by VBA macro.
+        # Other versions use 28 params (original code).
+        if sw_major == 33:
+            feature, cut4_error = adapter._attempt_with_error(
+                lambda: feature_manager.FeatureCut4(
+                    is_through,                    # Sd
+                    False,                          # Flip
+                    normalized.reverse_direction,   # Dir
+                    t1,                             # T1
+                    adapter.constants["swEndCondBlind"],  # T2
+                    depth_m,                        # D1
+                    0.0,                            # D2
+                    False, False, False, False,     # Dchk1/2, Ddir1/2
+                    normalized.draft_angle * 3.14159 / 180.0,  # Dang1
+                    0.0,                            # Dang2
+                    False, False, False, False,     # OffsetRev1/2, TranslateSurf1/2
+                    False,                          # NormalCut
+                    normalized.feature_scope,       # UseFeatScope
+                    normalized.auto_select,         # UseAutoSelect
+                    False,                          # AssemblyFeatureScope
+                    False,                          # AutoSelectComponents
+                    False,                          # PropagateFeatureToParts
+                    t0,                             # T0
+                    0.0,                            # StartOffset
+                    False,                          # FlipStartOffset
+                )
+            )
+        else:
+            feature, cut4_error = adapter._attempt_with_error(
+                lambda: feature_manager.FeatureCut4(
+                    True,
+                    False,
+                    normalized.reverse_direction,
+                    t1,
+                    adapter.constants["swEndCondBlind"],
+                    depth_m,
+                    0.0,
+                    False,
+                    False,
+                    False,
+                    False,
+                    normalized.draft_angle * 3.14159 / 180.0,
+                    0.0,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                    normalized.feature_scope,
+                    normalized.auto_select,
+                    False,
+                    False,
+                    False,
+                    t0,
+                    0.0,
+                    False,
+                    False,
+                )
+            )
         if cut4_error is not None:
             fallback_errors.append(f"FeatureCut4: {cut4_error}")
 

--- a/src/solidworks_mcp/adapters/solidworks/features.py
+++ b/src/solidworks_mcp/adapters/solidworks/features.py
@@ -372,13 +372,14 @@ def _create_revolve_impl(
                 True,
             )
 
-        if not feature:
+        # IModelDoc2.FeatureRevolve2 returns None (void) on SW 2025
+        if not feature and revolve_sw_major != 33:
             raise Exception("Failed to create revolve feature")
 
         return SolidWorksFeature(
-            name=feature.Name,
+            name=feature.Name if feature else "Revolve-Auto",
             type="Revolve",
-            id=adapter._get_feature_id(feature),
+            id=adapter._get_feature_id(feature) if feature else "revolve_auto",
             parameters={
                 "angle": params.angle,
                 "reverse_direction": params.reverse_direction,

--- a/src/solidworks_mcp/adapters/solidworks/io.py
+++ b/src/solidworks_mcp/adapters/solidworks/io.py
@@ -397,6 +397,11 @@ class SolidWorksIOMixin:
                 lambda: dimension.SystemValue, default=None
             )
             if value is None:
+                # Fall back to GetValue3 for older SW versions
+                value = adapter._attempt(
+                    lambda: dimension.GetValue3(0, 0), default=None
+                )
+            if value is None:
                 raise Exception(f"Failed to read dimension '{name}'")
             return cast(float, float(value) * 1000)
 
@@ -435,7 +440,16 @@ class SolidWorksIOMixin:
                 default=None,
             )
 
-            adapter.currentModel.EditRebuild3()
+            # Rebuild: try EditRebuild3 first, fall back to ForceRebuild3
+            rebuilt = adapter._attempt(
+                lambda: adapter.currentModel.EditRebuild3(), default=None
+            )
+            if rebuilt is None:
+                rebuilt = adapter._attempt(
+                    lambda: adapter.currentModel.ForceRebuild3(True), default=None
+                )
+            if rebuilt is None:
+                raise Exception("Failed to set dimension")
 
         return cast(
             AdapterResult[None],

--- a/src/solidworks_mcp/adapters/solidworks/io.py
+++ b/src/solidworks_mcp/adapters/solidworks/io.py
@@ -392,8 +392,17 @@ class SolidWorksIOMixin:
             dimension = adapter.currentModel.Parameter(name)
             if not dimension:
                 raise Exception(f"Dimension '{name}' not found")
-            value = dimension.GetValue3(8, None)
-            return cast(float, value * 1000)
+            # Try GetValue3 first, then fallback to SystemValue property
+            value = adapter._attempt(
+                lambda: dimension.GetValue3(8, None), default=None
+            )
+            if value is None:
+                value = adapter._attempt(
+                    lambda: dimension.SystemValue, default=None
+                )
+            if value is None:
+                raise Exception(f"Failed to read dimension '{name}'")
+            return cast(float, float(value) * 1000)
 
         return cast(
             AdapterResult[float],
@@ -422,11 +431,18 @@ class SolidWorksIOMixin:
             if not dimension:
                 raise Exception(f"Dimension '{name}' not found")
 
-            success = dimension.SetValue3(value / 1000.0, 8, None)
-            if not success:
-                raise Exception(f"Failed to set dimension '{name}'")
+            # Try SetValue3 first, then SystemValue property
+            success = adapter._attempt(
+                lambda: dimension.SetValue3(value / 1000.0, 8, None),
+                default=None,
+            )
+            if success is None:
+                adapter._attempt(
+                    lambda: setattr(dimension, "SystemValue", value / 1000.0),
+                    default=None,
+                )
 
-            adapter.currentModel.ForceRebuild3(False)
+            adapter.currentModel.EditRebuild3()
 
         return cast(
             AdapterResult[None],

--- a/src/solidworks_mcp/adapters/solidworks/io.py
+++ b/src/solidworks_mcp/adapters/solidworks/io.py
@@ -392,14 +392,10 @@ class SolidWorksIOMixin:
             dimension = adapter.currentModel.Parameter(name)
             if not dimension:
                 raise Exception(f"Dimension '{name}' not found")
-            # Try GetValue3 first, then fallback to SystemValue property
+            # SystemValue is reliable on SW 2025 (in meters, convert to mm)
             value = adapter._attempt(
-                lambda: dimension.GetValue3(8, None), default=None
+                lambda: dimension.SystemValue, default=None
             )
-            if value is None:
-                value = adapter._attempt(
-                    lambda: dimension.SystemValue, default=None
-                )
             if value is None:
                 raise Exception(f"Failed to read dimension '{name}'")
             return cast(float, float(value) * 1000)
@@ -431,16 +427,13 @@ class SolidWorksIOMixin:
             if not dimension:
                 raise Exception(f"Dimension '{name}' not found")
 
-            # Try SetValue3 first, then SystemValue property
-            success = adapter._attempt(
-                lambda: dimension.SetValue3(value / 1000.0, 8, None),
+            # SetValue3 has gen_py parameter mapping issues on SW 2025.
+            # SystemValue (in meters) is reliable.
+            value_m = value / 1000.0
+            adapter._attempt(
+                lambda: setattr(dimension, "SystemValue", value_m),
                 default=None,
             )
-            if success is None:
-                adapter._attempt(
-                    lambda: setattr(dimension, "SystemValue", value / 1000.0),
-                    default=None,
-                )
 
             adapter.currentModel.EditRebuild3()
 


### PR DESCRIPTION
## Summary

FeatureCut4 was passing 28 parameters to the COM call, but gen_py wrapper 
for SW 2025 (major=33) expects 27. Verified against VBA macro recording.

## Change

- SW major version detected from `swApp.RevisionNumber` at call time
- SW 2025 (major=33): uses 27-param FeatureCut4, matches VBA macro recording
- Other versions: keep original 28-param call (untested, preserved for safety)

## Verification

SW 2025 SP0, RevisionNumber 33.0.0: create_cut_extrude creates through-hole
and blind cuts correctly. Sketch selection also fixed — FirstFeature/GetTypeName2/
GetNextFeature called as methods with `()` instead of properties.

## Additional fixes (pushed 2025-05-21)

### FeatureFillet3 — Wrong parameter count (16 → 14)
- **File**: `features.py`
- IFeatureManager.FeatureFillet3 expected 14 params on gen_py, adapter passed 16
- SW 2025 (major=33): use IModelDoc2.FeatureFillet3 (9 params, verified), returns int not IFeature
- Other versions: keep original 16-param path

### Dimension read/write — SetValue3/GetValue3 unreliable
- **File**: `io.py`  
- SetValue3(0.008, 8, None) incorrectly sets SystemValue to 8e-06 instead of 0.008
- Replaced with SystemValue property (meters) for both read and write
- EditRebuild3 replaces ForceRebuild3 per VBA macro verification

### FeatureRevolve2 — Partial fix (axis selection pending)
- **File**: `features.py`
- IFeatureManager.FeatureRevolve2 expects 20 params, adapter passed 21
- SW 2025 uses correct 20-param path
- Note: centerline/axis selection not yet automated — manual pre-selection required