### PR TITLE
Fix save_file destroying the document when saving to its own path

### DIFF
--- a/src/solidworks_mcp/adapters/solidworks/io.py
+++ b/src/solidworks_mcp/adapters/solidworks/io.py
@@ -530,14 +530,50 @@ class SolidWorksIOMixin:
             """Save the model."""
             if file_path:
                 resolved_path = os.path.abspath(file_path)
-                os.makedirs(os.path.dirname(resolved_path), exist_ok=True)
+                directory = os.path.dirname(resolved_path)
+                if directory:
+                    os.makedirs(directory, exist_ok=True)
 
+                current_path = adapter._attempt(
+                    lambda: adapter._get_attr_or_call(
+                        adapter.currentModel, "GetPathName"
+                    ),
+                    default="",
+                )
+                same_file = bool(current_path) and os.path.normcase(
+                    os.path.abspath(str(current_path))
+                ) == os.path.normcase(resolved_path)
+
+                if same_file:
+                    # Saving a document over its own path is a plain Save.
+                    # It used to fall through to the Save-As branch below, which
+                    # closed the document and deleted the file before calling
+                    # SaveAs3 on the now-closed doc. That wrote an empty part and
+                    # lost the geometry.
+                    save_result = adapter._attempt(
+                        lambda: adapter.currentModel.Save3(1, None, None)
+                    )
+                    if save_result is None:
+                        save_fn = getattr(adapter.currentModel, "Save", None)
+                        if callable(save_fn):
+                            save_fn()
+                    if not os.path.exists(resolved_path):
+                        raise Exception(
+                            f"File not written after save: {resolved_path}"
+                        )
+                    return
+
+                # A *different* document may be holding the target path open.
+                # Close that one by name only - never the document being saved.
                 if adapter.swApp:
-                    adapter._attempt(lambda: adapter.swApp.CloseDoc(resolved_path))
+                    adapter._attempt(
+                        lambda: adapter.swApp.CloseDoc(
+                            os.path.basename(resolved_path)
+                        )
+                    )
 
-                if os.path.exists(resolved_path):
-                    adapter._attempt(lambda: os.remove(resolved_path))
-
+                # Deliberately no os.remove here: SaveAs3 overwrites, and
+                # deleting first meant a failed save destroyed the old file too.
                 save_as3_result = adapter.currentModel.SaveAs3(resolved_path, 0, 0)
                 if not self._is_success(save_as3_result):
                     save_as = getattr(adapter.currentModel, "SaveAs", None)

