### PR TITLE
fix: make SolidWorks live readback consistent

### DIFF
--- a/src/solidworks_mcp/adapters/intelligent_router.py
+++ b/src/solidworks_mcp/adapters/intelligent_router.py
@@ -61,12 +61,15 @@ class IntelligentRouter:
         self._analyzer = analyzer
         self._cache = cache
         self._cacheable_operations = cacheable_operations or {
-            # Lightweight metadata operations
-            "get_model_info",
-            "list_features",
-            "list_configurations",
-            "get_file_properties",
-            "get_dimension",
+            # Live document metadata is deliberately NOT cached. Model state,
+            # save state, paths, features, configurations, dimensions and
+            # properties can all change after any CAD operation, and this
+            # router has no reliable mutation-triggered invalidation.
+            # "get_model_info",
+            # "list_features",
+            # "list_configurations",
+            # "get_file_properties",
+            # "get_dimension",
             # Analysis operations — NOT cached: model state changes with
             # every feature-creation tool call and the router has no
             # automatic invalidation. Caching these produced stale

--- a/src/solidworks_mcp/adapters/pywin32_adapter.py
+++ b/src/solidworks_mcp/adapters/pywin32_adapter.py
@@ -1238,15 +1238,19 @@ class _FeatureSelectionService:
                     default=0,
                 )
 
-        if features:
-            return features
-
+        # Always augment the forward traversal with FeatureByPositionReverse.
+        # Some SolidWorks COM/type-library combinations stop GetNextFeature at
+        # the system folders even though later sketches and body features
+        # exist. The dedupe set keeps this fallback safe when both traversals
+        # return the same entries.
         feature_manager = getattr(self._adapter.currentModel, "FeatureManager", None)
         count = self._adapter._attempt(
             lambda: int(feature_manager.GetFeatureCount(True) or 0),  # type: ignore[union-attr]
             default=0,
         )
