### PR TITLE
feat(adapter): implement sweep and loft COM operations (closes #4)

### DIFF
--- a/scripts/demo_sweep_loft.py
+++ b/scripts/demo_sweep_loft.py
@@ -1,0 +1,226 @@
+r"""Live end-to-end demo for the Phase 1 sweep and loft operations.
+
+Builds a single multibody part that exercises both methods delivered under
+fork issue #2 / upstream issue #4:
+
+    create_loft, create_sweep
+
+Layout (mm):
+
+* **Lofted cone** centred at X=+90: a 30 mm-radius circle on the Front plane
+  lofted to a 12 mm-radius circle on a reference plane offset 80 mm in front
+  of it — a cone/gear-like tapered bevel (``create_loft``).
+* **Swept coil spring** centred near the origin: a 3.5 mm-radius circular
+  profile on the Front plane swept along a helix built from an 18 mm-radius
+  base circle on the Top plane (60 mm tall, 12 mm pitch) (``create_sweep``).
+
+Geometry the Phase 1 surface does not yet build natively — an offset
+reference plane for the loft's second profile, and a helix for the sweep
+path — is created with raw COM (InsertRefPlane / InsertHelix), exactly as a
+caller would until Phase 3 reference-geometry support lands.
+
+On success the script saves the part and two PNG screenshots (isometric and
+trimetric) to ``out/`` and exits 0.  Run with the project virtualenv on a
+Windows box that already has SolidWorks open::
+
+    .\.venv\Scripts\python.exe scripts\demo_sweep_loft.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import traceback
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from solidworks_mcp.adapters.base import (  # noqa: E402
+    LoftParameters,
+    SweepParameters,
+)
+from solidworks_mcp.adapters.pywin32_adapter import PyWin32Adapter  # noqa: E402
+
+
+def _check(label: str, result) -> None:
+    """Raise with the COM error attached when an adapter result is not success."""
+    if not result.is_success:
+        raise RuntimeError(f"{label} failed: {result.error}")
+    print(f"  OK  {label}")
+
+
+def _read_member(obj, name):
+    """Read a COM accessor that pywin32 may expose as a method or a property.
+
+    Calls the member when it is callable and falls back to the raw member if
+    the call raises, so it yields the value whether the dispatch is flagged,
+    unflagged, or a property that returns a COM object.
+    """
+    member = getattr(obj, name, None)
+    if not callable(member):
+        return member
+    try:
+        return member()
+    except Exception:
+        return member
+
+
+def _feature_name_by_type(adapter, type_name: str) -> str:
+    """Return the name of the last feature whose GetTypeName2 matches.
+
+    Used to recover a feature whose creator call returns None on success
+    (e.g. InsertHelix), by walking the feature tree with method flagging.
+    """
+    from solidworks_mcp.adapters import sw_type_info
+
+    def _flag(obj, iface):
+        try:
+            sw_type_info.flag_methods(obj, iface)
+        except Exception:
+            pass
+
+    _flag(adapter.currentModel, "IModelDoc2")
+    found = ""
+    feat = _read_member(adapter.currentModel, "FirstFeature")
+    for _ in range(5000):
+        if not feat:
+            break
+        _flag(feat, "IFeature")
+        try:
+            if _read_member(feat, "GetTypeName2") == type_name:
+                found = str(_read_member(feat, "Name"))
+        except Exception:
+            pass
+        feat = _read_member(feat, "GetNextFeature")
+    return found
+
+
+async def build_demo_part(out_dir: Path) -> dict[str, str]:
+    """Build the demo part end-to-end and return artefact paths."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    adapter = PyWin32Adapter({})
+    print("Connecting to SolidWorks ...")
+    await adapter.connect()
+    print(f"Connected: swApp={type(adapter.swApp).__name__}")
+
+    try:
+        part = await adapter.create_part()
+        _check("create_part", part)
+        print(f"  doc: {part.data.name}")
+
+        # ------------------------------------------------------------------
+        # Feature 1: lofted cone (tapered bevel) centred at X=+90.
+        # ------------------------------------------------------------------
+        s_loft1 = await adapter.create_sketch("Front")
+        _check("create_sketch Front (loft profile 1)", s_loft1)
+        _check("add_circle R30 (loft base)", await adapter.add_circle(90.0, 0.0, 30.0))
+        _check("exit_sketch (loft profile 1)", await adapter.exit_sketch())
+
+        # Reference plane 80 mm in front of the Front plane (FirstConstraint
+        # flag 8 == distance; InsertRefPlane works in metres).
+        front = adapter.currentModel.FeatureByName("Front Plane")
+        if not (front and front.Select2(False, 0)):
+            raise RuntimeError("could not select Front plane for the offset plane")
+        ref_plane = adapter.currentModel.FeatureManager.InsertRefPlane(
+            8, 0.080, 0, 0, 0, 0
+        )
+        adapter.currentModel.ClearSelection2(True)
+        plane_name = str(ref_plane.Name) if ref_plane else ""
+        if not plane_name:
+            raise RuntimeError("InsertRefPlane returned no reference plane")
+        print(f"  OK  InsertRefPlane -> {plane_name}")
+
+        s_loft2 = await adapter.create_sketch(plane_name)
+        _check("create_sketch offset plane (loft profile 2)", s_loft2)
+        _check("add_circle R12 (loft top)", await adapter.add_circle(90.0, 0.0, 12.0))
+        _check("exit_sketch (loft profile 2)", await adapter.exit_sketch())
+
+        _check(
+            "create_loft (R30 -> R12 tapered cone)",
+            await adapter.create_loft(
+                LoftParameters(profiles=[s_loft1.data, s_loft2.data])
+            ),
+        )
+
+        # ------------------------------------------------------------------
+        # Feature 2: swept coil spring centred at the origin.
+        # ------------------------------------------------------------------
+        base = await adapter.create_sketch("Top")
+        _check("create_sketch Top (helix base)", base)
+        _check("add_circle R18 (helix base)", await adapter.add_circle(0.0, 0.0, 18.0))
+
+        # InsertHelix consumes the *open* base sketch directly; it lives on
+        # IModelDoc2 and returns None on success, so read the name back from
+        # the tree. Height & pitch (swHelixDefinedBy_e == 2): 60 mm tall,
+        # 12 mm pitch -> 5 revolutions.
+        adapter.currentModel.InsertHelix(
+            False, True, False, False, 2, 0.060, 0.012, 0.0, 0.0, 0.0
+        )
+        adapter.currentModel.ClearSelection2(True)
+        helix_name = _feature_name_by_type(adapter, "Helix")
+        if not helix_name:
+            raise RuntimeError("InsertHelix did not create a helix feature")
+        print(f"  OK  InsertHelix -> {helix_name}")
+
+        prof = await adapter.create_sketch("Front")
+        _check("create_sketch Front (sweep profile)", prof)
+        _check(
+            "add_circle R3.5 (sweep profile at helix start)",
+            await adapter.add_circle(18.0, 0.0, 3.5),
+        )
+        _check("exit_sketch (sweep profile)", await adapter.exit_sketch())
+
+        _check(
+            "create_sweep (circular profile along helix -> spring)",
+            await adapter.create_sweep(SweepParameters(path=helix_name)),
+        )
+
+        # ------------------------------------------------------------------
+        # Persist + screenshots.
+        # ------------------------------------------------------------------
+        part_path = (out_dir / "sweep_loft_demo.SLDPRT").resolve()
+        _check(f"save_file -> {part_path}", await adapter.save_file(str(part_path)))
+
+        shots: dict[str, str] = {}
+        for orientation in ("isometric", "trimetric"):
+            img_path = (out_dir / f"sweep_loft_demo_{orientation}.png").resolve()
+            _check(
+                f"export_image ({orientation}) -> {img_path}",
+                await adapter.export_image(
+                    {
+                        "file_path": str(img_path),
+                        "format_type": "png",
+                        "width": 1600,
+                        "height": 1000,
+                        "view_orientation": orientation,
+                    }
+                ),
+            )
+            shots[f"screenshot_{orientation}"] = str(img_path)
+
+        return {"part": str(part_path), **shots}
+    finally:
+        try:
+            await adapter.disconnect()
+            print("Disconnected.")
+        except Exception as exc:  # noqa: BLE001
+            print(f"  WARN disconnect failed: {exc}")
+
+
+def main() -> int:
+    out_dir = REPO_ROOT / "out"
+    try:
+        artefacts = asyncio.run(build_demo_part(out_dir))
+    except Exception:
+        traceback.print_exc()
+        return 1
+    print("\nDemo artefacts:")
+    for key, value in artefacts.items():
+        print(f"  {key}: {value or '(skipped)'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/solidworks_mcp/adapters/solidworks/features.py
+++ b/src/solidworks_mcp/adapters/solidworks/features.py
@@ -417,62 +417,416 @@ def _create_revolve_impl(
     )
 
 
+def _select_named_feature(
+    adapter: Any,
+    name: str,
+    mark: int,
+    append: bool,
+) -> bool:
+    """Select a named feature under a specific selection mark via ``Select2``.
+
+    Sweep and loft rely on selection marks to tell SolidWorks which selection
+    is the profile (1), guide curve (2), or sweep path (4).  We resolve the
+    feature with ``IModelDoc2::FeatureByName`` and select it with
+    ``IFeature::Select2(append, mark)`` — the same proven path the rest of the
+    adapter uses for plane/sketch selection.  ``IModelDocExtension::SelectByID2``
+    is avoided deliberately: late-bound ``SelectByID2`` raises
+    ``Type mismatch`` on some SolidWorks builds, whereas ``FeatureByName`` +
+    ``Select2`` is reliable, works for sketches *and* reference curves such as
+    a helix, and needs no entity-type string.
+
+    Args:
+        adapter: A connected adapter with a valid ``currentModel``.
+        name: Feature name (e.g. ``"Sketch1"`` or ``"Helix/Spiral1"``).  Any
+            ``@document`` qualifier is stripped before lookup.
+        mark: Selection mark — 1=profile, 2=guide curve, 4=sweep path.
+        append: ``True`` to add to the current selection set, ``False`` to
+            replace it.
+
+    Returns:
+        bool: ``True`` when the feature was found and selected.
+    """
+    bare = name.split("@", 1)[0]
+    feature = adapter._attempt(
+        lambda: adapter.currentModel.FeatureByName(bare), default=None
+    )
+    if not feature:
+        return False
+    return bool(
+        adapter._attempt(lambda: feature.Select2(append, mark), default=False)
+    )
+
+
+def _flag_feature_methods(obj: Any, interface: str) -> None:
+    """Best-effort method flagging for a COM object via ``sw_type_info``.
+
+    Flagging tells pywin32 late binding to resolve names like ``GetTypeName2``
+    / ``GetNextFeature`` / ``FirstFeature`` as methods.  No-ops on plain test
+    doubles (and any environment without the gen_py wrapper).
+
+    Args:
+        obj: The COM object (or test double) to flag.
+        interface: SolidWorks interface name (e.g. ``"IFeature"``).
+    """
+    try:
+        from solidworks_mcp.adapters import sw_type_info
+
+        sw_type_info.flag_methods(obj, interface)
+    except Exception:
+        pass
+
+
+def _read_member(obj: Any, name: str) -> Any:
+    """Read a COM member that pywin32 may expose as a property *or* a method.
+
+    Late-bound pywin32 dispatches are inconsistent: an unflagged zero-arg
+    accessor may come back as a bound method (needing a call) *or* as the
+    already-resolved value — and when that value is itself a COM object it is
+    also callable, so a naive "call if callable" check wrongly invokes its
+    default dispatch (``Member not found``).  This helper calls the member and
+    falls back to the raw member if the call raises, so it yields the value in
+    every case (flagged method, unflagged method, property-returning-object,
+    or plain test double).
+
+    Args:
+        obj: The COM object (or test double) to read from.
+        name: Member name.
+
+    Returns:
+        Any: The member's value, or ``None`` when the attribute is absent.
+    """
+    member = getattr(obj, name, None)
+    if not callable(member):
+        return member
+    try:
+        return member()
+    except Exception:
+        return member
+
+
+def _profile_feature_names(adapter: Any) -> list[str]:
+    """Return sketch (``ProfileFeature``) names in feature-tree order.
+
+    Walks ``FirstFeature`` → ``GetNextFeature`` reading ``GetTypeName2`` and
+    collecting features whose type is ``"ProfileFeature"`` (a 2D/3D sketch).
+    Mirrors the tree walk used by :func:`_create_cut_extrude_impl`, but flags
+    each feature for ``IFeature`` and reads members through
+    :func:`_read_member` so it is robust to pywin32's method-vs-property
+    late-binding ambiguity.
+
+    Args:
+        adapter: A connected adapter with a valid ``currentModel``.
+
+    Returns:
+        list[str]: Bare sketch names, earliest first.  Empty when the walk
+        finds no sketches or the tree is inaccessible.
+    """
+    names: list[str] = []
+    try:
+        _flag_feature_methods(adapter.currentModel, "IModelDoc2")
+        feat = _read_member(adapter.currentModel, "FirstFeature")
+        # Bound the walk so a misbehaving GetNextFeature can't spin forever.
+        for _ in range(5000):
+            if not feat:
+                break
+            _flag_feature_methods(feat, "IFeature")
+            try:
+                if _read_member(feat, "GetTypeName2") == "ProfileFeature":
+                    names.append(str(_read_member(feat, "Name")))
+            except Exception:
+                pass
+            try:
+                feat = _read_member(feat, "GetNextFeature")
+            except Exception:
+                break
+    except Exception:
+        pass
+    return names
+
+
 def _create_sweep_impl(
     adapter: Any, params: SweepParameters
 ) -> AdapterResult[SolidWorksFeature]:
-    """Placeholder for sweep feature creation ΓÇö not yet implemented.
+    """Create a swept boss/protrusion from a profile sketch along a path sketch.
 
-    Retained for interface compatibility with the base ``SolidWorksAdapter``
-    contract.  Callers that need a sweep should use a VBA macro via
-    ``execute_macro`` until native support is added.
+    Uses ``IFeatureManager::InsertProtrusionSwept4``.  Two sketches are
+    required in the active part: a closed **profile** sketch and an open
+    **path** sketch named by ``params.path``.  The path is selected under
+    mark 4 and the profile under mark 1, per the SolidWorks selection-mark
+    contract for sweeps.
+
+    Because :class:`SweepParameters` only names the path, the profile is
+    inferred as the first ``ProfileFeature`` sketch in the feature tree whose
+    name is **not** the path.  In the common "draw profile, draw path, sweep"
+    workflow this is unambiguous (exactly two sketches exist).
 
     Args:
-        adapter: The active adapter instance (unused).
-        params: Sweep parameter bag (unused).
+        adapter: A fully connected ``PyWin32Adapter`` with a non-``None``
+            ``currentModel``.
+        params: Sweep parameter bag.  Relevant fields:
+            - ``path`` (str): Name of the path sketch (e.g. ``"Sketch2"``).
+            - ``twist_along_path`` (bool): Apply a constant twist along the
+              path.
+            - ``twist_angle`` (float): Twist angle in **degrees** (used only
+              when ``twist_along_path`` is true).
+            - ``merge_result`` (bool): Merge with existing bodies.
 
     Returns:
-        AdapterResult[SolidWorksFeature]: Always returns ``ERROR`` status with
-        an explanatory message.
+        AdapterResult[SolidWorksFeature]: On success, ``data`` is a
+        ``SolidWorksFeature`` whose ``type`` is ``"Sweep"``.  On failure,
+        ``status`` is ``ERROR`` with a descriptive message.
+
+    Raises:
+        Exception: Propagated through ``_handle_com_operation`` when the
+            profile/path cannot be selected or the COM call returns ``None``.
 
     Example::
 
-        result = pywin32_feature_ops.create_sweep(adapter, params)
-        # result.status == AdapterResultStatus.ERROR
-        # result.error  == "Sweep feature not implemented ..."
+        from solidworks_mcp.adapters.base import SweepParameters
+
+        params = SweepParameters(path="Sketch2", merge_result=True)
+        result = await adapter.create_sweep(params)
+        print(result.data.name)  # e.g. "Sweep1"
     """
-    _ = params
-    return AdapterResult(
-        status=AdapterResultStatus.ERROR,
-        error="Sweep feature not implemented in basic pywin32 adapter",
+    if not adapter.currentModel:
+        return AdapterResult(status=AdapterResultStatus.ERROR, error="No active model")
+
+    if not getattr(params, "path", None):
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="Sweep requires a 'path' sketch name",
+        )
+
+    def _sweep_operation() -> SolidWorksFeature:
+        """Inner COM closure that selects profile + path and runs the sweep.
+
+        Returns:
+            SolidWorksFeature: Populated feature descriptor on success.
+
+        Raises:
+            Exception: When selections fail or ``InsertProtrusionSwept4``
+                returns ``None``.
+        """
+        import math
+
+        feature_manager = adapter.currentModel.FeatureManager
+
+        # Resolve the path name against the actual tree sketches so the
+        # profile/path comparison is on bare names, then pick the first
+        # non-path sketch as the profile.
+        sketch_names = _profile_feature_names(adapter)
+        path_name = params.path
+        for name in sketch_names:
+            if name == params.path or name.lower() == params.path.lower():
+                path_name = name
+                break
+
+        # Profile = the most recently created sketch that isn't the path.
+        # Preferring the latest sketch handles both a sketch path (profile is
+        # drawn first, so it's the only non-path sketch) and a helix/curve
+        # path (the helix's base-circle sketch precedes the profile in the
+        # tree, so "first non-path" would wrongly pick the base circle).
+        profile_name = None
+        last = getattr(adapter, "_last_sketch_name", None)
+        if last and last != path_name and last in sketch_names:
+            profile_name = last
+        if profile_name is None:
+            profile_name = next(
+                (name for name in reversed(sketch_names) if name != path_name), None
+            )
+        if profile_name is None:
+            raise Exception(
+                "Sweep needs a profile sketch distinct from the path "
+                f"'{params.path}'. Sketches found: {sketch_names or 'none'}"
+            )
+
+        adapter._attempt(
+            lambda: adapter.currentModel.ClearSelection2(True), default=None
+        )
+
+        if not _select_named_feature(adapter, profile_name, 1, False):
+            raise Exception(f"Failed to select sweep profile sketch: {profile_name}")
+        if not _select_named_feature(adapter, path_name, 4, True):
+            raise Exception(f"Failed to select sweep path: {path_name}")
+
+        twist = bool(getattr(params, "twist_along_path", False))
+        twist_angle_deg = float(getattr(params, "twist_angle", 0.0))
+        # swTwistControlType_e: 0 = follow path, 8 = constant twist along path.
+        twist_ctrl = 8 if twist else 0
+        twist_angle_rad = math.radians(twist_angle_deg) if twist else 0.0
+
+        feature = feature_manager.InsertProtrusionSwept4(
+            False,  # Propagate to next tangent edge
+            False,  # Alignment (go through end faces)
+            twist_ctrl,  # TwistCtrlOption (swTwistControlType_e)
+            False,  # KeepTangency
+            False,  # BAdvancedSmoothing
+            0,  # StartMatchingType (swTangencyType_e)
+            0,  # EndMatchingType
+            False,  # IsThinBody
+            0.0,  # Thickness1
+            0.0,  # Thickness2
+            0,  # ThinType (swThinWallType_e)
+            0,  # PathAlign
+            bool(getattr(params, "merge_result", True)),  # Merge
+            True,  # UseFeatScope
+            True,  # UseAutoSelect
+            twist_angle_rad,  # TwistAngle (radians)
+            True,  # BMergeSmoothFaces
+            False,  # CircularProfile
+            0.0,  # CircularProfileDiameter
+            0,  # Direction
+        )
+
+        if not feature:
+            raise Exception("Failed to create sweep feature")
+
+        return SolidWorksFeature(
+            name=feature.Name,
+            type="Sweep",
+            id=adapter._get_feature_id(feature),
+            parameters={
+                "profile": profile_name,
+                "path": path_name,
+                "twist_along_path": twist,
+                "twist_angle": twist_angle_deg,
+                "merge_result": bool(getattr(params, "merge_result", True)),
+            },
+            properties={"created": datetime.now().isoformat()},
+        )
+
+    return cast(
+        AdapterResult[SolidWorksFeature],
+        adapter._handle_com_operation("create_sweep", _sweep_operation),
     )
 
 
 def _create_loft_impl(
     adapter: Any, params: LoftParameters
 ) -> AdapterResult[SolidWorksFeature]:
-    """Placeholder for loft feature creation ΓÇö not yet implemented.
+    """Create a lofted boss/protrusion between two or more profile sketches.
 
-    Retained for interface compatibility with the base ``SolidWorksAdapter``
-    contract.  Callers that need a loft should use a VBA macro via
-    ``execute_macro`` until native support is added.
+    Uses ``IFeatureManager::InsertProtrusionBlend2``.  Each profile named in
+    ``params.profiles`` is selected under mark 1 (in order — the selection
+    order determines the loft direction), and any ``params.guide_curves`` are
+    selected under mark 2.  Because a solid is produced, every profile must be
+    a closed contour.
 
     Args:
-        adapter: The active adapter instance (unused).
-        params: Loft parameter bag (unused).
+        adapter: A fully connected ``PyWin32Adapter`` with a non-``None``
+            ``currentModel``.
+        params: Loft parameter bag.  Relevant fields:
+            - ``profiles`` (list[str]): Ordered profile sketch names; at least
+              two are required.
+            - ``guide_curves`` (list[str] | None): Optional guide curve names.
+            - ``start_tangent`` / ``end_tangent`` (str | None): ``"normal"``
+              tangency at the start/end profile, anything else / ``None`` →
+              no tangency.
+            - ``merge_result`` (bool): Merge with existing bodies.
 
     Returns:
-        AdapterResult[SolidWorksFeature]: Always returns ``ERROR`` status with
-        an explanatory message.
+        AdapterResult[SolidWorksFeature]: On success, ``data`` is a
+        ``SolidWorksFeature`` whose ``type`` is ``"Loft"``.  On failure,
+        ``status`` is ``ERROR`` with a descriptive message.
+
+    Raises:
+        Exception: Propagated through ``_handle_com_operation`` when a profile
+            cannot be selected or the COM call returns ``None``.
 
     Example::
 
-        result = pywin32_feature_ops.create_loft(adapter, params)
-        # result.status == AdapterResultStatus.ERROR
+        from solidworks_mcp.adapters.base import LoftParameters
+
+        params = LoftParameters(profiles=["Sketch1", "Sketch2"])
+        result = await adapter.create_loft(params)
+        print(result.data.name)  # e.g. "Loft1"
     """
-    _ = params
-    return AdapterResult(
-        status=AdapterResultStatus.ERROR,
-        error="Loft feature not implemented in basic pywin32 adapter",
+    if not adapter.currentModel:
+        return AdapterResult(status=AdapterResultStatus.ERROR, error="No active model")
+
+    profiles = list(getattr(params, "profiles", None) or [])
+    if len(profiles) < 2:
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="Loft requires at least 2 profile sketches",
+        )
+
+    def _loft_operation() -> SolidWorksFeature:
+        """Inner COM closure that selects profiles/guides and runs the loft.
+
+        Returns:
+            SolidWorksFeature: Populated feature descriptor on success.
+
+        Raises:
+            Exception: When a profile selection fails or
+                ``InsertProtrusionBlend2`` returns ``None``.
+        """
+        guide_curves = list(getattr(params, "guide_curves", None) or [])
+
+        adapter._attempt(
+            lambda: adapter.currentModel.ClearSelection2(True), default=None
+        )
+
+        # Profiles under mark 1, in order. First replaces the selection set,
+        # the rest append so SW sees them as an ordered profile group.
+        for index, profile in enumerate(profiles):
+            if not _select_named_feature(adapter, profile, 1, append=index > 0):
+                raise Exception(f"Failed to select loft profile sketch: {profile}")
+
+        # Optional guide curves under mark 2 (a sketch or a reference curve).
+        for guide in guide_curves:
+            if not _select_named_feature(adapter, guide, 2, append=True):
+                raise Exception(f"Failed to select loft guide curve: {guide}")
+
+        # swTangencyType_e: 0 = none, 1 = tangent to profile normal.
+        def _tangency(value: str | None) -> int:
+            return 1 if str(value or "").strip().lower() == "normal" else 0
+
+        start_match = _tangency(getattr(params, "start_tangent", None))
+        end_match = _tangency(getattr(params, "end_tangent", None))
+
+        feature_manager = adapter.currentModel.FeatureManager
+        feature = feature_manager.InsertProtrusionBlend2(
+            False,  # Closed loft
+            True,  # KeepTangency
+            False,  # ForceNonRational
+            1.0,  # TessToleranceFactor
+            start_match,  # StartMatchingType (swTangencyType_e)
+            end_match,  # EndMatchingType
+            1.0,  # StartTangentLength
+            1.0,  # EndTangentLength
+            True,  # StartTangentDir
+            True,  # EndTangentDir
+            False,  # IsThinBody
+            0.0,  # Thickness1
+            0.0,  # Thickness2
+            0,  # ThinType
+            bool(getattr(params, "merge_result", True)),  # Merge
+            True,  # UseFeatScope
+            True,  # UseAutoSelect
+            2,  # GuideCurveInfluence (swGuideCurveInfluenceNextEdge)
+        )
+
+        if not feature:
+            raise Exception("Failed to create loft feature")
+
+        return SolidWorksFeature(
+            name=feature.Name,
+            type="Loft",
+            id=adapter._get_feature_id(feature),
+            parameters={
+                "profiles": profiles,
+                "guide_curves": guide_curves or None,
+                "start_tangent": getattr(params, "start_tangent", None),
+                "end_tangent": getattr(params, "end_tangent", None),
+                "merge_result": bool(getattr(params, "merge_result", True)),
+            },
+            properties={"created": datetime.now().isoformat()},
+        )
+
+    return cast(
+        AdapterResult[SolidWorksFeature],
+        adapter._handle_com_operation("create_loft", _loft_operation),
     )
 
 

--- a/src/solidworks_mcp/adapters/solidworks/sketch.py
+++ b/src/solidworks_mcp/adapters/solidworks/sketch.py
@@ -345,7 +345,14 @@ def _create_sketch_impl(adapter: Any, plane: str) -> AdapterResult[str]:
             adapter.currentSketch = adapter.currentSketchManager.InsertSketch()
 
         if not adapter.currentSketch:
+            # Prefer the method-flagged ``currentModel`` dispatch: a bare
+            # ``swApp.ActiveDoc`` is not flagged, so its ``GetActiveSketch2``
+            # resolves to a non-callable and silently yields ``None`` — which
+            # forces the synthetic ``Sketch_N`` fallback name and makes the
+            # sketch unselectable by later features.
             adapter.currentSketch = adapter._attempt(
+                lambda: adapter.currentModel.GetActiveSketch2()
+            ) or adapter._attempt(
                 lambda: adapter.swApp.ActiveDoc.GetActiveSketch2()
             )
 

--- a/src/solidworks_mcp/tools/modeling.py
+++ b/src/solidworks_mcp/tools/modeling.py
@@ -12,8 +12,10 @@ from pydantic import BaseModel, Field
 
 from ..adapters.base import (
     ExtrusionParameters,
+    LoftParameters,
     RevolveParameters,
     SolidWorksAdapter,
+    SweepParameters,
 )
 from .input_compat import CompatInput
 
@@ -1099,5 +1101,128 @@ async def register_modeling_tools(
             logger.error(f"Error in add_fillet tool: {e}")
             return {"status": "error", "message": f"Unexpected error: {str(e)}"}
 
-    tool_count = 10  # Number of tools registered
+    @mcp.tool()
+    async def create_sweep(input_data: CreateSweepInput) -> dict[str, Any]:
+        """Sweep the active profile sketch along a named path sketch.
+
+        Creates a swept boss/protrusion (Insert > Boss/Base > Sweep). Requires
+        two sketches in the active part: a closed profile sketch and an open
+        path sketch named by ``path``. The profile is inferred as the sketch
+        that is not the path (in the usual "draw profile, draw path, sweep"
+        flow this is unambiguous). Optionally applies a constant twist along
+        the path.
+
+        Args:
+            input_data (CreateSweepInput): Path name and twist/merge options.
+
+        Returns:
+            dict[str, Any]: Status and feature details.
+
+        Example:
+            ```python
+            # Sweep a circular profile along "Sketch2"
+            result = await create_sweep({"path": "Sketch2"})
+
+            # Sweep with a 90-degree twist along the path
+            result = await create_sweep({
+                "path": "Sketch2",
+                "twist_along_path": True,
+                "twist_angle": 90.0,
+            })
+            ```
+        """
+        try:
+            input_data = _normalize_input(input_data, CreateSweepInput)
+            params = SweepParameters(
+                path=input_data.path,
+                twist_along_path=input_data.twist_along_path,
+                twist_angle=input_data.twist_angle,
+                merge_result=input_data.merge_result,
+            )
+            result = await adapter.create_sweep(params)
+            if result.is_success:
+                feature = result.data
+                return {
+                    "status": "success",
+                    "message": f"Created sweep: {_result_value(feature, 'feature_name', 'name', default='Sweep')}",
+                    "sweep": {
+                        "name": _result_value(
+                            feature, "feature_name", "name", default="Sweep"
+                        ),
+                        "path": input_data.path,
+                        "twist_along_path": input_data.twist_along_path,
+                        "twist_angle": input_data.twist_angle,
+                    },
+                    "execution_time": result.execution_time,
+                }
+            else:
+                return {
+                    "status": "error",
+                    "message": f"Failed to create sweep: {result.error}",
+                }
+        except Exception as e:
+            logger.error(f"Error in create_sweep tool: {e}")
+            return {"status": "error", "message": f"Unexpected error: {str(e)}"}
+
+    @mcp.tool()
+    async def create_loft(input_data: CreateLoftInput) -> dict[str, Any]:
+        """Loft a solid between two or more profile sketches.
+
+        Creates a lofted boss/protrusion (Insert > Boss/Base > Loft) blending
+        the listed profile sketches in order. Each profile must be a closed
+        contour. Optional guide curves shape the transition between profiles.
+
+        Args:
+            input_data (CreateLoftInput): Profile names, optional guide curves,
+                and tangency/merge options.
+
+        Returns:
+            dict[str, Any]: Status and feature details.
+
+        Example:
+            ```python
+            # Loft between two profiles (e.g. a tapered bevel)
+            result = await create_loft({"profiles": ["Sketch1", "Sketch2"]})
+
+            # Loft with guide curves
+            result = await create_loft({
+                "profiles": ["Sketch1", "Sketch2"],
+                "guide_curves": ["Sketch3"],
+            })
+            ```
+        """
+        try:
+            input_data = _normalize_input(input_data, CreateLoftInput)
+            params = LoftParameters(
+                profiles=input_data.profiles,
+                guide_curves=input_data.guide_curves,
+                start_tangent=input_data.start_tangent,
+                end_tangent=input_data.end_tangent,
+                merge_result=input_data.merge_result,
+            )
+            result = await adapter.create_loft(params)
+            if result.is_success:
+                feature = result.data
+                return {
+                    "status": "success",
+                    "message": f"Created loft: {_result_value(feature, 'feature_name', 'name', default='Loft')}",
+                    "loft": {
+                        "name": _result_value(
+                            feature, "feature_name", "name", default="Loft"
+                        ),
+                        "profiles": input_data.profiles,
+                        "guide_curves": input_data.guide_curves,
+                    },
+                    "execution_time": result.execution_time,
+                }
+            else:
+                return {
+                    "status": "error",
+                    "message": f"Failed to create loft: {result.error}",
+                }
+        except Exception as e:
+            logger.error(f"Error in create_loft tool: {e}")
+            return {"status": "error", "message": f"Unexpected error: {str(e)}"}
+
+    tool_count = 12  # Number of tools registered
     return tool_count

--- a/tests/solidworks_mcp/adapters/test_adapters.py
+++ b/tests/solidworks_mcp/adapters/test_adapters.py
@@ -5,6 +5,7 @@ Comprehensive test suite covering adapter factory, pywin32 adapter,
 mock adapter, circuit breaker, and connection pooling functionality.
 """
 
+import math
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -2538,6 +2539,264 @@ class TestPyWin32AdapterBranches:
         assert "Failed to create extrusion feature" in (extrusion_result.error or "")
         assert revolve_result.is_error
         assert "Failed to create revolve feature" in (revolve_result.error or "")
+
+    @staticmethod
+    def _sketch_tree(*names):
+        """Build a FirstFeature→GetNextFeature chain of ProfileFeature mocks.
+
+        Each node mimics the COM ``IFeature`` attributes the feature-tree
+        walk in ``features.py`` reads: ``GetTypeName2`` and ``Name`` as
+        properties and ``GetNextFeature`` as the link to the next node.
+        """
+        nxt = None
+        for name in reversed(names):
+            nxt = SimpleNamespace(
+                GetTypeName2="ProfileFeature", Name=name, GetNextFeature=nxt
+            )
+        return nxt
+
+    @staticmethod
+    def _feature_by_name(selected, *, fail=()):
+        """Return a FeatureByName mock that records ``Select2(append, mark)``.
+
+        ``features.py`` selects sketches/curves via
+        ``currentModel.FeatureByName(name).Select2(append, mark)``.  This
+        helper returns a callable that appends ``(name, append, mark)`` to
+        ``selected`` and reports success, except for names in ``fail`` (which
+        return ``None`` from ``FeatureByName`` to simulate a missing feature).
+        """
+
+        def factory(name):
+            if name in fail:
+                return None
+            feature = SimpleNamespace()
+            feature.Select2 = (
+                lambda append, mark, _n=name: bool(
+                    selected.append((_n, append, mark)) or True
+                )
+            )
+            return feature
+
+        return factory
+
+    @pytest.mark.asyncio
+    async def test_create_sweep_no_model_and_missing_path(self, monkeypatch) -> None:
+        """create_sweep guards: no active model, then missing path name."""
+        adapter = self._build_adapter(monkeypatch)
+
+        adapter.currentModel = None
+        no_model = await adapter.create_sweep(SimpleNamespace(path="Sketch2"))
+        assert no_model.is_error
+        assert "No active model" in (no_model.error or "")
+
+        adapter.currentModel = SimpleNamespace()
+        no_path = await adapter.create_sweep(
+            SimpleNamespace(path="", twist_along_path=False, twist_angle=0.0)
+        )
+        assert no_path.is_error
+        assert "path" in (no_path.error or "")
+
+    @pytest.mark.asyncio
+    async def test_create_sweep_success_selects_profile_and_path(
+        self, monkeypatch
+    ) -> None:
+        """create_sweep selects the non-path sketch (mark 1) + path (mark 4)
+        and forwards the constant-twist option to InsertProtrusionSwept4."""
+        adapter = self._build_adapter(monkeypatch)
+
+        selected: list[tuple] = []
+        swept = Mock(return_value=SimpleNamespace(Name="Sweep1", GetID=lambda: 7))
+        adapter.currentModel = SimpleNamespace(
+            FirstFeature=self._sketch_tree("Sketch1", "Sketch2"),
+            FeatureByName=self._feature_by_name(selected),
+            ClearSelection2=Mock(return_value=True),
+            FeatureManager=SimpleNamespace(InsertProtrusionSwept4=swept),
+        )
+
+        result = await adapter.create_sweep(
+            SimpleNamespace(
+                path="Sketch2",
+                twist_along_path=True,
+                twist_angle=90.0,
+                merge_result=True,
+            )
+        )
+
+        assert result.is_success, result.error
+        assert result.data.type == "Sweep"
+        assert result.data.parameters["profile"] == "Sketch1"
+        assert result.data.parameters["path"] == "Sketch2"
+
+        # Profile selected under mark 1 (append False), path under mark 4
+        # (append True). Recorded tuples are (name, append, mark).
+        assert ("Sketch1", False, 1) in selected
+        assert ("Sketch2", True, 4) in selected
+
+        # TwistCtrlOption (arg index 2) == 8 (constant twist along path) and
+        # TwistAngle (arg index 15) == 90 degrees in radians.
+        swept_args = swept.call_args.args
+        assert swept_args[2] == 8
+        assert swept_args[15] == pytest.approx(math.radians(90.0))
+
+    @pytest.mark.asyncio
+    async def test_create_sweep_no_profile_distinct_from_path(
+        self, monkeypatch
+    ) -> None:
+        """When the only sketch is the path itself, create_sweep errors."""
+        adapter = self._build_adapter(monkeypatch)
+        adapter.currentModel = SimpleNamespace(
+            FirstFeature=self._sketch_tree("Sketch2"),
+            FeatureByName=self._feature_by_name([]),
+            ClearSelection2=Mock(return_value=True),
+            FeatureManager=SimpleNamespace(InsertProtrusionSwept4=Mock()),
+        )
+
+        result = await adapter.create_sweep(
+            SimpleNamespace(path="Sketch2", twist_along_path=False, twist_angle=0.0)
+        )
+        assert result.is_error
+        assert "profile sketch distinct from the path" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_create_sweep_feature_none_errors(self, monkeypatch) -> None:
+        """create_sweep errors when InsertProtrusionSwept4 returns None."""
+        adapter = self._build_adapter(monkeypatch)
+        adapter.currentModel = SimpleNamespace(
+            FirstFeature=self._sketch_tree("Sketch1", "Sketch2"),
+            FeatureByName=self._feature_by_name([]),
+            ClearSelection2=Mock(return_value=True),
+            FeatureManager=SimpleNamespace(
+                InsertProtrusionSwept4=Mock(return_value=None)
+            ),
+        )
+
+        result = await adapter.create_sweep(
+            SimpleNamespace(path="Sketch2", twist_along_path=False, twist_angle=0.0)
+        )
+        assert result.is_error
+        assert "Failed to create sweep feature" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_create_sweep_profile_selection_failure(self, monkeypatch) -> None:
+        """create_sweep errors with the profile name when Select2 can't find it."""
+        adapter = self._build_adapter(monkeypatch)
+        adapter.currentModel = SimpleNamespace(
+            FirstFeature=self._sketch_tree("Sketch1", "Sketch2"),
+            # FeatureByName returns None for the inferred profile sketch.
+            FeatureByName=self._feature_by_name([], fail=("Sketch1",)),
+            ClearSelection2=Mock(return_value=True),
+            FeatureManager=SimpleNamespace(InsertProtrusionSwept4=Mock()),
+        )
+
+        result = await adapter.create_sweep(
+            SimpleNamespace(path="Sketch2", twist_along_path=False, twist_angle=0.0)
+        )
+        assert result.is_error
+        assert "Sketch1" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_create_loft_no_model_and_too_few_profiles(
+        self, monkeypatch
+    ) -> None:
+        """create_loft guards: no active model, then fewer than two profiles."""
+        adapter = self._build_adapter(monkeypatch)
+
+        adapter.currentModel = None
+        no_model = await adapter.create_loft(SimpleNamespace(profiles=["A", "B"]))
+        assert no_model.is_error
+        assert "No active model" in (no_model.error or "")
+
+        adapter.currentModel = SimpleNamespace()
+        too_few = await adapter.create_loft(SimpleNamespace(profiles=["OnlyOne"]))
+        assert too_few.is_error
+        assert "at least 2 profile" in (too_few.error or "")
+
+    @pytest.mark.asyncio
+    async def test_create_loft_success_selects_profiles_in_order(
+        self, monkeypatch
+    ) -> None:
+        """create_loft selects every profile under mark 1 (first replaces,
+        rest append) and guide curves under mark 2."""
+        adapter = self._build_adapter(monkeypatch)
+
+        selected: list[tuple] = []
+        blend = Mock(return_value=SimpleNamespace(Name="Loft1", GetID=lambda: 9))
+        adapter.currentModel = SimpleNamespace(
+            FeatureByName=self._feature_by_name(selected),
+            ClearSelection2=Mock(return_value=True),
+            FeatureManager=SimpleNamespace(InsertProtrusionBlend2=blend),
+        )
+
+        result = await adapter.create_loft(
+            SimpleNamespace(
+                profiles=["Sketch1", "Sketch2"],
+                guide_curves=["Sketch3"],
+                start_tangent="normal",
+                end_tangent=None,
+                merge_result=True,
+            )
+        )
+
+        assert result.is_success, result.error
+        assert result.data.type == "Loft"
+        assert result.data.parameters["profiles"] == ["Sketch1", "Sketch2"]
+
+        # Recorded tuples are (name, append, mark).
+        assert ("Sketch1", False, 1) in selected  # first profile, replace
+        assert ("Sketch2", True, 1) in selected  # second profile, append
+        assert ("Sketch3", True, 2) in selected  # guide curve, mark 2
+
+        # StartMatchingType (arg 4) == 1 (tangent to normal) from
+        # start_tangent="normal"; EndMatchingType (arg 5) == 0 from None.
+        blend_args = blend.call_args.args
+        assert blend_args[4] == 1
+        assert blend_args[5] == 0
+
+    @pytest.mark.asyncio
+    async def test_create_loft_feature_none_errors(self, monkeypatch) -> None:
+        """create_loft errors when InsertProtrusionBlend2 returns None."""
+        adapter = self._build_adapter(monkeypatch)
+        adapter.currentModel = SimpleNamespace(
+            FeatureByName=self._feature_by_name([]),
+            ClearSelection2=Mock(return_value=True),
+            FeatureManager=SimpleNamespace(
+                InsertProtrusionBlend2=Mock(return_value=None)
+            ),
+        )
+
+        result = await adapter.create_loft(
+            SimpleNamespace(
+                profiles=["Sketch1", "Sketch2"],
+                guide_curves=None,
+                start_tangent=None,
+                end_tangent=None,
+                merge_result=True,
+            )
+        )
+        assert result.is_error
+        assert "Failed to create loft feature" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_create_loft_profile_selection_failure(self, monkeypatch) -> None:
+        """create_loft errors with the profile name when Select2 can't find it."""
+        adapter = self._build_adapter(monkeypatch)
+        adapter.currentModel = SimpleNamespace(
+            FeatureByName=self._feature_by_name([], fail=("SketchA",)),
+            ClearSelection2=Mock(return_value=True),
+            FeatureManager=SimpleNamespace(InsertProtrusionBlend2=Mock()),
+        )
+
+        result = await adapter.create_loft(
+            SimpleNamespace(
+                profiles=["SketchA", "SketchB"],
+                guide_curves=None,
+                start_tangent=None,
+                end_tangent=None,
+                merge_result=True,
+            )
+        )
+        assert result.is_error
+        assert "SketchA" in (result.error or "")
 
     @pytest.mark.asyncio
     async def test_create_sketch_empty_plane_and_total_select_failure(

--- a/tests/solidworks_mcp/tools/test_modeling.py
+++ b/tests/solidworks_mcp/tools/test_modeling.py
@@ -30,7 +30,10 @@ class TestModelingTools:
         tool_count = await register_modeling_tools(
             mcp_server, mock_adapter, mock_config
         )
-        assert tool_count == 10
+        assert tool_count == 12
+        # The Phase 1 sweep/loft tools must be registered alongside the rest.
+        names = {tool.name for tool in await mcp_server.list_tools()}
+        assert {"create_sweep", "create_loft"} <= names
 
     @pytest.mark.asyncio
     async def test_open_model_success(self, mcp_server, mock_adapter, mock_config):
@@ -233,6 +236,109 @@ class TestModelingTools:
         assert result["status"] == "success"
         assert result["revolve"]["angle"] == 360.0
         assert result["revolve"]["direction"] == "one_direction"
+
+    @pytest.mark.asyncio
+    async def test_create_sweep_success(self, mcp_server, mock_adapter, mock_config):
+        """create_sweep wires the path/twist params and reports success."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+
+        mock_adapter.create_sweep = AsyncMock(
+            return_value=Mock(
+                is_success=True, data={"feature_name": "Sweep1"}, execution_time=1.2
+            )
+        )
+
+        tool_func = None
+        for tool in await mcp_server.list_tools():
+            if tool.name == "create_sweep":
+                tool_func = tool.fn
+                break
+        assert tool_func is not None, "create_sweep tool was not registered"
+
+        input_data = CreateSweepInput(
+            path="Sketch2", twist_along_path=True, twist_angle=90.0
+        )
+        result = await tool_func(input_data)
+
+        assert result["status"] == "success"
+        assert result["sweep"]["name"] == "Sweep1"
+        assert result["sweep"]["path"] == "Sketch2"
+        assert result["sweep"]["twist_along_path"] is True
+        assert result["sweep"]["twist_angle"] == 90.0
+        # Adapter received the translated SweepParameters.
+        params = mock_adapter.create_sweep.await_args.args[0]
+        assert params.path == "Sketch2"
+        assert params.twist_along_path is True
+        assert params.twist_angle == 90.0
+
+    @pytest.mark.asyncio
+    async def test_create_sweep_failure(self, mcp_server, mock_adapter, mock_config):
+        """create_sweep surfaces the adapter error message."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+
+        mock_adapter.create_sweep = AsyncMock(
+            return_value=Mock(is_success=False, error="no path sketch")
+        )
+
+        tool_func = None
+        for tool in await mcp_server.list_tools():
+            if tool.name == "create_sweep":
+                tool_func = tool.fn
+                break
+
+        result = await tool_func(CreateSweepInput(path="Sketch2"))
+        assert result["status"] == "error"
+        assert "no path sketch" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_create_loft_success(self, mcp_server, mock_adapter, mock_config):
+        """create_loft wires the profile/guide params and reports success."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+
+        mock_adapter.create_loft = AsyncMock(
+            return_value=Mock(
+                is_success=True, data={"feature_name": "Loft1"}, execution_time=1.5
+            )
+        )
+
+        tool_func = None
+        for tool in await mcp_server.list_tools():
+            if tool.name == "create_loft":
+                tool_func = tool.fn
+                break
+        assert tool_func is not None, "create_loft tool was not registered"
+
+        input_data = CreateLoftInput(
+            profiles=["Sketch1", "Sketch2"], guide_curves=["Sketch3"]
+        )
+        result = await tool_func(input_data)
+
+        assert result["status"] == "success"
+        assert result["loft"]["name"] == "Loft1"
+        assert result["loft"]["profiles"] == ["Sketch1", "Sketch2"]
+        assert result["loft"]["guide_curves"] == ["Sketch3"]
+        params = mock_adapter.create_loft.await_args.args[0]
+        assert params.profiles == ["Sketch1", "Sketch2"]
+        assert params.guide_curves == ["Sketch3"]
+
+    @pytest.mark.asyncio
+    async def test_create_loft_failure(self, mcp_server, mock_adapter, mock_config):
+        """create_loft surfaces the adapter error message."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+
+        mock_adapter.create_loft = AsyncMock(
+            return_value=Mock(is_success=False, error="need 2 profiles")
+        )
+
+        tool_func = None
+        for tool in await mcp_server.list_tools():
+            if tool.name == "create_loft":
+                tool_func = tool.fn
+                break
+
+        result = await tool_func(CreateLoftInput(profiles=["Sketch1", "Sketch2"]))
+        assert result["status"] == "error"
+        assert "need 2 profiles" in result["message"]
 
     @pytest.mark.asyncio
     async def test_get_dimension_value(self, mcp_server, mock_adapter, mock_config):

--- a/tests/test_live_sw_regression.py
+++ b/tests/test_live_sw_regression.py
@@ -38,6 +38,10 @@ import threading
 
 import pytest
 
+# base.py is pure-pydantic (no pywin32), so importing the parameter models at
+# module scope is safe on non-Windows CI even though the SW tests are skipped.
+from solidworks_mcp.adapters.base import LoftParameters, SweepParameters
+
 # Skip the entire module when the env flag isn't set. This matches the
 # pattern used by tests/test_real_solidworks_integration.py and keeps CI
 # fast on boxes without SW.
@@ -1862,5 +1866,221 @@ async def test_spline_id_flows_into_mirror_live(connected_adapter) -> None:
         assert mirrored.is_success, (
             f"spline -> mirror composition failed: {mirrored.error}"
         )
+    finally:
+        await adapter.close_model(save=False)
+
+
+# ---- create_sweep / create_loft live regression ----
+#
+# Phase 1 of the tool-surface expansion (fork issue #2). These exercise the
+# real InsertProtrusionSwept4 / InsertProtrusionBlend2 COM calls end to end.
+# Geometry the adapter can't yet build natively (an offset reference plane for
+# the loft's second profile, a helix for the sweep path) is created with raw
+# COM, routed through the adapter's ComExecutor so it runs on the STA thread.
+
+
+def _solid_body_count(adapter) -> int:
+    """Return the number of solid bodies in the active part.
+
+    Uses ``IPartDoc.GetBodies2(swSolidBody, bVisibleOnly=True)``. A successful
+    boss feature (loft/sweep) must leave at least one solid body, so this is
+    the geometric proof that the feature actually built rather than silently
+    no-opping. COM runs inline on the calling thread, matching the rest of
+    this suite.
+    """
+    # swBodyType_e.swSolidBody == 0.
+    bodies = adapter.currentModel.GetBodies2(0, True)
+    if bodies is None:
+        return 0
+    try:
+        return len(bodies)
+    except TypeError:
+        # Single body comes back as a bare IBody2, not a tuple.
+        return 1
+
+
+def _feature_name_by_type(adapter, type_name: str) -> str:
+    """Return the name of the last feature whose ``GetTypeName2`` matches.
+
+    Walks ``FirstFeature`` → ``GetNextFeature``, flagging each feature for
+    ``IFeature`` and reading members with a call-then-fallback accessor so it
+    works whether or not pywin32 has method-flagged the feature. Used to
+    recover a feature whose creator call returns None on success (e.g.
+    ``InsertHelix``).
+    """
+    from solidworks_mcp.adapters import sw_type_info
+
+    def _flag(obj, iface):
+        try:
+            sw_type_info.flag_methods(obj, iface)
+        except Exception:
+            pass
+
+    def _read(obj, name):
+        member = getattr(obj, name, None)
+        if not callable(member):
+            return member
+        try:
+            return member()
+        except Exception:
+            return member
+
+    _flag(adapter.currentModel, "IModelDoc2")
+    found = ""
+    feat = _read(adapter.currentModel, "FirstFeature")
+    for _ in range(5000):
+        if not feat:
+            break
+        _flag(feat, "IFeature")
+        try:
+            if _read(feat, "GetTypeName2") == type_name:
+                found = str(_read(feat, "Name"))
+        except Exception:
+            pass
+        try:
+            feat = _read(feat, "GetNextFeature")
+        except Exception:
+            break
+    return found
+
+
+async def test_create_loft_tapered_bevel(connected_adapter) -> None:
+    """End-to-end loft between two parallel circular profiles of different
+    radii — a cone/gear-like tapered bevel.
+
+    Builds a 30 mm-radius circle on the Front plane, an offset reference
+    plane 40 mm in front of it, and a 10 mm-radius circle on that plane, then
+    lofts the two profiles. Asserts the feature is created AND a solid body
+    now exists, so a silently-failing ``InsertProtrusionBlend2`` (returns
+    None / leaves no geometry) fails the test.
+    """
+    adapter = connected_adapter
+
+    part_result = await adapter.create_part()
+    assert part_result.is_success, f"create_part failed: {part_result.error}"
+
+    try:
+        # Profile 1: large circle on the Front plane.
+        s1 = await adapter.create_sketch("Front")
+        assert s1.is_success, f"create_sketch(Front) failed: {s1.error}"
+        c1 = await adapter.add_circle(0.0, 0.0, 30.0)
+        assert c1.is_success, f"add_circle #1 failed: {c1.error}"
+        assert (await adapter.exit_sketch()).is_success
+
+        # Offset reference plane 40 mm in front of the Front plane. The
+        # FirstConstraint flag 8 == distance (per the InsertProtrusionBlend
+        # API example); InsertRefPlane works in metres.
+        front = adapter.currentModel.FeatureByName("Front Plane")
+        assert front and front.Select2(False, 0), "could not select Front plane"
+        ref_plane = adapter.currentModel.FeatureManager.InsertRefPlane(
+            8, 0.040, 0, 0, 0, 0
+        )
+        adapter.currentModel.ClearSelection2(True)
+        plane_name = str(ref_plane.Name) if ref_plane else ""
+        assert plane_name, "InsertRefPlane returned no reference plane"
+
+        # Profile 2: small circle on the offset plane.
+        s2 = await adapter.create_sketch(plane_name)
+        assert s2.is_success, f"create_sketch({plane_name}) failed: {s2.error}"
+        c2 = await adapter.add_circle(0.0, 0.0, 10.0)
+        assert c2.is_success, f"add_circle #2 failed: {c2.error}"
+        assert (await adapter.exit_sketch()).is_success
+
+        loft = await adapter.create_loft(
+            LoftParameters(profiles=[s1.data, s2.data])
+        )
+        assert loft.is_success, f"create_loft failed: {loft.error}"
+        assert loft.data.type == "Loft"
+        assert loft.data.name, "loft feature has no name"
+
+        assert _solid_body_count(adapter) >= 1, (
+            "loft reported success but the part has no solid body"
+        )
+    finally:
+        await adapter.close_model(save=False)
+
+
+async def test_create_sweep_circular_profile_along_helix(connected_adapter) -> None:
+    """End-to-end sweep of a circular profile along a helical path — the
+    classic spring/coil.
+
+    Builds a helix from a base circle on the Top plane, a small circular
+    profile on the Front plane positioned at the helix's start point, then
+    sweeps the profile along the helix. The profile-inference logic must pick
+    the *profile* sketch (most recent, on the Front plane) rather than the
+    helix's base-circle sketch, and the path selection must resolve the helix
+    as a reference curve (not a sketch). Asserts a solid body results.
+    """
+    adapter = connected_adapter
+
+    part_result = await adapter.create_part()
+    assert part_result.is_success, f"create_part failed: {part_result.error}"
+
+    try:
+        # Base circle (helix diameter) on the Top plane, radius 10 mm,
+        # centred on the origin. The helix axis is the Top-plane normal, so
+        # the helix starts at (10, 0, 0).
+        base = await adapter.create_sketch("Top")
+        assert base.is_success, f"create_sketch(Top) failed: {base.error}"
+        base_circle = await adapter.add_circle(0.0, 0.0, 10.0)
+        assert base_circle.is_success, f"base add_circle failed: {base_circle.error}"
+
+        # Helix by height & pitch (swHelixDefinedBy_e.HeightAndPitch == 2):
+        # 50 mm tall, 10 mm pitch → 5 revolutions. InsertHelix consumes the
+        # *open* base sketch directly (matching the SW Create_Spiral example),
+        # so the sketch must NOT be exited or re-selected first. It lives on
+        # IModelDoc2 (not IFeatureManager) and, like FeatureRevolve2 on recent
+        # SW builds, returns None on success — the helix name is read back from
+        # the feature tree afterwards.
+        adapter.currentModel.InsertHelix(
+            False,  # Reversed
+            True,  # Clockwise
+            False,  # Tapered
+            False,  # Outward
+            2,  # Helixdef = height & pitch
+            0.050,  # Height (m)
+            0.010,  # Pitch (m)
+            0.0,  # Revolution (ignored for height & pitch)
+            0.0,  # TaperAngle
+            0.0,  # Startangle
+        )
+        adapter.currentModel.ClearSelection2(True)
+        helix_name = _feature_name_by_type(adapter, "Helix")
+        assert helix_name, "InsertHelix did not create a helix feature"
+
+        # Profile: small circle on the Front plane (z=0), centred at the
+        # helix start point (10, 0) so the profile pierces the path start.
+        prof = await adapter.create_sketch("Front")
+        assert prof.is_success, f"create_sketch(Front) failed: {prof.error}"
+        prof_circle = await adapter.add_circle(10.0, 0.0, 2.0)
+        assert prof_circle.is_success, f"profile add_circle failed: {prof_circle.error}"
+        assert (await adapter.exit_sketch()).is_success
+
+        sweep = await adapter.create_sweep(SweepParameters(path=helix_name))
+        assert sweep.is_success, f"create_sweep failed: {sweep.error}"
+        assert sweep.data.type == "Sweep"
+        # The profile must be the Front-plane circle, not the helix base.
+        assert sweep.data.parameters["profile"] == prof.data, (
+            f"sweep used wrong profile {sweep.data.parameters['profile']!r}; "
+            f"expected the Front-plane profile {prof.data!r}"
+        )
+
+        assert _solid_body_count(adapter) >= 1, (
+            "sweep reported success but the part has no solid body"
+        )
+    finally:
+        await adapter.close_model(save=False)
+
+
+async def test_create_loft_too_few_profiles_returns_error(connected_adapter) -> None:
+    """A single-profile loft must error without touching SW geometry."""
+    adapter = connected_adapter
+
+    part_result = await adapter.create_part()
+    assert part_result.is_success
+    try:
+        bad = await adapter.create_loft(LoftParameters(profiles=["Sketch1"]))
+        assert bad.is_error
+        assert "at least 2 profile" in (bad.error or "")
     finally:
         await adapter.close_model(save=False)

--- a/tests/test_live_sw_regression.py
+++ b/tests/test_live_sw_regression.py
@@ -1797,8 +1797,6 @@ async def test_exit_sketch_clears_leftover_sw_sketch_live(
         adapter._reset_sketch_entity_registry()
 
         # SW still has the sketch open (verify before the actual exercise).
-        from solidworks_mcp.adapters import sw_type_info
-
         def _probe_sw_state() -> object:
             return adapter.swApp.ActiveDoc.GetActiveSketch2()
 


### PR DESCRIPTION
## Implement sweep and loft COM operations

Closes #4. Replaces the `create_sweep` / `create_loft` stubs with real SolidWorks COM calls and registers the matching `@mcp.tool`s.

### What changed
- **`create_sweep`** → `IFeatureManager.InsertProtrusionSwept4`. Selects the profile sketch (mark 1) and the path (mark 4); the profile is inferred as the most-recent sketch that is **not** the path, so it works whether the path is a sketch or a reference curve such as a helix. Optional constant twist (`TwistCtrlOption=8`, angle→radians).
- **`create_loft`** → `IFeatureManager.InsertProtrusionBlend2`. Selects ≥ 2 profiles (mark 1, in order) and optional guide curves (mark 2), with start/end tangency mapping.
- **`tools/modeling.py`**: registers `create_sweep` and `create_loft`.
- Selection uses `FeatureByName(name).Select2(append, mark)` — late-bound `Extension.SelectByID2` raises `Type mismatch` on SW 2026.
- Feature-tree walk hardened against pywin32's method-vs-property late-binding ambiguity (`sw_type_info` flagging + call-then-fallback read).
- Mock adapter already returned a stub `SolidWorksFeature` for both.

> The issue names `InsertProtrusionSweep2`, which does not exist — the real sweep method is `InsertProtrusionSwept*`. This uses `InsertProtrusionSwept4` (20-param signature verified live against SW 2026).

### Bundled prerequisite fix
`fix(sketch): resolve active sketch via flagged currentModel` — `create_sketch`'s fallback read `swApp.ActiveDoc.GetActiveSketch2()`; a bare `ActiveDoc` dispatch isn't method-flagged, so `GetActiveSketch2` resolved to a non-callable and yielded `None`, forcing a synthetic `Sketch_N` name that SolidWorks can't select (real name is `SketchN`). This broke any feature that selects a sketch by the name `create_sketch` returned — including the sweep/loft live tests below. Prefer the method-flagged `currentModel` dispatch, with `ActiveDoc` as a secondary fallback.

### Acceptance criteria
- [x] `create_sweep` returns SUCCESS + `SolidWorksFeature` with a valid profile + path
- [x] `create_loft` returns SUCCESS with ≥ 2 profiles
- [x] Both return ERROR with a descriptive message when `currentModel` is `None`
- [x] Mock adapter returns a stub `SolidWorksFeature` (not an error)
- [x] Unit tests: no-model guard, success path, parameter edge cases
- [x] `dev-test` (non-`solidworks_only`) passes

### Tests
- **13 mocked-COM unit tests** — guards, selection marks, feature-None paths, tool wiring.
- **3 gated live regression tests** (`SOLIDWORKS_MCP_RUN_REAL_INTEGRATION=1`) — tapered-bevel loft, circular-profile-along-helix sweep, single-profile guard. All pass against live SW 2026, asserting a solid body results.

### Live demo
`scripts/demo_sweep_loft.py` builds a multibody part — a tapered cone (`create_loft`, R30→R12) and a coil spring (`create_sweep` along a helix) — and exports screenshots.

**Isometric**
![sweep_loft_demo_isometric.png](https://github.com/user-attachments/assets/9f2ec449-bad8-437e-af7e-05fcc268f825)

**Trimetric**
![sweep_loft_demo_trimetric.png](https://github.com/user-attachments/assets/77b03217-ffe0-4b06-b639-b84be2e27913)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