--- a/tests/solidworks_mcp/adapters/solidworks/test_io_save_file.py
+++ b/tests/solidworks_mcp/adapters/solidworks/test_io_save_file.py
@@ -1,0 +1,187 @@
+"""Regression tests for ``save_file``'s save-over-own-path data loss.
+
+Passing the document's own path to ``save_file`` used to take the Save-As
+branch, which closed the document and deleted the file on disk before calling
+``SaveAs3`` on the now-closed document. The result was an empty part and lost
+geometry.
+
+These tests drive the adapter with fakes, so they need no SolidWorks.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from solidworks_mcp.adapters.solidworks import io as io_mod
+
+
+class _FakeModel:
+    """Stands in for IModelDoc2, recording which save path was taken."""
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self.save3_calls = 0
+        self.save_as3_calls: list[str] = []
+
+    def GetPathName(self) -> str:
+        """Return the document's current on-disk path."""
+        return self._path
+
+    def Save3(self, options: int, errors: Any, warnings: Any) -> bool:
+        """Plain save; leaves the file where it is."""
+        self.save3_calls += 1
+        return True
+
+    def SaveAs3(self, path: str, version: int, options: int) -> bool:
+        """Save-As; writes the document to a new path."""
+        self.save_as3_calls.append(path)
+        Path(path).write_bytes(b"saved-as geometry")
+        return True
+
+
+class _FakeApp:
+    """Stands in for ISldWorks, recording CloseDoc arguments."""
+
+    def __init__(self) -> None:
+        self.closed: list[str] = []
+
+    def CloseDoc(self, name: str) -> None:
+        """Record the document SolidWorks was asked to close."""
+        self.closed.append(name)
+
+
+class _FakeAdapter:
+    """Minimal adapter surface used by SolidWorksIOMixin.save_file."""
+
+    def __init__(self, model: _FakeModel, app: _FakeApp) -> None:
+        self.currentModel = model
+        self.swApp = app
+
+    def _attempt(self, fn, default=None):
+        """Call fn, swallowing failures the way the real adapter does."""
+        try:
+            return fn()
+        except Exception:
+            return default
+
+    @staticmethod
+    def _get_attr_or_call(obj: Any, name: str) -> Any:
+        """Read a member that may be a property or a zero-arg method."""
+        member = getattr(obj, name, None)
+        return member() if callable(member) else member
+
+    def _handle_com_operation(self, _name: str, operation):
+        """Run the operation directly; COM plumbing is not under test here."""
+        from solidworks_mcp.adapters.base import AdapterResult, AdapterResultStatus
+
+        try:
+            return AdapterResult(
+                status=AdapterResultStatus.SUCCESS, data=operation()
+            )
+        except Exception as exc:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR, error=str(exc)
+            )
+
+
+def _mixin_for(adapter: _FakeAdapter) -> Any:
+    """Bind SolidWorksIOMixin to a fake adapter."""
+    mixin = io_mod.SolidWorksIOMixin()
+    mixin._adapter = lambda _self: adapter  # type: ignore[method-assign]
+    return mixin
+
+
+@pytest.mark.asyncio
+async def test_saving_to_own_path_preserves_the_file(tmp_path: Path) -> None:
+    """The regression: saving over the document's own path must not delete it."""
+    part = tmp_path / "bracket.sldprt"
+    part.write_bytes(b"original geometry")
+    original_size = part.stat().st_size
+
+    model = _FakeModel(str(part))
+    app = _FakeApp()
+    result = await _mixin_for(_FakeAdapter(model, app)).save_file(str(part))
+
+    assert result.is_success, result.error
+    # The file must still be there, with its contents intact.
+    assert part.exists()
+    assert part.read_bytes() == b"original geometry"
+    assert part.stat().st_size == original_size
+
+    # It must take the plain-Save path, and must not close the document
+    # being saved or Save-As over itself.
+    assert model.save3_calls == 1
+    assert model.save_as3_calls == []
+    assert app.closed == []
+
+
+@pytest.mark.asyncio
+async def test_saving_to_own_path_is_case_and_separator_insensitive(
+    tmp_path: Path,
+) -> None:
+    """Windows paths differing only in case are still the same file."""
+    part = tmp_path / "Bracket.SLDPRT"
+    part.write_bytes(b"original geometry")
+
+    model = _FakeModel(str(part))
+    app = _FakeApp()
+    # Same file, spelled differently.
+    odd_case = str(part).upper() if os.name == "nt" else str(part)
+    result = await _mixin_for(_FakeAdapter(model, app)).save_file(odd_case)
+
+    assert result.is_success, result.error
+    assert part.read_bytes() == b"original geometry"
+    if os.name == "nt":
+        assert model.save3_calls == 1
+        assert model.save_as3_calls == []
+
+
+@pytest.mark.asyncio
+async def test_saving_to_a_new_path_still_uses_save_as(tmp_path: Path) -> None:
+    """Save-As to a genuinely different path is unaffected by the fix."""
+    part = tmp_path / "bracket.sldprt"
+    part.write_bytes(b"original geometry")
+    target = tmp_path / "copy.sldprt"
+
+    model = _FakeModel(str(part))
+    app = _FakeApp()
+    result = await _mixin_for(_FakeAdapter(model, app)).save_file(str(target))
+
+    assert result.is_success, result.error
+    assert target.exists()
+    assert model.save_as3_calls == [str(target)]
+    assert model.save3_calls == 0
+    # The source document is left alone; only the name occupying the target
+    # path is closed.
+    assert app.closed == [target.name]
+    assert part.read_bytes() == b"original geometry"
+
+
+@pytest.mark.asyncio
+async def test_failed_save_as_leaves_the_existing_target_intact(
+    tmp_path: Path,
+) -> None:
+    """A rejected Save-As must not have already deleted the target."""
+    part = tmp_path / "bracket.sldprt"
+    part.write_bytes(b"original geometry")
+    target = tmp_path / "existing.sldprt"
+    target.write_bytes(b"valuable existing file")
+
+    class _RefusingModel(_FakeModel):
+        def SaveAs3(self, path: str, version: int, options: int) -> bool:
+            """Refuse the save without writing anything."""
+            self.save_as3_calls.append(path)
+            return False
+
+    model = _RefusingModel(str(part))
+    result = await _mixin_for(_FakeAdapter(model, _FakeApp())).save_file(
+        str(target)
+    )
+
+    assert not result.is_success
+    # The old file survives, because nothing is deleted up front.
+    assert target.read_bytes() == b"valuable existing file"


### PR DESCRIPTION
save_file(file_path=...) always took the Save-As branch, even when the path given was the document's own. That branch does, in order:

    swApp.CloseDoc(resolved_path)      # closes the document being saved
    os.remove(resolved_path)           # deletes it from disk
    currentModel.SaveAs3(resolved_path, 0, 0)   # saves a closed document

So the common call - "save this part back to where it came from" - closed the part, deleted the file, then wrote an empty document over it. The geometry was gone, and save_file reported success.

Two smaller problems in the same branch:

- CloseDoc was passed a full path. ISldWorks::CloseDoc takes a document name, so it silently matched nothing when the intent was to release a *different* document holding the target path.
- The os.remove ran before the save. If SaveAs3 then failed, the original file had already been deleted, so a failed save destroyed the old file too.

Fixed by comparing the requested path against IModelDoc2::GetPathName (normcase + abspath, so a Windows path differing only in case still counts as the same file). Same file means a plain Save3. Different file keeps Save-As, closes only the basename, and no longer deletes anything up front, since SaveAs3 overwrites.

Four regression tests added, driving the adapter with fakes so they need no SolidWorks. Against this fix they pass; against the code they replace, all four fail:

    test_saving_to_own_path_preserves_the_file
        AssertionError: assert b'saved-as geometry' == b'original geometry'
    test_failed_save_as_leaves_the_existing_target_intact
        FileNotFoundError: ... existing.sldprt

The second is the clearest statement of the bug: the file was deleted and never came back.

Suite: 1837 passed, 0 failed. Coverage 99.87%, gate passing. ruff clean.