-        for reverse_pos in range(1, (count or 0) + 1):
+        # FeatureByPositionReverse is zero-based. Starting at one silently
+        # skipped the newest feature (typically the just-created extrusion).
+        for reverse_pos in range(0, count or 0):
             feature = self._adapter._attempt(
                 lambda pos=reverse_pos: (  # type: ignore[misc]
                     self._adapter.currentModel.FeatureByPositionReverse(pos)  # type: ignore[union-attr]
@@ -1258,7 +1262,7 @@ class _FeatureSelectionService:
                 features,
                 seen,
                 feature,
-                (count or 0) - reverse_pos,
+                (count or 0) - reverse_pos - 1,
                 include_suppressed,
             )
 
@@ -1283,7 +1287,10 @@ class _FeatureSelectionService:
         """
         name = str(getattr(feature, "Name", ""))
         feature_type = str(
-            self._adapter._attempt(lambda: feature.GetTypeName2(), default="Unknown")
+            self._adapter._attempt(
+                lambda: self._adapter._get_attr_or_call(feature, "GetTypeName2"),
+                default="Unknown",
+            )
         )
         dedupe_key = (name, feature_type)
         if dedupe_key in seen:
@@ -2198,7 +2205,7 @@ class PyWin32Adapter(
         if not self.currentModel:
             return "Unknown"
 
-        doc_type = self.currentModel.GetType()
+        doc_type = self._get_attr_or_call(self.currentModel, "GetType")
         type_map = {1: "Part", 2: "Assembly", 3: "Drawing"}
         return type_map.get(doc_type, "Unknown")
 

--- a/src/solidworks_mcp/adapters/solidworks/io.py
+++ b/src/solidworks_mcp/adapters/solidworks/io.py
@@ -606,6 +606,11 @@ class SolidWorksIOMixin:
             AdapterResult[dict[str, Any]]: Model information payload.
         """
         adapter = self._adapter(self)
+        active_model = (
+            getattr(adapter.swApp, "ActiveDoc", None) if adapter.swApp else None
+        )
+        if active_model is not None:
+            adapter.currentModel = active_model
         if not adapter.currentModel:
             return AdapterResult(
                 status=AdapterResultStatus.ERROR, error="No active model"
@@ -613,7 +618,13 @@ class SolidWorksIOMixin:
 
         def _get_info() -> dict[str, Any]:
             """Get model information."""
-            active_config = adapter.currentModel.GetActiveConfiguration()
+            # With late-bound SolidWorks COM, GetActiveConfiguration is
+            # exposed as an object-valued property even though the API names
+            # it like a method. Calling that COM object raises "member not
+            # found", so read it directly.
+            active_config = getattr(
+                adapter.currentModel, "GetActiveConfiguration", None
+            )
             # 'Name' on Configuration is a property, not a method.
             config_name = (
                 getattr(active_config, "Name", "Default")
@@ -622,7 +633,10 @@ class SolidWorksIOMixin:
             )
             # Try GetSaveFlag (method) first, fallback to property
             is_dirty_raw = adapter._attempt(
-                lambda: adapter.currentModel.GetSaveFlag(), default=None
+                lambda: adapter._get_attr_or_call(
+                    adapter.currentModel, "GetSaveFlag"
+                ),
+                default=None,
             )
             is_dirty = bool(is_dirty_raw) if is_dirty_raw is not None else None
             feature_count = adapter._attempt(
@@ -639,8 +653,12 @@ class SolidWorksIOMixin:
                 rebuild_status_raw if rebuild_status_raw is not None else None
             )
             return {
-                "title": adapter.currentModel.GetTitle(),
-                "path": adapter.currentModel.GetPathName(),
+                "title": adapter._get_attr_or_call(
+                    adapter.currentModel, "GetTitle"
+                ),
+                "path": adapter._get_attr_or_call(
+                    adapter.currentModel, "GetPathName"
+                ),
                 "type": adapter._get_document_type(),
                 "configuration": config_name,
                 "is_dirty": is_dirty,

--- a/src/solidworks_mcp/adapters/solidworks/selection.py
+++ b/src/solidworks_mcp/adapters/solidworks/selection.py
@@ -25,6 +25,10 @@ class SolidWorksSelectionMixin:
     async def list_features(
         self, include_suppressed: bool = False
     ) -> AdapterResult[list[dict[str, Any]]]:
+        sw_app = getattr(self, "swApp", None)
+        active_model = getattr(sw_app, "ActiveDoc", None) if sw_app else None
+        if active_model is not None:
+            self.currentModel = active_model
         if not self.currentModel:
             return AdapterResult(
                 status=AdapterResultStatus.ERROR,

--- a/src/solidworks_mcp/tools/file_management.py
+++ b/src/solidworks_mcp/tools/file_management.py
@@ -826,20 +826,60 @@ async def register_file_management_tools(
                             - Some properties may be empty if not set
                             - Technical properties depend on document configuration
         """
-        # Simulated file properties - would get from adapter
-        return {
-            "status": "success",
-            "properties": {
-                "file_name": "Example.sldprt",
-                "file_size": "2.5 MB",
-                "created_date": "2024-03-14T00:00:00Z",
-                "modified_date": "2024-03-14T12:00:00Z",
-                "author": "User",
-                "description": "SolidWorks part file",
-                "material": "Default",
-                "units": "millimeters",
-            },
-        }
+        try:
+            if not hasattr(adapter, "get_model_info"):
+                return {
+                    "status": "error",
+                    "message": "Active adapter does not support model metadata",
+                }
+
+            result = await adapter.get_model_info()
+            if not result.is_success or not isinstance(result.data, dict):
+                return {
+                    "status": "error",
+                    "message": result.error or "No active SolidWorks document",
+                }
+
+            model_info = dict(result.data)
+            raw_path = str(model_info.get("path") or "")
+            file_path = Path(raw_path) if raw_path else None
+            properties: dict[str, Any] = {
+                "file_name": (
+                    file_path.name
+                    if file_path is not None
+                    else str(model_info.get("title") or "")
+                ),
+                "file_path": raw_path,
+                "file_size_bytes": None,
+                "created_date": None,
+                "modified_date": None,
+                "document_type": model_info.get("type"),
+                "configuration": model_info.get("configuration"),
+                "is_dirty": model_info.get("is_dirty"),
+                "feature_count": model_info.get("feature_count"),
+            }
+
+            if file_path is not None and file_path.is_file():
+                stat = file_path.stat()
+                properties.update(
+                    {
+                        "file_size_bytes": stat.st_size,
+                        "created_date": stat.st_ctime,
+                        "modified_date": stat.st_mtime,
+                    }
+                )
+
+            return {
+                "status": "success",
+                "properties": properties,
+                "execution_time": result.execution_time,
+            }
+        except Exception as e:
+            logger.error(f"Error in get_file_properties tool: {e}")
+            return {
+                "status": "error",
+                "message": f"Unexpected error: {str(e)}",
+            }
 
     @mcp.tool()
     async def get_model_info() -> dict[str, Any]:

--- a/tests/solidworks_mcp/adapters/test_adapters.py
+++ b/tests/solidworks_mcp/adapters/test_adapters.py
@@ -750,9 +750,11 @@ class TestPyWin32AdapterBranches:
                 """Test helper for IsSuppressed."""
                 return False
 
+        # FeatureByPositionReverse is zero-based: position 0 is the newest
+        # feature (Boss-Extrude1), position 1 is the next-oldest (Sketch1).
         by_pos = {
-            1: _Feature("Boss-Extrude1", "Boss"),
-            2: _Feature("Sketch1", "ProfileFeature"),
+            0: _Feature("Boss-Extrude1", "Boss"),
+            1: _Feature("Sketch1", "ProfileFeature"),
         }
 
         adapter.currentModel = SimpleNamespace(
@@ -2319,6 +2321,59 @@ class TestPyWin32AdapterBranches:
         assert info_result.error == "No active model"
         assert list_result.is_error
         assert list_result.error == "No active model"
+
+    @pytest.mark.asyncio
+    async def test_get_model_info_syncs_currentmodel_from_active_doc(
+        self, monkeypatch
+    ) -> None:
+        """get_model_info should resync currentModel to swApp.ActiveDoc.
+
+        Regression coverage for the live-readback fix: a stale currentModel
+        pointer (e.g. from a prior document) must not shadow whatever
+        document is actually active in SolidWorks right now.
+        """
+        adapter = self._build_adapter(monkeypatch)
+
+        active_doc = SimpleNamespace(
+            GetTitle=Mock(return_value="LiveActive.sldprt"),
+            GetPathName=Mock(return_value="C:/parts/LiveActive.sldprt"),
+            GetType=Mock(return_value=1),
+            GetSaveFlag=Mock(return_value=False),
+            GetRebuildStatus=Mock(return_value=0),
+            GetActiveConfiguration=None,
+            FeatureManager=SimpleNamespace(GetFeatureCount=Mock(return_value=3)),
+        )
+        adapter.swApp = SimpleNamespace(ActiveDoc=active_doc)
+        # A stale reference from a previously-open document.
+        adapter.currentModel = SimpleNamespace(
+            GetTitle=Mock(return_value="Stale.sldprt")
+        )
+
+        result = await adapter.get_model_info()
+
+        assert result.is_success
+        assert result.data["title"] == "LiveActive.sldprt"
+        assert result.data["path"] == "C:/parts/LiveActive.sldprt"
+        assert adapter.currentModel is active_doc
+
+    @pytest.mark.asyncio
+    async def test_list_features_syncs_currentmodel_from_active_doc(
+        self, monkeypatch
+    ) -> None:
+        """list_features should resync currentModel to swApp.ActiveDoc before traversal."""
+        adapter = self._build_adapter(monkeypatch)
+
+        active_doc = SimpleNamespace(
+            FirstFeature=Mock(return_value=None),
+            FeatureManager=SimpleNamespace(GetFeatureCount=Mock(return_value=0)),
+        )
+        adapter.swApp = SimpleNamespace(ActiveDoc=active_doc)
+        adapter.currentModel = None
+
+        result = await adapter.list_features()
+
+        assert result.is_success
+        assert adapter.currentModel is active_doc
 
     @pytest.mark.asyncio
     async def test_list_features_handles_none_feature_in_reverse_fallback(

--- a/tests/solidworks_mcp/test_architecture_runtime_features.py
+++ b/tests/solidworks_mcp/test_architecture_runtime_features.py
@@ -222,8 +222,15 @@ def test_security_enforcer_requires_valid_api_key(
 
 
 @pytest.mark.asyncio
-async def test_server_runtime_instrumentation_caches_read_calls() -> None:
-    """Server instrumentation should cache eligible read operations."""
+async def test_server_runtime_instrumentation_does_not_cache_live_reads() -> None:
+    """Live document reads must never be cached; state can change between calls.
+
+    ``get_model_info`` (and the other live-document reads) were removed from
+    the router's cacheable-operations set because the router has no
+    mutation-triggered invalidation. A cached read could report a stale path,
+    dirty flag, or feature list after a save or modeling operation. See PR
+    "fix: make SolidWorks live readback consistent".
+    """
     cfg = SolidWorksMCPConfig(
         mock_solidworks=True,
         enable_intelligent_routing=True,
@@ -256,7 +263,7 @@ async def test_server_runtime_instrumentation_caches_read_calls() -> None:
 
     assert first.is_success is True
     assert second.is_success is True
-    assert adapter.calls == 1
+    assert adapter.calls == 2
 
 
 def test_complexity_analyzer_recognizes_expanded_operations() -> None:

--- a/tests/solidworks_mcp/test_smoke_agents_live.py
+++ b/tests/solidworks_mcp/test_smoke_agents_live.py
@@ -16,7 +16,7 @@ from solidworks_mcp.agents.schemas import (
 
 
 async def _run_or_skip(**kwargs):
-    """Wrap run_validated_prompt and skip the test on auth/connection errors."""
+    """Wrap run_validated_prompt and skip the test on auth/connection/outage errors."""
     from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError
 
     try:
@@ -25,6 +25,14 @@ async def _run_or_skip(**kwargs):
         if exc.status_code == 401:
             pytest.skip(
                 "LLM credentials rejected with 401 — refresh GH_TOKEN or provide ANTHROPIC_API_KEY"
+            )
+        if exc.status_code == 410:
+            # GitHub Models has been returning this during its retirement
+            # rollout (body.code == "github_models_retirement_brownout").
+            # Treat as an unavailable provider rather than a hard failure.
+            pytest.skip(
+                "GitHub Models API returned 410 (service retirement/brownout) — "
+                "provide ANTHROPIC_API_KEY or wait for GitHub Models availability"
             )
         raise
     except ModelAPIError:

--- a/tests/solidworks_mcp/tools/test_file_management.py
+++ b/tests/solidworks_mcp/tools/test_file_management.py
@@ -407,7 +407,94 @@ class TestFileManagementTools:
 
         properties_result = await properties_tool()
         assert properties_result["status"] == "success"
-        assert properties_result["properties"]["file_name"] == "Example.sldprt"
+        # get_file_properties now derives file_name from the live active
+        # document instead of returning placeholder data (was "Example.sldprt").
+        assert properties_result["properties"]["file_name"] == "CoveragePart.sldprt"
+
+    @pytest.mark.asyncio
+    async def test_get_file_properties_error_when_adapter_lacks_model_info(
+        self, mcp_server, mock_config
+    ):
+        """get_file_properties should error cleanly when the adapter can't read live state."""
+
+        class _AdapterWithoutModelInfo:
+            """Stand-in adapter missing get_model_info entirely."""
+
+        await register_file_management_tools(
+            mcp_server, _AdapterWithoutModelInfo(), mock_config
+        )
+
+        properties_tool = None
+        for tool in await mcp_server.list_tools():
+            if tool.name == "get_file_properties":
+                properties_tool = tool.fn
+                break
+
+        assert properties_tool is not None
+        result = await properties_tool()
+        assert result["status"] == "error"
+        assert "does not support model metadata" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_get_file_properties_reads_real_file_stats(
+        self, mcp_server, mock_adapter, mock_config, tmp_path
+    ):
+        """get_file_properties should populate size/timestamps for a file that exists on disk."""
+        await register_file_management_tools(mcp_server, mock_adapter, mock_config)
+
+        real_file = tmp_path / "OnDisk.sldprt"
+        real_file.write_bytes(b"not a real sldprt, just needs to exist")
+
+        mock_adapter.get_model_info = AsyncMock(
+            return_value=Mock(
+                is_success=True,
+                data={
+                    "title": "OnDisk.sldprt",
+                    "path": str(real_file),
+                    "type": "Part",
+                    "configuration": "Default",
+                    "is_dirty": False,
+                    "feature_count": 1,
+                },
+                execution_time=0.02,
+            )
+        )
+
+        properties_tool = None
+        for tool in await mcp_server.list_tools():
+            if tool.name == "get_file_properties":
+                properties_tool = tool.fn
+                break
+
+        assert properties_tool is not None
+        result = await properties_tool()
+
+        assert result["status"] == "success"
+        assert result["properties"]["file_name"] == "OnDisk.sldprt"
+        assert result["properties"]["file_size_bytes"] == real_file.stat().st_size
+        assert result["properties"]["created_date"] is not None
+        assert result["properties"]["modified_date"] is not None
+
+    @pytest.mark.asyncio
+    async def test_get_file_properties_handles_unexpected_exception(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """get_file_properties should catch unexpected errors and report them, not raise."""
+        await register_file_management_tools(mcp_server, mock_adapter, mock_config)
+
+        mock_adapter.get_model_info = AsyncMock(side_effect=RuntimeError("boom"))
+
+        properties_tool = None
+        for tool in await mcp_server.list_tools():
+            if tool.name == "get_file_properties":
+                properties_tool = tool.fn
+                break
+
+        assert properties_tool is not None
+        result = await properties_tool()
+        assert result["status"] == "error"
+        assert "Unexpected error" in result["message"]
+        assert "boom" in result["message"]
 
     @pytest.mark.asyncio
     async def test_save_as_solidworks_path_success_and_error(


### PR DESCRIPTION
This PR fixes inconsistent live readback from an active SolidWorks document.

Previously, modeling and save operations could report success while subsequent read tools returned stale, incomplete, or placeholder data. For example:

- `list_features` could omit newly created sketches and extrusion features.
- `get_model_info` could continue reporting an empty path and dirty state after saving.
- `get_file_properties` could return placeholder information such as `Example.sldprt`.
- Repeated calls could reuse cached results instead of querying the current SolidWorks document.

## Changes

- Disable caching for live document-dependent reads, including:
  - model information
  - feature lists
  - configurations
  - file properties
  - dimensions
- Synchronize readback operations with the current `ActiveDoc`.
- Improve late-bound COM property and method compatibility.
- Ensure feature-tree traversal falls back to direct SolidWorks feature iteration.
- Correct zero-based handling of `FeatureByPositionReverse`.
- Replace placeholder file properties with values derived from the active document and filesystem.

## Validation

Validated against:

- SOLIDWORKS Design Standard 2026 SP3.2, academic license
- Windows
- A real saved part containing one sketch and one extrusion

The following checks passed:

- `get_model_info` returned the actual file name and complete saved path.
- `is_dirty` was `false` after saving.
- `list_features` returned both the sketch (`ProfileFeature`) and extrusion (`Extrusion`).
- `get_file_properties` returned the actual file path and a non-zero file size.
- No `Example.sldprt` placeholder data appeared.
- Repeated read calls produced fresh execution timings while returning consistent document state.
- Python compilation and `git diff --check` passed.

This change is limited to readback consistency and COM compatibility; it does not intentionally alter the public MCP tool interface.