### PR TITLE
Make list_features assembly-aware (issue #21)

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,181 @@
+---
+name: "OPSX: Apply"
+description: "Implement tasks from an OpenSpec change (Experimental)"
+allowed-tools: Bash(openspec:*)
+category: "Workflow"
+tags: ["workflow", "artifacts", "experimental"]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Once selected, treat `--store <id>` as sticky for the rest of the workflow. Every unscoped example of those commands below is shorthand: before running it, append the flag. For example, run `openspec status --change "<name>" --json --store "<id>"`, not the unscoped form shown below. Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and ask the user to select one
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+   - Optional `context`: current required project instruction input from the selected root
+   - Optional `operationGuidance`: current advisory guidance for apply
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue` (if it is not installed, run `openspec status --change "<name>" --json` to see the next artifact and `openspec instructions <artifact-id> --change "<name>" --json` for how to create it)
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+   Treat `context` as a required prompt-level input. Read and consider it, and
+   apply relevant project facts, conventions, and constraints while implementing.
+   Treat `operationGuidance` as optional additive advice. Read and consider every
+   entry, and follow entries that are applicable and compatible with the built-in
+   workflow.
+
+   Keep both fields separate from CLI-returned state, missing artifacts, tasks,
+   progress, `contextFiles`, and the built-in `instruction`. They are not
+   evidence of task completion, do not replace the built-in instruction, and do
+   not permit bypassing a blocked state. If context conflicts with the built-in
+   instruction, an explicit user choice, or a CLI-controlled value, report the
+   conflict and preserve the controlling value. If guidance is inapplicable or
+   conflicts with those controlling inputs, do not follow it and explain why.
+   These are prompt-level behavior contracts, not enforceable checks.
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+   Do not copy `context` or `operationGuidance` verbatim into implementation
+   files or planning artifacts unless the user separately asks for that content.
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+- Do not use context or operation guidance as proof that a task is complete
+- Apply relevant project context; report conflicts with controlling workflow inputs
+- Consider every guidance entry; explain any inapplicable or conflicting advice
+- Do not copy runtime context or operation guidance into implementation files or planning artifacts
+- Preserve CLI-controlled blocked/ready/all-done behavior and completion criteria
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,225 @@
+---
+name: "OPSX: Archive"
+description: "Archive a completed change in the experimental workflow"
+allowed-tools: Bash(openspec:*)
+category: "Workflow"
+tags: ["workflow", "archive", "experimental"]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Once selected, treat `--store <id>` as sticky for the rest of the workflow. Every unscoped example of those commands below is shorthand: before running it, append the flag. For example, run `openspec status --change "<name>" --json --store "<id>"`, not the unscoped form shown below. Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+`<capability-path>` is the spec directory relative to `specs/` (for example, `user-auth` or `identity/user-auth`). Preserve the full path from each delta spec when resolving its main spec.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and ask the user to select one
+
+   When prompting, show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:archive <other>`).
+
+   **Load current archive inputs before the existing archive checks:**
+
+   After resolving the selected change and planning root, run:
+   ```bash
+   openspec instructions archive --change "<name>" --json
+   ```
+   Keep the same selected-root flags on this command. This lookup is advisory and
+   optional: it only supplies extra prompt inputs, so it must never block archiving.
+   If it exits non-zero or returns invalid JSON — for example on an older CLI that
+   does not support this command yet — continue the archive workflow with no
+   context and no operation guidance. Do not report an error and do not stop.
+
+   A successful response may omit both optional fields. Treat `context` as a
+   required prompt-level input: read and consider it, and apply relevant project
+   facts, conventions, and constraints. Treat `operationGuidance` as optional
+   additive advice: read and consider every entry, and follow entries that are
+   applicable and compatible with the built-in archive workflow.
+
+   Keep both fields separate from built-in steps, explicit user choices, resolved
+   paths, CLI checks, and command contracts. If context conflicts with one of those
+   controlling inputs, report the conflict and preserve the controlling value. If
+   guidance is inapplicable or conflicts with a controlling input, do not follow it
+   and explain why. Do not infer replacement paths, skipped prompts, or flags from
+   either field, and do not copy their text verbatim into specs, change artifacts,
+   or archive summaries unless the user separately asks for it. These are
+   prompt-level behavior contracts, not enforceable checks.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done`, `skipped`, or other)
+
+   **If any artifacts are neither `done` nor `skipped`** (skipped artifacts satisfy the requirement - the change declares skip_specs):
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON as the only
+   delta-spec source. If the `specs` entry is missing or
+   `existingOutputPaths` is empty, proceed without a sync prompt and do not infer
+   delta specs from other artifacts.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `<planningHome.root>/openspec/specs/<capability-path>/spec.md` (use the store-aware `planningHome.root` from step 2, not a hardcoded repo path)
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   Route on the answer:
+   - "Cancel" — stop, do not archive
+   - "Archive without syncing" or "Archive now" — proceed to archive
+   - "Sync now" or "Sync anyway" — sync, then verify (below)
+   - Anything else — ask again rather than archiving
+
+   Before a selected sync writes any main spec, run
+   `openspec instructions specs --change "<name>" --json` once with the same
+   selected-root flags. Require a zero exit status and valid artifact-instruction
+   JSON. If the lookup fails or returns invalid JSON, report the error and stop
+   before writing any main spec or moving the change. A valid response with omitted
+   `rules` is the no-rules case. Apply returned `rules` only to the content and
+   form of main specs produced by this merge; do not use them as archive guidance,
+   change CLI behavior, or copy the rule text into any output file.
+
+   Then run the `/opsx:sync` workflow inline (agent-driven intelligent merge) for change '<name>', passing the delta spec analysis and the fetched specs-rule snapshot from above, and wait for it to finish. The inline sync must reuse that snapshot without fetching `specs` instructions again. Do not delegate it to a background task — step 5 would move `changeRoot` out from under a sync that is still reading it, leaving the change archived and the main specs never updated. If your agent can only run it by delegation, delegate synchronously and wait for the result.
+
+   Then re-run the comparison from the top of this step against every capability that has a delta spec in `artifactPaths.specs.existingOutputPaths` — not only the ones the sync reports it touched. A successful sync leaves nothing left to apply, so each capability must now read as already synced:
+   - ADDED requirements present
+   - MODIFIED requirements carrying the scenario and description changes named in the delta, with their other scenarios intact
+   - REMOVED requirements gone — and where this sync retired a capability (removed its last requirement, leaving `## Requirements` empty), its main spec deleted rather than left empty; a spec the sync deliberately kept and reported is also a match
+   - RENAMED requirements present under the new name and absent under the old one
+
+   If the sync failed, or any capability does not match, report what differs and stop — do not archive. Nothing has moved and `changeRoot` is intact, so the user can fix the mismatch or re-run the sync and start the archive again.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate the target name: use the change name as-is when it already starts with a `YYYY-MM-DD-` prefix; otherwise prepend the current date as `YYYY-MM-DD-<change-name>`. Never stack a second date (same rule as `openspec archive`).
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/<target-name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```markdown
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/<target-name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```markdown
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/<target-name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```markdown
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/<target-name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```markdown
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** the archive path derived from `planningHome.changesDir`/<target-name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Announce the selected change; prompt for selection when it is ambiguous
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, run the `/opsx:sync` workflow inline (agent-driven)
+- Never archive while a spec sync is still in flight — run the sync inline and verify the main specs before moving `changeRoot`
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting
+- Apply relevant runtime context and report conflicts; operation guidance remains advisory
+- Consider every guidance entry and explain any inapplicable or conflicting advice
+- Existing CLI checks, resolved paths, prompts, and command contracts are unchanged
+- Artifact rules constrain only the specs being written and are never operation guidance
+- Never copy runtime context, operation guidance, or artifact-rule text verbatim into output files

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,193 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+allowed-tools: Bash(openspec:*)
+category: "Workflow"
+tags: ["workflow", "explore", "experimental", "thinking"]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing. For a new change, scaffold it first as described below.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Once selected, treat `--store <id>` as sticky for the rest of the workflow. Every unscoped example of those commands below is shorthand: before running it, append the flag. For example, run `openspec status --change "<name>" --json --store "<id>"`, not the unscoped form shown below. Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+Then read the project's own context from the resolved root - `<root.path>/openspec/config.yaml` (or `config.yml`). Use the `root.path` returned above, and skip this if neither file exists:
+- `context`: project background - tech stack, conventions, constraints
+- `rules`: keyed by artifact id - the entries for an artifact apply only when you write that artifact
+
+Ground your thinking in these. They are constraints for you to follow, not content to reproduce: do NOT copy them into the conversation or into any artifact you create.
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+If the user asks you to capture the exploration as a new change, transition seamlessly into the requested capture:
+
+1. Run `openspec new change "<name>"` (with `--store <id>` when applicable) before creating any artifacts. Never create a new change directory under `openspec/changes/` by hand; the CLI scaffold creates required metadata such as `.openspec.yaml`. Keep the selected `--store <id>` on every applicable follow-up `status` and `instructions` command.
+2. Run `openspec status --change "<name>" --json` (append the confirmed `--store "<id>"` only for a registered standalone store), then process the requested artifacts in dependency order. For each requested artifact that is `ready`, run `openspec instructions "<artifact-id>" --change "<name>" --json` (append the confirmed `--store "<id>"` only for a registered standalone store). Before creating a requested artifact, evaluate any condition in its own `instruction` against the explored change; record a deliberate skip instead when the condition does not apply. If a requested artifact is blocked by a direct prerequisite the user did not request, run `openspec instructions "<prerequisite-id>" --change "<name>" --json` (append the confirmed `--store "<id>"` only for a registered standalone store) for that prerequisite whether it is `ready` or `blocked`. If its own `instruction` states a condition, evaluate that condition against the explored change and record a deliberate skip only when the condition does not apply. If the condition applies, or the prerequisite is not conditional, treat it as a normal prerequisite and ask before expanding the capture. Do not create an unrequested prerequisite unless the user approves.
+3. Follow the returned `template` and `instruction` fields. Read completed dependency files listed in `dependencies`, and apply `context` and `rules` as constraints without copying them into the artifact. If the instruction delegates creation to a specific skill or command, invoke it; otherwise write the artifact to `resolvedOutputPath`, using the instruction to choose a concrete path when it is a glob. Verify that the selected concrete output exists.
+4. After creating each artifact, re-run `openspec status --change "<name>" --json` (append the confirmed `--store "<id>"` only for a registered standalone store) and continue until every requested artifact is `done`, `skipped`, or was deliberately skipped because its own `instruction` stated a condition that did not apply. Tell the user about a deliberate conditional skip, remember it, and do not reconsider it. Dependencies are enablers, not gates: if a requested artifact is still `blocked` only because you deliberately skipped a conditional prerequisite, run `openspec instructions "<artifact-id>" --change "<name>" --json` (append the confirmed `--store "<id>"` only for a registered standalone store) despite the blocked status, then create it using step 3 only when those recorded conditional skips are its sole missing dependencies. If a requested artifact is blocked by a prerequisite the user did not ask to capture and cannot be conditionally skipped, explain that dependency and ask before expanding the capture.
+
+Capture the artifact(s) the user requested without asking them to invoke another workflow command. If they asked only to start a change, stop after scaffolding and show its status.
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   `<capability-path>` is the spec directory relative to `specs/` (for example, `user-auth` or `identity/user-auth`). Preserve an existing capability's full path and follow the project's established organization for new capabilities.
+
+    | Insight Type               | Where to Capture                    |
+    |----------------------------|-------------------------------------|
+    | New requirement discovered | `specs/<capability-path>/spec.md` |
+    | Requirement changed        | `specs/<capability-path>/spec.md` |
+    | Design decision made       | `design.md`                       |
+    | Scope changed              | `proposal.md`                     |
+    | New work identified        | `tasks.md`                        |
+    | Assumption invalidated     | Relevant artifact                   |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Don't manually scaffold changes** - Never create a new change directory under `openspec/changes/` by hand. Always use `openspec new change "<name>"` (with `--store <id>` when applicable) so required metadata such as `.openspec.yaml` is created before writing artifacts.
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,145 @@
+---
+name: "OPSX: Propose"
+description: "Propose a new change - create it and generate all artifacts in one step"
+allowed-tools: Bash(openspec:*)
+category: "Workflow"
+tags: ["workflow", "artifacts", "experimental"]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+**Planning boundary**: This workflow creates planning artifacts only. The user request that selected or triggered this workflow authorizes planning only, even if it asks to build or fix something. Do not edit project code. After the planning artifacts are complete, stop. Do not start implementation in the same response, even if the initial request asks for it. Wait for a new user request after the artifacts are presented; then start the apply workflow.
+
+I'll create a change with the artifacts your schema defines. With the default spec-driven schema that is:
+- proposal.md (what & why)
+- `specs/<capability-path>/spec.md` (what the system must do - a delta, not the main spec)
+- design.md (how)
+- tasks.md (implementation steps)
+
+`<capability-path>` is the spec directory relative to `specs/` (for example, `user-auth` or `identity/user-auth`). Preserve an existing capability's full path and follow the project's established organization for new capabilities.
+
+When the user is ready to implement, they must start the apply workflow explicitly.
+
+---
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Once selected, treat `--store <id>` as sticky for the rest of the workflow. Every unscoped example of those commands below is shorthand: before running it, append the flag. For example, run `openspec status --change "<name>" --json --store "<id>"`, not the unscoped form shown below. Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **Understand the request and clarify material ambiguity**
+
+   If no input is provided, ask the user (open-ended, no preset options):
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+   If the request contains ambiguity that would materially affect scope, externally observable behavior, compatibility, or acceptance criteria, ask the user before creating the change. For minor details, make a reasonable assumption and record it in the planning artifacts.
+
+2. **Determine the workflow schema**
+
+   Use the configured default schema unless the user explicitly requests a different workflow.
+
+   **Use a different schema only if the user:**
+   - Explicitly requests a specific schema by name → use `--schema <schema-name>`
+   - Asks to "show workflows" or asks "what workflows" exist → resolve the authoritative root by running `openspec context --json` from the current working directory. If the user explicitly selected a registered store, use `openspec context --json --store "<store-id>"`. Then run `openspec schemas --json` with its working directory set to the returned `root.path` and let them choose. This preserves roots selected by a local `store:` pointer or the global `defaultStore`; `schemas` does not accept `--store`. If context reports only `no_openspec_root`, run `openspec schemas --json` from the current working directory instead. Do not use this fallback for invalid or unavailable stores.
+
+   Otherwise, omit `--schema` to preserve the configured default.
+
+3. **Create the change directory**
+
+   Choose one schema form below. If a registered store is selected, append `--store "<store-id>"` to that command and each later OpenSpec command shown below that accepts `--store`.
+
+   Using the configured default:
+   ```bash
+   openspec new change "<name>"
+   ```
+
+   Using an explicitly requested schema:
+   ```bash
+   openspec new change "<name>" --schema "<schema-name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+4. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts, each with its `status` and its `requires` edges (the artifact IDs it directly depends on)
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+5. **Create every artifact in the required set**
+
+   Use a todo list to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `skipped`/`warning`: present when the change declares skip_specs and this artifact must NOT be created - stop and pick another artifact
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context - always re-read them from disk, even if you saw them earlier in the conversation (the user may have edited them)
+      - If the `instruction` field delegates creation to a specific skill or command, invoke it to produce the artifact instead of writing the file yourself, then verify the artifact file exists at `resolvedOutputPath`
+      - Otherwise create the artifact file using `template` as the structure and write it to `resolvedOutputPath`. If `resolvedOutputPath` is a glob, follow `instruction` to choose the concrete file path
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until every artifact in the required set exists (not just `apply.requires`)**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - The required set is `applyRequires` plus every artifact reachable from those by following the `requires` edges in `status --json` - walk them transitively (spec-driven closes over proposal, specs, design, tasks). Leave artifacts outside that set alone
+      - `status` is file-existence only, so an `applyRequires` artifact reading `done` does NOT mean its dependencies exist - writing `tasks.md` early marks `tasks` done while `specs` was never written. Use each artifact's `requires` edges, not its `status`, to build the required set: a `done` artifact still lists what it depends on
+      - An artifact already reading `status: "skipped"` is satisfied: the change declares `skip_specs` in `.openspec.yaml`, so its files must NOT exist. Never try to create one
+      - Create every artifact in the required set that is missing, then re-check - creating one can unblock others
+      - Skip one only when `status` already reports it `skipped`, or when its own `instruction` says it is conditional: run `openspec instructions <artifact-id> --change "<name>" --json` and skip only if its `instruction` field marks it optional (e.g. "create only if..."). Spec-driven's `design.md` qualifies; `specs` qualifies only via the `skipped` status above, never by your own judgment. Tell the user, and do not reconsider it
+      - Dependencies are enablers, not gates: if a required artifact is still `blocked` only because you skipped a conditional dependency, write it anyway
+      - Stop when every artifact in the required set is `done`, `skipped`, or was deliberately skipped
+
+   c. **If an artifact requires user input** (unclear context):
+      - Ask the user to clarify
+      - Then continue with creation
+
+6. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions, plus any conditional artifact you skipped and why
+- What's ready: "All artifacts needed for implementation are ready."
+- Prompt: "The artifacts are ready for review. When you are ready, run `/opsx:apply`."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type - it is the authoritative guidance, even for familiar artifact names
+- If the `instruction` field directs you to use a specific skill or command to create the artifact, invoke it instead of writing the artifact directly
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- The request that invoked this workflow authorizes planning only. Any implementation or apply instruction in that request does not carry forward. Do NOT implement the change, start the apply workflow, or edit project code during this workflow. After presenting the artifacts, stop and wait for a new user request to start the apply workflow
+- Create every artifact the apply phase transitively depends on, not just the ids listed in `apply.requires`
+- Always read dependency artifacts before creating a new one - re-read from disk, not from conversation memory (files may have changed since you last saw them)
+- Ask about ambiguities that would materially change scope, externally observable behavior, compatibility, or acceptance criteria; for minor details, make reasonable assumptions and record them
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/commands/opsx/sync.md
+++ b/.claude/commands/opsx/sync.md
@@ -1,0 +1,258 @@
+---
+name: "OPSX: Sync"
+description: "Sync delta specs from a change to main specs"
+allowed-tools: Bash(openspec:*)
+category: "Workflow"
+tags: ["workflow", "specs", "experimental"]
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Once selected, treat `--store <id>` as sticky for the rest of the workflow. Every unscoped example of those commands below is shorthand: before running it, append the flag. For example, run `openspec status --change "<name>" --json --store "<id>"`, not the unscoped form shown below. Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+`<capability-path>` is the spec directory relative to `specs/` (for example, `user-auth` or `identity/user-auth`). Preserve the full path from each delta spec when resolving its main spec.
+
+**Input**: Optionally specify a change name after `/opsx:sync` (e.g., `/opsx:sync add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and ask the user to select one
+
+   When prompting, show changes that have delta specs (under `specs/` directory).
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:sync <other>`).
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+   The JSON includes `planningHome.root`. Main specs live under `<planningHome.root>/openspec/specs/` — use that (store-aware) root for every main-spec path below, not a hardcoded repo path. When a store is selected it points at the store, not the current repository.
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the
+   only source of delta spec paths. If the `specs` entry is missing or
+   `existingOutputPaths` is empty, report that there are no delta specs to sync,
+   do not infer them from other artifacts, and stop without requesting artifact
+   instructions or writing a main spec.
+
+   Sync every path in `existingOutputPaths` unless the caller narrowed the set.
+   A caller narrows it by naming an explicit list of complete entries from
+   `existingOutputPaths` — copy those absolute values verbatim. Archive does
+   this inline, and a user can too (for example, by selecting the entry ending
+   in `/specs/billing/invoices/spec.md`).
+   Then sync only the named paths and leave the remaining delta specs untouched:
+   bulk archive excludes a delta whose implementation it could not find, and
+   syncing it anyway would write a main spec the caller deliberately withheld.
+   Carry that narrowed selection through step 4; never widen it back to the full
+   list. If a named path is not in `existingOutputPaths`, do not sync it —
+   report it and stop, rather than dropping it silently. If the named list is
+   empty, report that there is nothing to sync and stop without writing a main
+   spec.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   Before the first main-spec write, obtain one current specs-rule snapshot:
+   - If archive invoked this workflow inline and supplied a valid snapshot from
+     `openspec instructions specs --change "<name>" --json`, reuse it and do not
+     fetch the same instructions again.
+   - Otherwise run that command once now with the same selected-root flags.
+   - If the direct lookup exits non-zero or returns invalid artifact-instruction
+     JSON, report the error and stop before writing any main spec. Do not treat the
+     failure as an absent rule set.
+   - A valid response with omitted `rules` means no artifact rules are configured
+     and the existing semantic merge continues.
+
+   Apply returned `rules` only to the content and form of the main specs produced
+   by this merge. Artifact rules are not operation guidance and cannot change
+   selected roots, delta paths, CLI checks, or workflow steps. Use their text as
+   constraints without copying it verbatim into a main spec or summary.
+
+   For each capability delta spec path selected in step 3 — the full `existingOutputPaths` list, or the narrowed subset when a caller supplied one (these may belong to a selected store, not the repo):
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `<planningHome.root>/openspec/specs/<capability-path>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios the main spec does not have yet
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+      - Retiring the capability. Delete the whole `spec.md` - and the directory once
+        nothing else is left in it - only when ALL of these hold:
+        1. removing the requirements *this run* left no requirement blocks;
+        2. the rest of the spec is well-formed (it still has a `## Purpose`);
+        3. the main spec was not already empty before this sync - if you removed
+           nothing, change nothing;
+        4. every other nonblank line in the whole file is accounted for as the
+           title, Purpose, Requirements header, or a canonical requirement's
+           statement, scenarios, or fenced examples;
+        5. the change's `.openspec.yaml` declares `retire_capabilities: true`;
+        6. the `spec.md` resolves inside the real specs root (do not follow a
+           capability-directory symlink to delete an external file).
+        If removing the selected requirements would leave no requirement blocks and
+        any retirement condition is not satisfied, do not modify the main spec. Stop
+        the sync for that capability, report the blocking condition, and tell the user
+        how to resolve it. Never write or leave an empty `## Requirements` section.
+        When only the marker is missing, say that too - it is the one thing the user
+        can add to make the retirement go through.
+      - Deleting the file also deletes its `## Purpose`; any other section blocks
+        retirement. Name Purpose when you report the retirement. Include a pasteable
+        `git checkout` only when the spec lived in the caller's checkout;
+        otherwise give checkout-scoped recovery guidance.
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+      **`## Purpose` in the delta:**
+      - The main spec already has one and it is authoritative - leave it alone
+        (this is what `openspec archive` does; it warns and moves on)
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `<planningHome.root>/openspec/specs/<capability-path>/spec.md`
+      - Add Purpose section: copy the delta's `## Purpose` body verbatim when it has one
+        (this is what `openspec archive` does); only write a brief TBD placeholder when it does not
+      - Add Requirements section with the ADDED requirements
+      - Follow the **Main Spec Format Reference** below
+
+5. **Validate updated main specs**
+
+   Run `openspec validate --specs` with the same selected-root flags used earlier.
+   If validation fails, report the problems and do not claim the sync succeeded.
+
+6. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+   - Any new main spec left with a TBD Purpose placeholder, so it gets written
+     now rather than lingering
+   - Any capability retired, naming the deleted `spec.md`, its Purpose, and
+     either a pasteable `git checkout` or checkout-scoped recovery guidance
+
+**Delta Spec Format Reference**
+
+```markdown
+## Purpose
+
+Only on a delta that introduces a brand-new capability. Seeds the new main spec.
+
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+The system SHALL keep doing the existing thing, now also handling A.
+
+#### Scenario: Scenario the main spec already has
+- **WHEN** user does X
+- **THEN** system does Y
+
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Main Spec Format Reference**
+
+Main specs are what the delta merges INTO. They must never contain delta operation headers (`## ADDED/MODIFIED/REMOVED/RENAMED Requirements`) - after syncing, every requirement lives under a single `## Requirements` section:
+
+```markdown
+# <capability> Specification
+
+## Purpose
+Short description of what this capability does and why it exists.
+
+## Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you merge rather than overwrite:
+- A MODIFIED block carries the whole requirement - body plus every scenario that survives the change. `openspec validate` and `openspec archive` both reject one that drops a scenario the main spec still has.
+- Keep anything the delta does not mention, in the main spec's existing order
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```markdown
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- Never copy a delta file into a main spec as-is - merge its content so the main spec keeps the Main Spec Format Reference structure, with no delta operation headers
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result
+- Use only `artifactPaths.specs.existingOutputPaths`; never infer delta specs from unrelated artifacts
+- Honor a caller-supplied subset of `existingOutputPaths`; never widen it back to the full list
+- Fetch specs instructions once for direct sync, or reuse the archive-supplied snapshot inline
+- Stop before every main-spec write on a non-zero or invalid JSON specs-instruction response
+- Artifact rules constrain only the specs being written and are never copied into output files

--- a/.claude/commands/opsx/update.md
+++ b/.claude/commands/opsx/update.md
@@ -1,0 +1,87 @@
+---
+name: "OPSX: Update"
+description: "Update a change - revise existing planning artifacts and keep them coherent (Experimental)"
+allowed-tools: Bash(openspec:*)
+category: "Workflow"
+tags: ["workflow", "artifacts", "experimental"]
+---
+
+Revise a change's existing planning artifacts and keep them coherent. Never edit code.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Once selected, treat `--store <id>` as sticky for the rest of the workflow. Every unscoped example of those commands below is shorthand: before running it, append the flag. For example, run `openspec status --change "<name>" --json --store "<id>"`, not the unscoped form shown below. Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name after `/opsx:update` (e.g., `/opsx:update add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+`/opsx:continue` is an expanded-profile workflow and may not be installed. Before suggesting it anywhere below, verify that it is available. If it is unavailable, `openspec status --change "<name>" --json` shows the next artifact and `openspec instructions "<artifact-id>" --change "<name>" --json` explains how to create it.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes sorted by most recently modified, and ask the user to select one
+
+   When prompting, present the top 3-4 most recently modified changes as options, showing:
+   - Change name
+   - Schema (from `schema` field if present, otherwise "spec-driven")
+   - Status (e.g., "0/5 tasks", "complete", "no tasks")
+   - How recently it was modified (from `lastModified` field)
+
+   Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to update.
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:update <other>`).
+
+2. **Get the change's artifacts**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand current state. The response includes:
+   - `schemaName`: The workflow schema being used (e.g., "spec-driven")
+   - `artifacts`: Array of artifacts with their status ("done", "skipped", "ready", "blocked")
+   - `isPlanningComplete`: Boolean indicating if all planning artifacts are complete. Older CLI versions expose the same value as `isComplete`.
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+   The artifact ids and paths come from the active schema - do NOT assume them, and do NOT branch on hardcoded artifact names. Custom schemas must work unchanged.
+
+   The files to edit are `artifactPaths.<id>.existingOutputPaths` - the concrete files that exist on disk, already glob-expanded for glob artifacts (e.g. `specs/**/*.md`). Do NOT write to `resolvedOutputPath`: for a glob artifact it is still the glob pattern, not a real file.
+
+3. **Understand the request**
+   - If the user asked for a specific revision ("the design now uses X"), that is the starting edit.
+   - If they only said "update" / "make this coherent", treat it as a coherence review: read the existing artifacts and check them against each other for contradictions, gaps, and duplication.
+
+4. **Read and reconcile**
+   - Read the artifact(s) the request touches and the change's other existing artifacts.
+   - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
+   - Note everything that is now inconsistent, missing, or contradictory.
+   - Revise only files that already exist (`existingOutputPaths`). Do NOT create artifacts that don't exist yet, and do NOT invent new files under a glob artifact - note them and point the user to `/opsx:continue` to create them.
+   - If the change is already coherent, say so and make no edits.
+
+5. **Confirm and apply, one artifact at a time**
+   - Show each proposed revision and why. Write only after the user confirms.
+   - If the user rejects a revision, do not write it - leave that artifact unchanged.
+   - When a substantial rewrite is needed, get that artifact's rules and template first:
+     ```bash
+     openspec instructions "<artifact-id>" --change "<name>" --json
+     ```
+
+6. **Point to the next step (guidance only - NEVER act on it)**
+   - Artifacts still missing -> suggest `/opsx:continue` to create them.
+   - Change already implemented (tasks checked off / already applied) -> the code may no longer match the revised plan; suggest `/opsx:apply` to carry the delta into code.
+   - Everything done and implemented -> suggest `/opsx:archive`.
+
+**Output**
+
+After each invocation, show:
+- Which artifacts were revised (and which proposed revisions were rejected)
+- Anything deferred to `/opsx:continue` (not-yet-created artifacts or files)
+- Where the change stands and the recommended next command
+
+**Guardrails**
+- Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to `/opsx:apply`.
+- Use the artifact ids and paths reported by `openspec status`; never branch on hardcoded artifact names.
+- Edit only the concrete files in `existingOutputPaths`; never write to a glob `resolvedOutputPath`.
+- Do not advance the build frontier: no new artifacts, no new files under glob artifacts - that is `/opsx:continue`'s job.
+- Confirm every edit with the user before writing.
+- If the request changes the change's *intent* rather than refining it, first verify whether the expanded-profile `/opsx:new` workflow is available. If it is, recommend starting fresh with `/opsx:new` (the "Update vs. Start Fresh" heuristic). If it is unavailable, ask for a distinct unused change name and recommend `openspec new change "<new-change-name>"` instead.

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.8.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Once selected, treat `--store <id>` as sticky for the rest of the workflow. Every unscoped example of those commands below is shorthand: before running it, append the flag. For example, run `openspec status --change "<name>" --json --store "<id>"`, not the unscoped form shown below. Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and ask the user to select one
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+   - Optional `context`: current required project instruction input from the selected root
+   - Optional `operationGuidance`: current advisory guidance for apply
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue` (if it is not installed, run `openspec status --change "<name>" --json` to see the next artifact and `openspec instructions <artifact-id> --change "<name>" --json` for how to create it)
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+   Treat `context` as a required prompt-level input. Read and consider it, and
+   apply relevant project facts, conventions, and constraints while implementing.
+   Treat `operationGuidance` as optional additive advice. Read and consider every
+   entry, and follow entries that are applicable and compatible with the built-in
+   workflow.
+
+   Keep both fields separate from CLI-returned state, missing artifacts, tasks,
+   progress, `contextFiles`, and the built-in `instruction`. They are not
+   evidence of task completion, do not replace the built-in instruction, and do
+   not permit bypassing a blocked state. If context conflicts with the built-in
+   instruction, an explicit user choice, or a CLI-controlled value, report the
+   conflict and preserve the controlling value. If guidance is inapplicable or
+   conflicts with those controlling inputs, do not follow it and explain why.
+   These are prompt-level behavior contracts, not enforceable checks.
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+   Do not copy `context` or `operationGuidance` verbatim into implementation
+   files or planning artifacts unless the user separately asks for that content.
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+- Do not use context or operation guidance as proof that a task is complete
+- Apply relevant project context; report conflicts with controlling workflow inputs
+- Consider every guidance entry; explain any inapplicable or conflicting advice
+- Do not copy runtime context or operation guidance into implementation files or planning artifacts
+- Preserve CLI-controlled blocked/ready/all-done behavior and completion criteria
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.8.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Once selected, treat `--store <id>` as sticky for the rest of the workflow. Every unscoped example of those commands below is shorthand: before running it, append the flag. For example, run `openspec status --change "<name>" --json --store "<id>"`, not the unscoped form shown below. Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+`<capability-path>` is the spec directory relative to `specs/` (for example, `user-auth` or `identity/user-auth`). Preserve the full path from each delta spec when resolving its main spec.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and ask the user to select one
+
+   When prompting, show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:archive <other>`).
+
+   **Load current archive inputs before the existing archive checks:**
+
+   After resolving the selected change and planning root, run:
+   ```bash
+   openspec instructions archive --change "<name>" --json
+   ```
+   Keep the same selected-root flags on this command. This lookup is advisory and
+   optional: it only supplies extra prompt inputs, so it must never block archiving.
+   If it exits non-zero or returns invalid JSON — for example on an older CLI that
+   does not support this command yet — continue the archive workflow with no
+   context and no operation guidance. Do not report an error and do not stop.
+
+   A successful response may omit both optional fields. Treat `context` as a
+   required prompt-level input: read and consider it, and apply relevant project
+   facts, conventions, and constraints. Treat `operationGuidance` as optional
+   additive advice: read and consider every entry, and follow entries that are
+   applicable and compatible with the built-in archive workflow.
+
+   Keep both fields separate from built-in steps, explicit user choices, resolved
+   paths, CLI checks, and command contracts. If context conflicts with one of those
+   controlling inputs, report the conflict and preserve the controlling value. If
+   guidance is inapplicable or conflicts with a controlling input, do not follow it
+   and explain why. Do not infer replacement paths, skipped prompts, or flags from
+   either field, and do not copy their text verbatim into specs, change artifacts,
+   or archive summaries unless the user separately asks for it. These are
+   prompt-level behavior contracts, not enforceable checks.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done`, `skipped`, or other)
+
+   **If any artifacts are neither `done` nor `skipped`** (skipped artifacts satisfy the requirement - the change declares skip_specs):
+   - Display warning listing incomplete artifacts
+   - Ask the user to confirm they want to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Ask the user to confirm they want to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON as the only
+   delta-spec source. If the `specs` entry is missing or
+   `existingOutputPaths` is empty, proceed without a sync prompt and do not infer
+   delta specs from other artifacts.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `<planningHome.root>/openspec/specs/<capability-path>/spec.md` (use the store-aware `planningHome.root` from step 2, not a hardcoded repo path)
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   Route on the answer:
+   - "Cancel" — stop, do not archive
+   - "Archive without syncing" or "Archive now" — proceed to archive
+   - "Sync now" or "Sync anyway" — sync, then verify (below)
+   - Anything else — ask again rather than archiving
+
+   Before a selected sync writes any main spec, run
+   `openspec instructions specs --change "<name>" --json` once with the same
+   selected-root flags. Require a zero exit status and valid artifact-instruction
+   JSON. If the lookup fails or returns invalid JSON, report the error and stop
+   before writing any main spec or moving the change. A valid response with omitted
+   `rules` is the no-rules case. Apply returned `rules` only to the content and
+   form of main specs produced by this merge; do not use them as archive guidance,
+   change CLI behavior, or copy the rule text into any output file.
+
+   Then run the `openspec-sync-specs` workflow inline (agent-driven intelligent merge) for change '<name>', passing the delta spec analysis and the fetched specs-rule snapshot from above, and wait for it to finish. The inline sync must reuse that snapshot without fetching `specs` instructions again. Do not delegate it to a background task — step 5 would move `changeRoot` out from under a sync that is still reading it, leaving the change archived and the main specs never updated. If your agent can only run it by delegation, delegate synchronously and wait for the result.
+
+   Then re-run the comparison from the top of this step against every capability that has a delta spec in `artifactPaths.specs.existingOutputPaths` — not only the ones the sync reports it touched. A successful sync leaves nothing left to apply, so each capability must now read as already synced:
+   - ADDED requirements present
+   - MODIFIED requirements carrying the scenario and description changes named in the delta, with their other scenarios intact
+   - REMOVED requirements gone — and where this sync retired a capability (removed its last requirement, leaving `## Requirements` empty), its main spec deleted rather than left empty; a spec the sync deliberately kept and reported is also a match
+   - RENAMED requirements present under the new name and absent under the old one
+
+   If the sync failed, or any capability does not match, report what differs and stop — do not archive. Nothing has moved and `changeRoot` is intact, so the user can fix the mismatch or re-run the sync and start the archive again.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate the target name: use the change name as-is when it already starts with a `YYYY-MM-DD-` prefix; otherwise prepend the current date as `YYYY-MM-DD-<change-name>`. Never stack a second date (same rule as `openspec archive`).
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/<target-name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```markdown
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/<target-name>/
+**Specs:** <"✓ Synced to main specs" only if the step 4 verification passed; otherwise "No delta specs" or "Sync skipped">
+
+<"All artifacts complete. All tasks complete." — or, if archived with warnings, list them instead (e.g. "Archived with 2 incomplete tasks")>
+```
+
+**Guardrails**
+- Announce the selected change; prompt for selection when it is ambiguous
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, run the `openspec-sync-specs` workflow inline (agent-driven)
+- Never archive while a spec sync is still in flight — run the sync inline and verify the main specs before moving `changeRoot`
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting
+- Apply relevant runtime context and report conflicts; operation guidance remains advisory
+- Consider every guidance entry and explain any inapplicable or conflicting advice
+- Existing CLI checks, resolved paths, prompts, and command contracts are unchanged
+- Artifact rules constrain only the specs being written and are never operation guidance
+- Never copy runtime context, operation guidance, or artifact-rule text verbatim into output files

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.8.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing. For a new change, scaffold it first as described below.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Once selected, treat `--store <id>` as sticky for the rest of the workflow. Every unscoped example of those commands below is shorthand: before running it, append the flag. For example, run `openspec status --change "<name>" --json --store "<id>"`, not the unscoped form shown below. Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+Then read the project's own context from the resolved root - `<root.path>/openspec/config.yaml` (or `config.yml`). Use the `root.path` returned above, and skip this if neither file exists:
+- `context`: project background - tech stack, conventions, constraints
+- `rules`: keyed by artifact id - the entries for an artifact apply only when you write that artifact
+
+Ground your thinking in these. They are constraints for you to follow, not content to reproduce: do NOT copy them into the conversation or into any artifact you create.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+If the user asks you to capture the exploration as a new change, transition seamlessly into the requested capture:
+
+1. Run `openspec new change "<name>"` (with `--store <id>` when applicable) before creating any artifacts. Never create a new change directory under `openspec/changes/` by hand; the CLI scaffold creates required metadata such as `.openspec.yaml`. Keep the selected `--store <id>` on every applicable follow-up `status` and `instructions` command.
+2. Run `openspec status --change "<name>" --json` (append the confirmed `--store "<id>"` only for a registered standalone store), then process the requested artifacts in dependency order. For each requested artifact that is `ready`, run `openspec instructions "<artifact-id>" --change "<name>" --json` (append the confirmed `--store "<id>"` only for a registered standalone store). Before creating a requested artifact, evaluate any condition in its own `instruction` against the explored change; record a deliberate skip instead when the condition does not apply. If a requested artifact is blocked by a direct prerequisite the user did not request, run `openspec instructions "<prerequisite-id>" --change "<name>" --json` (append the confirmed `--store "<id>"` only for a registered standalone store) for that prerequisite whether it is `ready` or `blocked`. If its own `instruction` states a condition, evaluate that condition against the explored change and record a deliberate skip only when the condition does not apply. If the condition applies, or the prerequisite is not conditional, treat it as a normal prerequisite and ask before expanding the capture. Do not create an unrequested prerequisite unless the user approves.
+3. Follow the returned `template` and `instruction` fields. Read completed dependency files listed in `dependencies`, and apply `context` and `rules` as constraints without copying them into the artifact. If the instruction delegates creation to a specific skill or command, invoke it; otherwise write the artifact to `resolvedOutputPath`, using the instruction to choose a concrete path when it is a glob. Verify that the selected concrete output exists.
+4. After creating each artifact, re-run `openspec status --change "<name>" --json` (append the confirmed `--store "<id>"` only for a registered standalone store) and continue until every requested artifact is `done`, `skipped`, or was deliberately skipped because its own `instruction` stated a condition that did not apply. Tell the user about a deliberate conditional skip, remember it, and do not reconsider it. Dependencies are enablers, not gates: if a requested artifact is still `blocked` only because you deliberately skipped a conditional prerequisite, run `openspec instructions "<artifact-id>" --change "<name>" --json` (append the confirmed `--store "<id>"` only for a registered standalone store) despite the blocked status, then create it using step 3 only when those recorded conditional skips are its sole missing dependencies. If a requested artifact is blocked by a prerequisite the user did not ask to capture and cannot be conditionally skipped, explain that dependency and ask before expanding the capture.
+
+Capture the artifact(s) the user requested without asking them to invoke another workflow command. If they asked only to start a change, stop after scaffolding and show its status.
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   `<capability-path>` is the spec directory relative to `specs/` (for example, `user-auth` or `identity/user-auth`). Preserve an existing capability's full path and follow the project's established organization for new capabilities.
+
+    | Insight Type               | Where to Capture                    |
+    |----------------------------|-------------------------------------|
+    | New requirement discovered | `specs/<capability-path>/spec.md` |
+    | Requirement changed        | `specs/<capability-path>/spec.md` |
+    | Design decision made       | `design.md`                       |
+    | Scope changed              | `proposal.md`                     |
+    | New work identified        | `tasks.md`                        |
+    | Assumption invalidated     | Relevant artifact                   |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Don't manually scaffold changes** - Never create a new change directory under `openspec/changes/` by hand. Always use `openspec new change "<name>"` (with `--store <id>` when applicable) so required metadata such as `.openspec.yaml` is created before writing artifacts.
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.8.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+**Planning boundary**: This workflow creates planning artifacts only. The user request that selected or triggered this workflow authorizes planning only, even if it asks to build or fix something. Do not edit project code. After the planning artifacts are complete, stop. Do not start implementation in the same response, even if the initial request asks for it. Wait for a new user request after the artifacts are presented; then start the apply workflow.
+
+I'll create a change with the artifacts your schema defines. With the default spec-driven schema that is:
+- proposal.md (what & why)
+- `specs/<capability-path>/spec.md` (what the system must do - a delta, not the main spec)
+- design.md (how)
+- tasks.md (implementation steps)
+
+`<capability-path>` is the spec directory relative to `specs/` (for example, `user-auth` or `identity/user-auth`). Preserve an existing capability's full path and follow the project's established organization for new capabilities.
+
+When the user is ready to implement, they must start the apply workflow explicitly.
+
+---
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Once selected, treat `--store <id>` as sticky for the rest of the workflow. Every unscoped example of those commands below is shorthand: before running it, append the flag. For example, run `openspec status --change "<name>" --json --store "<id>"`, not the unscoped form shown below. Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **Understand the request and clarify material ambiguity**
+
+   If no clear input is provided, ask the user (open-ended, no preset options):
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+   If the request contains ambiguity that would materially affect scope, externally observable behavior, compatibility, or acceptance criteria, ask the user before creating the change. For minor details, make a reasonable assumption and record it in the planning artifacts.
+
+2. **Determine the workflow schema**
+
+   Use the configured default schema unless the user explicitly requests a different workflow.
+
+   **Use a different schema only if the user:**
+   - Explicitly requests a specific schema by name → use `--schema <schema-name>`
+   - Asks to "show workflows" or asks "what workflows" exist → resolve the authoritative root by running `openspec context --json` from the current working directory. If the user explicitly selected a registered store, use `openspec context --json --store "<store-id>"`. Then run `openspec schemas --json` with its working directory set to the returned `root.path` and let them choose. This preserves roots selected by a local `store:` pointer or the global `defaultStore`; `schemas` does not accept `--store`. If context reports only `no_openspec_root`, run `openspec schemas --json` from the current working directory instead. Do not use this fallback for invalid or unavailable stores.
+
+   Otherwise, omit `--schema` to preserve the configured default.
+
+3. **Create the change directory**
+
+   Choose one schema form below. If a registered store is selected, append `--store "<store-id>"` to that command and each later OpenSpec command shown below that accepts `--store`.
+
+   Using the configured default:
+   ```bash
+   openspec new change "<name>"
+   ```
+
+   Using an explicitly requested schema:
+   ```bash
+   openspec new change "<name>" --schema "<schema-name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+4. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts, each with its `status` and its `requires` edges (the artifact IDs it directly depends on)
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+5. **Create every artifact in the required set**
+
+   Use a todo list to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `skipped`/`warning`: present when the change declares skip_specs and this artifact must NOT be created - stop and pick another artifact
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context - always re-read them from disk, even if you saw them earlier in the conversation (the user may have edited them)
+      - If the `instruction` field delegates creation to a specific skill or command, invoke it to produce the artifact instead of writing the file yourself, then verify the artifact file exists at `resolvedOutputPath`
+      - Otherwise create the artifact file using `template` as the structure and write it to `resolvedOutputPath`. If `resolvedOutputPath` is a glob, follow `instruction` to choose the concrete file path
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until every artifact in the required set exists (not just `apply.requires`)**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - The required set is `applyRequires` plus every artifact reachable from those by following the `requires` edges in `status --json` - walk them transitively (spec-driven closes over proposal, specs, design, tasks). Leave artifacts outside that set alone
+      - `status` is file-existence only, so an `applyRequires` artifact reading `done` does NOT mean its dependencies exist - writing `tasks.md` early marks `tasks` done while `specs` was never written. Use each artifact's `requires` edges, not its `status`, to build the required set: a `done` artifact still lists what it depends on
+      - An artifact already reading `status: "skipped"` is satisfied: the change declares `skip_specs` in `.openspec.yaml`, so its files must NOT exist. Never try to create one
+      - Create every artifact in the required set that is missing, then re-check - creating one can unblock others
+      - Skip one only when `status` already reports it `skipped`, or when its own `instruction` says it is conditional: run `openspec instructions <artifact-id> --change "<name>" --json` and skip only if its `instruction` field marks it optional (e.g. "create only if..."). Spec-driven's `design.md` qualifies; `specs` qualifies only via the `skipped` status above, never by your own judgment. Tell the user, and do not reconsider it
+      - Dependencies are enablers, not gates: if a required artifact is still `blocked` only because you skipped a conditional dependency, write it anyway
+      - Stop when every artifact in the required set is `done`, `skipped`, or was deliberately skipped
+
+   c. **If an artifact requires user input** (unclear context):
+      - Ask the user to clarify
+      - Then continue with creation
+
+6. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions, plus any conditional artifact you skipped and why
+- What's ready: "All artifacts needed for implementation are ready."
+- Prompt: "The artifacts are ready for review. When you are ready, run `/opsx:apply` or ask me to apply this change."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type - it is the authoritative guidance, even for familiar artifact names
+- If the `instruction` field directs you to use a specific skill or command to create the artifact, invoke it instead of writing the artifact directly
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- The request that invoked this workflow authorizes planning only. Any implementation or apply instruction in that request does not carry forward. Do NOT implement the change, start the apply workflow, or edit project code during this workflow. After presenting the artifacts, stop and wait for a new user request to start the apply workflow
+- Create every artifact the apply phase transitively depends on, not just the ids listed in `apply.requires`
+- Always read dependency artifacts before creating a new one - re-read from disk, not from conversation memory (files may have changed since you last saw them)
+- Ask about ambiguities that would materially change scope, externally observable behavior, compatibility, or acceptance criteria; for minor details, make reasonable assumptions and record them
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-sync-specs/SKILL.md
+++ b/.claude/skills/openspec-sync-specs/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: openspec-sync-specs
+description: Sync delta specs from a change to main specs. Use when the user wants to update main specs with changes from a delta spec, without archiving the change.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.8.0"
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Once selected, treat `--store <id>` as sticky for the rest of the workflow. Every unscoped example of those commands below is shorthand: before running it, append the flag. For example, run `openspec status --change "<name>" --json --store "<id>"`, not the unscoped form shown below. Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+`<capability-path>` is the spec directory relative to `specs/` (for example, `user-auth` or `identity/user-auth`). Preserve the full path from each delta spec when resolving its main spec.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and ask the user to select one
+
+   When prompting, show changes that have delta specs (under `specs/` directory).
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:sync <other>`).
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+   The JSON includes `planningHome.root`. Main specs live under `<planningHome.root>/openspec/specs/` — use that (store-aware) root for every main-spec path below, not a hardcoded repo path. When a store is selected it points at the store, not the current repository.
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the
+   only source of delta spec paths. If the `specs` entry is missing or
+   `existingOutputPaths` is empty, report that there are no delta specs to sync,
+   do not infer them from other artifacts, and stop without requesting artifact
+   instructions or writing a main spec.
+
+   Sync every path in `existingOutputPaths` unless the caller narrowed the set.
+   A caller narrows it by naming an explicit list of complete entries from
+   `existingOutputPaths` — copy those absolute values verbatim. Archive does
+   this inline, and a user can too (for example, by selecting the entry ending
+   in `/specs/billing/invoices/spec.md`).
+   Then sync only the named paths and leave the remaining delta specs untouched:
+   bulk archive excludes a delta whose implementation it could not find, and
+   syncing it anyway would write a main spec the caller deliberately withheld.
+   Carry that narrowed selection through step 4; never widen it back to the full
+   list. If a named path is not in `existingOutputPaths`, do not sync it —
+   report it and stop, rather than dropping it silently. If the named list is
+   empty, report that there is nothing to sync and stop without writing a main
+   spec.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   Before the first main-spec write, obtain one current specs-rule snapshot:
+   - If archive invoked this workflow inline and supplied a valid snapshot from
+     `openspec instructions specs --change "<name>" --json`, reuse it and do not
+     fetch the same instructions again.
+   - Otherwise run that command once now with the same selected-root flags.
+   - If the direct lookup exits non-zero or returns invalid artifact-instruction
+     JSON, report the error and stop before writing any main spec. Do not treat the
+     failure as an absent rule set.
+   - A valid response with omitted `rules` means no artifact rules are configured
+     and the existing semantic merge continues.
+
+   Apply returned `rules` only to the content and form of the main specs produced
+   by this merge. Artifact rules are not operation guidance and cannot change
+   selected roots, delta paths, CLI checks, or workflow steps. Use their text as
+   constraints without copying it verbatim into a main spec or summary.
+
+   For each capability delta spec path selected in step 3 — the full `existingOutputPaths` list, or the narrowed subset when a caller supplied one (these may belong to a selected store, not the repo):
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `<planningHome.root>/openspec/specs/<capability-path>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios the main spec does not have yet
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+      - Retiring the capability. Delete the whole `spec.md` - and the directory once
+        nothing else is left in it - only when ALL of these hold:
+        1. removing the requirements *this run* left no requirement blocks;
+        2. the rest of the spec is well-formed (it still has a `## Purpose`);
+        3. the main spec was not already empty before this sync - if you removed
+           nothing, change nothing;
+        4. every other nonblank line in the whole file is accounted for as the
+           title, Purpose, Requirements header, or a canonical requirement's
+           statement, scenarios, or fenced examples;
+        5. the change's `.openspec.yaml` declares `retire_capabilities: true`;
+        6. the `spec.md` resolves inside the real specs root (do not follow a
+           capability-directory symlink to delete an external file).
+        If removing the selected requirements would leave no requirement blocks and
+        any retirement condition is not satisfied, do not modify the main spec. Stop
+        the sync for that capability, report the blocking condition, and tell the user
+        how to resolve it. Never write or leave an empty `## Requirements` section.
+        When only the marker is missing, say that too - it is the one thing the user
+        can add to make the retirement go through.
+      - Deleting the file also deletes its `## Purpose`; any other section blocks
+        retirement. Name Purpose when you report the retirement. Include a pasteable
+        `git checkout` only when the spec lived in the caller's checkout;
+        otherwise give checkout-scoped recovery guidance.
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+      **`## Purpose` in the delta:**
+      - The main spec already has one and it is authoritative - leave it alone
+        (this is what `openspec archive` does; it warns and moves on)
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `<planningHome.root>/openspec/specs/<capability-path>/spec.md`
+      - Add Purpose section: copy the delta's `## Purpose` body verbatim when it has one
+        (this is what `openspec archive` does); only write a brief TBD placeholder when it does not
+      - Add Requirements section with the ADDED requirements
+      - Follow the **Main Spec Format Reference** below
+
+5. **Validate updated main specs**
+
+   Run `openspec validate --specs` with the same selected-root flags used earlier.
+   If validation fails, report the problems and do not claim the sync succeeded.
+
+6. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+   - Any new main spec left with a TBD Purpose placeholder, so it gets written
+     now rather than lingering
+   - Any capability retired, naming the deleted `spec.md`, its Purpose, and
+     either a pasteable `git checkout` or checkout-scoped recovery guidance
+
+**Delta Spec Format Reference**
+
+```markdown
+## Purpose
+
+Only on a delta that introduces a brand-new capability. Seeds the new main spec.
+
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+The system SHALL keep doing the existing thing, now also handling A.
+
+#### Scenario: Scenario the main spec already has
+- **WHEN** user does X
+- **THEN** system does Y
+
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Main Spec Format Reference**
+
+Main specs are what the delta merges INTO. They must never contain delta operation headers (`## ADDED/MODIFIED/REMOVED/RENAMED Requirements`) - after syncing, every requirement lives under a single `## Requirements` section:
+
+```markdown
+# <capability> Specification
+
+## Purpose
+Short description of what this capability does and why it exists.
+
+## Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you merge rather than overwrite:
+- A MODIFIED block carries the whole requirement - body plus every scenario that survives the change. `openspec validate` and `openspec archive` both reject one that drops a scenario the main spec still has.
+- Keep anything the delta does not mention, in the main spec's existing order
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```markdown
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- Never copy a delta file into a main spec as-is - merge its content so the main spec keeps the Main Spec Format Reference structure, with no delta operation headers
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result
+- Use only `artifactPaths.specs.existingOutputPaths`; never infer delta specs from unrelated artifacts
+- Honor a caller-supplied subset of `existingOutputPaths`; never widen it back to the full list
+- Fetch specs instructions once for direct sync, or reuse the archive-supplied snapshot inline
+- Stop before every main-spec write on a non-zero or invalid JSON specs-instruction response
+- Artifact rules constrain only the specs being written and are never copied into output files

--- a/.claude/skills/openspec-update-change/SKILL.md
+++ b/.claude/skills/openspec-update-change/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: openspec-update-change
+description: Update an OpenSpec change by revising its existing planning artifacts and keeping them coherent with one another. Use when the user wants to revise a change's plan, fold new decisions into it, or reconcile its artifacts after an edit. Never edits code.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.8.0"
+---
+
+Revise a change's existing planning artifacts and keep them coherent. Never edit code.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Once selected, treat `--store <id>` as sticky for the rest of the workflow. Every unscoped example of those commands below is shorthand: before running it, append the flag. For example, run `openspec status --change "<name>" --json --store "<id>"`, not the unscoped form shown below. Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+`/opsx:continue` is an expanded-profile workflow and may not be installed. Before suggesting it anywhere below, verify that it is available. If it is unavailable, `openspec status --change "<name>" --json` shows the next artifact and `openspec instructions "<artifact-id>" --change "<name>" --json` explains how to create it.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes sorted by most recently modified, and ask the user to select one
+
+   When prompting, present the top 3-4 most recently modified changes as options, showing:
+   - Change name
+   - Schema (from `schema` field if present, otherwise "spec-driven")
+   - Status (e.g., "0/5 tasks", "complete", "no tasks")
+   - How recently it was modified (from `lastModified` field)
+
+   Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to update.
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:update <other>`).
+
+2. **Get the change's artifacts**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand current state. The response includes:
+   - `schemaName`: The workflow schema being used (e.g., "spec-driven")
+   - `artifacts`: Array of artifacts with their status ("done", "skipped", "ready", "blocked")
+   - `isPlanningComplete`: Boolean indicating if all planning artifacts are complete. Older CLI versions expose the same value as `isComplete`.
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+   The artifact ids and paths come from the active schema - do NOT assume them, and do NOT branch on hardcoded artifact names. Custom schemas must work unchanged.
+
+   The files to edit are `artifactPaths.<id>.existingOutputPaths` - the concrete files that exist on disk, already glob-expanded for glob artifacts (e.g. `specs/**/*.md`). Do NOT write to `resolvedOutputPath`: for a glob artifact it is still the glob pattern, not a real file.
+
+3. **Understand the request**
+   - If the user asked for a specific revision ("the design now uses X"), that is the starting edit.
+   - If they only said "update" / "make this coherent", treat it as a coherence review: read the existing artifacts and check them against each other for contradictions, gaps, and duplication.
+
+4. **Read and reconcile**
+   - Read the artifact(s) the request touches and the change's other existing artifacts.
+   - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
+   - Note everything that is now inconsistent, missing, or contradictory.
+   - Revise only files that already exist (`existingOutputPaths`). Do NOT create artifacts that don't exist yet, and do NOT invent new files under a glob artifact - note them and point the user to `/opsx:continue` to create them.
+   - If the change is already coherent, say so and make no edits.
+
+5. **Confirm and apply, one artifact at a time**
+   - Show each proposed revision and why. Write only after the user confirms.
+   - If the user rejects a revision, do not write it - leave that artifact unchanged.
+   - When a substantial rewrite is needed, get that artifact's rules and template first:
+     ```bash
+     openspec instructions "<artifact-id>" --change "<name>" --json
+     ```
+
+6. **Point to the next step (guidance only - NEVER act on it)**
+   - Artifacts still missing -> suggest `/opsx:continue` to create them.
+   - Change already implemented (tasks checked off / already applied) -> the code may no longer match the revised plan; suggest `/opsx:apply` to carry the delta into code.
+   - Everything done and implemented -> suggest `/opsx:archive`.
+
+**Output**
+
+After each invocation, show:
+- Which artifacts were revised (and which proposed revisions were rejected)
+- Anything deferred to `/opsx:continue` (not-yet-created artifacts or files)
+- Where the change stands and the recommended next command
+
+**Guardrails**
+- Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to `/opsx:apply`.
+- Use the artifact ids and paths reported by `openspec status`; never branch on hardcoded artifact names.
+- Edit only the concrete files in `existingOutputPaths`; never write to a glob `resolvedOutputPath`.
+- Do not advance the build frontier: no new artifacts, no new files under glob artifacts - that is `/opsx:continue`'s job.
+- Confirm every edit with the user before writing.
+- If the request changes the change's *intent* rather than refining it, first verify whether the expanded-profile `/opsx:new` workflow is available. If it is, recommend starting fresh with `/opsx:new` (the "Update vs. Start Fresh" heuristic). If it is unavailable, ask for a distinct unused change name and recommend `openspec new change "<new-change-name>"` instead.

--- a/.gitignore
+++ b/.gitignore
@@ -79,8 +79,12 @@ htmlcov/
 .playwright-mcp/
 tmp/ui_smoke/
 
-# Claude local settings
-.claude/
+# Claude local settings (personal, machine-specific)
+.claude/*
+!.claude/commands/
+!.claude/commands/**
+!.claude/skills/
+!.claude/skills/**
 
 # random mypy artifacts
 mypy_*

--- a/TODO.md
+++ b/TODO.md
@@ -131,10 +131,58 @@ new, unstarted scope (new external dependency, new tool, router wiring)
 well beyond this branch's issue #21 work, so I stopped short of drafting
 it without checking first.
 
+## Live SolidWorks verification (2026-08-11, later same session)
+
+A real SolidWorks 2026 instance turned out to be running on this machine
+after all — closed task 2.6's gap for real instead of leaving it
+theoretical:
+
+- Connected to the live session, ran the actual `SolidWorksDocsDiscovery`
+  tool (the "read docs" MCP tooling) to cross-check `GetComponents`/
+  `IComponent2`/`GetModelDoc2` against the installed SW 2026 (build
+  34.3.0) type library before trusting the implementation.
+- Exercised `list_features` against the built-in U-Joint sample —
+  `UJoint.SLDASM`, which conveniently already contains a nested
+  sub-assembly (`crank sub.SLDASM`) — and found **two real bugs neither
+  the mock adapter nor any unit test could have caught**, both late-binding
+  property-vs-method ambiguities: `document.GetType()` failing on a
+  freshly-fetched `ActiveDoc`, and `IComponent2.GetModelDoc2` needing
+  explicit `flag_methods` before it resolves. Fixed both; documented as
+  `docs/agents/com-api-pitfalls.md` items #11/#12. After the fix, a live
+  run resolved all 11 real components across 2 levels of nesting (271
+  features total) with zero `UnresolvedComponent` rows.
+- **Design refinement from your feedback**: the flat list-with-tags shape
+  was right for backward compatibility, but didn't capture actual
+  parent/child structure between components. Added a `component_parent`
+  tag (still additive/backward-compatible) plus
+  `build_component_tree()` — a pure function that reconstructs the real
+  nested tree from the flat list — exposed additively as `assembly_tree`
+  on the `list_features` MCP tool response. Verified live: `crank sub-1`'s
+  three child parts now nest correctly under it instead of sitting flat
+  alongside its top-level siblings.
+- Added a runnable demo script,
+  `docs/getting-started/tutorial-parts/list_features_assembly_demo.py`,
+  matching this repo's existing tutorial-script conventions.
+- Ran the full mock-only suite again (1903 passed, 0 failed, coverage
+  99.96%) and `dev-test-full` against the live SolidWorks session (1925
+  passed, 42 skipped, 49 failed, coverage 99.91% — gate passed). Every
+  `list_features`/assembly test passed. The 49 failures are all
+  `create_part: Failed to create new part` and are **confirmed
+  pre-existing and unrelated** to this change — they reproduce identically
+  with this branch's commits `git stash`-ed, and persist even with every
+  document closed, so it's not a too-many-open-docs issue either. Looks
+  like degraded state in the long-running `SLDWORKS.exe` process itself
+  after hours of automation churn this session. Flagging for you — a
+  SolidWorks restart is the likely fix, but I didn't restart your live
+  application unprompted.
+
 ## Next steps
 
 1. Open the PR for `assembly-aware-list-features` referencing issue #21
-   and this OpenSpec change, noting task 2.6 as a live-SolidWorks
-   follow-up.
-2. Decide whether to draft a second OpenSpec change for #43 now or later
+   and this OpenSpec change. Task 2.6 is now fully closed (verified live,
+   not just theoretical).
+2. Separately: `create_part` is currently failing in your live SolidWorks
+   session for reasons unrelated to this branch — worth a SolidWorks
+   restart before your next real-integration test run.
+3. Decide whether to draft a second OpenSpec change for #43 now or later
    (separate branch either way, since #42 is its prerequisite).

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,140 @@
+# TODO — OpenSpec adoption + assembly-aware `list_features`
+
+Branch: `feat/issue-21-openspec-assembly-list-features`
+Date: 2026-08-11
+
+## Initial assessment
+
+Two independent asks came in together:
+
+1. Adopt an OpenSpec-style ("spec-driven development") workflow for this
+   repo, as a repo-usability improvement in its own right.
+2. Pick a good feature issue and implement it *using* that workflow, as the
+   first real proof that the process works.
+3. Validate PR #49 (`fix/save-file-data-loss`) before treating it as safe,
+   since it's a data-loss bug fix and "very fundamental."
+
+Repo already had informal versions of (1): `CONTRIBUTING.md` documents a
+process, `docs/planning/` exists for roadmap docs, and issue #23 shows a
+contributor (Pedro) writing an ad hoc planning doc in their fork before
+starting a large multi-phase proposal. There was no shared, tool-enforced
+convention for *how* a proposal → spec → design → tasks sequence should
+look, so adopting OpenSpec formalizes something the repo was already
+reaching for informally.
+
+## Questions asked and answers received
+
+**Q1: Lightweight in-repo convention vs. the real OpenSpec CLI?**
+→ **Adopt the actual OpenSpec CLI** (`@fission-ai/openspec`). Not the
+lightweight custom-template option.
+
+**Q2: Which issue should be the first spec-driven change?**
+→ **#21, assembly-aware `list_features`**. Chosen over #23 (a large,
+multi-phase proposal better suited to being *its own* future OpenSpec
+change, not a first example) for being self-contained, having clear
+acceptance criteria, and directly improving usability for the most common
+real document type (assemblies).
+
+## OpenSpec setup
+
+- Node.js wasn't installed (Python-only toolchain). Installed via
+  `winget install OpenJS.NodeJS.LTS` with explicit confirmation first,
+  since it's a machine-wide dependency add.
+- Verified package identity before running anything: the bare `openspec`
+  npm package is an unrelated 2019 placeholder (1.3 kB, v0.0.0, different
+  GitHub repo). The real tool is `@fission-ai/openspec`
+  (github.com/Fission-AI/OpenSpec), confirmed via `npm search` — GitHub
+  Actions OIDC-published, current (v1.8.0 at time of writing).
+- Ran `openspec init --tools claude`, which scaffolded `openspec/` and
+  `.claude/commands/opsx/*` + `.claude/skills/openspec-*` (6 slash
+  commands, 6 skills) for the spec-driven workflow.
+- **Fixed `.gitignore`**: `.claude/` was fully ignored repo-wide, which
+  would have made the new OpenSpec commands/skills invisible to every
+  other contributor and to CI — silently defeating the point of adopting
+  a *shared* workflow. Scoped the ignore so `.claude/commands/` and
+  `.claude/skills/` are tracked while the rest of `.claude/` (personal
+  settings, local session state) stays ignored.
+- Populated `openspec/config.yaml` with real project context (adapter
+  architecture, COM threading invariants, testing commands) so
+  AI-generated proposals/specs/designs are grounded in this repo's actual
+  constraints rather than generic boilerplate.
+
+## Issue #21 change: `assembly-aware-list-features`
+
+Full proposal/specs/design/tasks live at
+`openspec/changes/assembly-aware-list-features/` and pass
+`openspec validate --strict`.
+
+**Important correction made during design, before any code was written**:
+issue #21's literal acceptance criteria sketch a nested response shape
+(`{"type", "components", "assembly_features"}`). Tracing actual callers of
+`adapter.list_features().data` found **four** existing places that assume
+it's a flat `list[dict]` unconditionally — the MCP tool's `count`/`features`
+fields, `classify_feature_tree`, `soc_pickup.py`'s feature-tree diffing
+(SolidWorks-as-Code pickup), and the UI's `model_service.py`. Shipping the
+issue's literal shape would have silently broken SoC pickup diffing and the
+UI feature panel for every assembly.
+
+**Resolution** (recorded in `design.md`): keep the response a flat list for
+every document type. Each feature descriptor gains two new optional keys,
+`component` and `component_path` (both `None` for a document's own
+features, matching today's Part behavior exactly). Assembly features get
+flattened into the same list, tagged by which component they came from,
+recursing into sub-assemblies up to a new optional `max_assembly_depth`
+parameter (default 2). This satisfies the issue's actual goal
+(component-scoped feature visibility) without an API shape that breaks
+working code.
+
+## Implementation status: done, pending one live-SolidWorks check
+
+All `tasks.md` items implemented and checked off except 2.6/6.2 (verifying
+the `IComponent2.GetModelDoc2` accessor against a live SolidWorks session —
+impossible in this environment, no SolidWorks installed). Full suite:
+1898 passed, 0 failed, 40 skipped, 73 `solidworks_only` deselected,
+coverage 99.98%. `ruff check` clean on every changed file (one pre-existing,
+unrelated `UP046` in `base.py`, confirmed identical on `main`).
+
+One self-inflicted detour worth recording: an early `ruff check src tests
+--fix` (scoped too broadly) auto-removed imports in `ui/service.py` and
+`ui/services/llm_service.py` that looked unused to static analysis but are
+actually re-exports test code monkeypatches by module-attribute name —
+broke 9 unrelated UI tests. Caught it by re-running the full suite,
+reverted both files, confirmed green again. Lesson: scope `ruff --fix` to
+the files actually being touched, not the whole tree.
+
+## Text-to-cad integration (#43) — investigated, not started
+
+Looked at #43 and its prerequisite #42 (skill-routing layer) at your
+request, to see where the OpenSpec commands/skills just set up could plug
+in. Finding: **no direct code-level overlap** — two different meanings of
+"skill" collide in name only:
+
+- OpenSpec's `.claude/commands/opsx/*` + `.claude/skills/openspec-*` are
+  Claude Code dev-tooling: they help *me* (or any contributor using Claude
+  Code) plan changes to *this repo's own source*.
+- The `#42`/`#43` "skill family" router (`solidworks-native` /
+  `text-to-cad` / `mesh-concept`) is *runtime* orchestration code
+  (`src/solidworks_mcp/ui/services/skill_router.py`, per #42's proposed
+  shape) that routes an end-user's MCP tool calls — it sits above the
+  existing `IntelligentRouter`/`ComplexityAnalyzer` COM/VBA routing and is
+  unrelated to Claude Code's own skill-loading.
+- The `cad` skill from `earthtojake/text-to-cad` (#43) *is* a Claude Code
+  plugin skill (`claude plugin install cad@text-to-cad`), so it lives in
+  the same `.claude/` namespace as OpenSpec's skills, but that's a shared
+  install location, not a shared code path.
+
+Where OpenSpec *does* apply directly: #43 is already written almost
+exactly like an OpenSpec proposal (Summary/Research/Non-goals/Acceptance
+criteria) and depends on #42 landing first. It's a strong candidate for a
+second `openspec/changes/` entry once you want to start it — but that's
+new, unstarted scope (new external dependency, new tool, router wiring)
+well beyond this branch's issue #21 work, so I stopped short of drafting
+it without checking first.
+
+## Next steps
+
+1. Open the PR for `assembly-aware-list-features` referencing issue #21
+   and this OpenSpec change, noting task 2.6 as a live-SolidWorks
+   follow-up.
+2. Decide whether to draft a second OpenSpec change for #43 now or later
+   (separate branch either way, since #42 is its prerequisite).

--- a/docs/agents/com-api-pitfalls.md
+++ b/docs/agents/com-api-pitfalls.md
@@ -245,6 +245,68 @@ await adapter.create_cut_extrude(
 
 ---
 
+## 11. `GetType()` resolves as a property, not a method, on a freshly-fetched `ActiveDoc`
+
+**Symptom:** `TypeError: 'int' object is not callable` when calling `document.GetType()` —
+but the *identical* call on a document just returned by `OpenDoc6`/`NewDocument` works fine.
+If this exception is caught by a broad `except Exception: return default` (e.g. this
+codebase's `_attempt` helper), the failure is silent: the caller just sees `doc_type == 0`
+and takes the wrong branch (e.g. treating an Assembly as unrecognized).
+
+**Root cause:** Late-bound COM dispatch resolves an unknown member name speculatively —
+sometimes as a callable method wrapper, sometimes by eagerly invoking it and returning the
+*value* (property semantics). Which one you get depends on whether the specific dispatch
+object has been flagged for its real interface via `sw_type_info.flag_doc`/`flag_methods`
+(`_FlagAsMethod`). A document object returned directly by `OpenDoc6` in this codebase's
+adapter is flagged immediately after open. A document re-fetched via `swApp.ActiveDoc` in a
+later call (e.g. a resync-before-traversal step) is a **new, unflagged** dispatch wrapping
+the same underlying document — `GetType` on it resolves as a property, and calling it with
+`()` tries to call the returned `int`.
+
+**Fix:** Never call a zero-arg accessor on a document/feature/component with bare
+parentheses unless you know it has just been flagged. Route through the existing
+`_get_attr_or_call(obj, "MethodName")` helper, which handles both property and method
+resolution:
+
+```python
+doc_type = adapter._attempt(
+    lambda: int(adapter._get_attr_or_call(document, "GetType") or 0), default=0
+)
+```
+
+Found and fixed 2026-08-11 while verifying assembly-aware `list_features`
+(`_FeatureSelectionService.list_features` in `pywin32_adapter.py`) against a live
+SolidWorks session — see `openspec/changes/assembly-aware-list-features/`.
+
+## 12. `IComponent2.GetModelDoc2` raises "Member not found" unless `IComponent2` is flagged first
+
+**Symptom:** `pywintypes.com_error: (-2147352573, 'Member not found.', None, None)` when
+calling `component.GetModelDoc2()` on an `IComponent2` object returned by
+`IAssemblyDoc.GetComponents`, even though `getattr(component, "GetModelDoc2", None)`
+returns something that looks callable.
+
+**Root cause:** Same late-binding ambiguity as #11 and #5, but manifesting as a COM error
+instead of a Python `TypeError`: dynamic dispatch returns a speculative callable wrapper for
+an attribute name it hasn't resolved a real DISPID for yet, and that wrapper only fails once
+actually invoked. `IComponent2` is never flagged anywhere else in the traversal — components
+come from `GetComponents`, not from `flag_doc` (which only knows about document-level
+interfaces: `IPartDoc`/`IAssemblyDoc`/`IDrawingDoc`).
+
+**Fix:** Flag the component for `IComponent2` before calling any of its methods:
+
+```python
+sw_type_info.flag_methods(component, "IComponent2")
+resolved_doc = adapter._get_attr_or_call(component, "GetModelDoc2")
+```
+
+Found and fixed 2026-08-11 alongside #11, in the same live-verification pass. Before this
+fix, every component in a real assembly resolved as `UnresolvedComponent` — the traversal
+logic itself was correct (confirmed by unit tests against mock COM fakes), but nothing had
+ever exercised it against a real, unflagged `IComponent2` dispatch until then. A reminder
+that mock-adapter tests validate the *shape* of a fix, not COM binding behavior itself.
+
+---
+
 ## Reference: Where to look things up
 
 | Question | Where to look |

--- a/docs/getting-started/tutorial-parts/list_features_assembly_demo.py
+++ b/docs/getting-started/tutorial-parts/list_features_assembly_demo.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+r"""Demo: assembly-aware ``list_features`` (GitHub issue #21).
+
+Connects to a running SolidWorks instance and calls ``list_features`` on
+both a Part and an Assembly from the built-in U-Joint sample set, showing
+the behavior added by the ``assembly-aware-list-features`` OpenSpec change
+(see ``openspec/changes/assembly-aware-list-features/``):
+
+- A Part's own features are unchanged from before this change.
+- An Assembly's response flattens in every resolved component's features
+  alongside the assembly's own, each descriptor tagged with ``component``/
+  ``component_path``/``component_parent`` (``None`` for the document's own
+  features). The adapter contract stays a flat list on purpose - see
+  design.md for why - but ``component_parent`` carries enough information
+  to reconstruct the real nested tree, which
+  ``build_component_tree`` (``solidworks_mcp.utils.feature_tree_classifier``)
+  does for callers who want to look at the assembly structure rather than
+  scan a flat, tagged list.
+- Sub-assemblies are recursed into up to ``max_assembly_depth`` (default 2):
+  ``UJoint.SLDASM`` contains a sub-assembly, ``crank sub.SLDASM``, whose own
+  three part components (crank-arm, crank-knob, crank-shaft) show up
+  correctly nested *under* ``crank sub-1`` in the tree view, not flattened
+  alongside its top-level siblings.
+
+Read-only: does not save or modify any document. Requires Windows +
+SolidWorks running with the U-Joint sample installed (ships with SolidWorks
+under ``…\samples\learn\U-Joint\``).
+
+API surface used here (``GetType``, ``GetComponents``, ``IComponent2.
+GetModelDoc2``) was cross-checked against the live SolidWorks installation
+via this repo's own ``discover_solidworks_docs``/``SolidWorksDocsDiscovery``
+tooling (``src/solidworks_mcp/tools/docs_discovery.py``). See
+``docs/agents/com-api-pitfalls.md`` items #11 and #12 for the two
+late-binding bugs found and fixed while first running this demo against a
+live SolidWorks session (2026-08-11) — the traversal logic passed every
+mock-adapter unit test but still failed on real COM until those fixes
+landed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "src"))
+
+from solidworks_mcp.adapters import create_adapter
+from solidworks_mcp.config import load_config
+from solidworks_mcp.utils.feature_tree_classifier import build_component_tree
+
+U_JOINT_DIR = Path(
+    r"C:\Users\Public\Documents\SOLIDWORKS\SOLIDWORKS 2026\samples\learn\U-Joint"
+)
+UJOINT_ASSEMBLY = U_JOINT_DIR / "UJoint.SLDASM"
+YOKE_MALE_PART = U_JOINT_DIR / "Yoke_male.sldprt"
+
+
+def unwrap_adapter(adapter: Any) -> Any | None:
+    """Walk the adapter chain to find the raw PyWin32Adapter (has swApp)."""
+    current: Any | None = adapter
+    visited: set[int] = set()
+    while current is not None and id(current) not in visited:
+        visited.add(id(current))
+        if hasattr(current, "swApp") and hasattr(current, "currentModel"):
+            return current
+        current = getattr(current, "adapter", None)
+    return None
+
+
+def print_tree(node: dict[str, Any], indent: int = 0) -> None:
+    """Print a build_component_tree() result as an indented outline."""
+    pad = "  " * indent
+    print(f"{pad}({len(node['features'])} own features)")
+    for name, child in sorted(node["components"].items()):
+        print(f"{pad}{name}  [{child['path']}]")
+        print_tree(child, indent + 1)
+
+
+def print_features(label: str, rows: list[dict[str, Any]], limit: int = 8) -> None:
+    """Print a compact summary of a list_features result."""
+    print(f"\n--- {label} ---")
+    print(f"total descriptors: {len(rows)}")
+    own = [r for r in rows if r["component"] is None]
+    by_component: dict[str, int] = {}
+    for row in rows:
+        comp = row["component"]
+        if comp:
+            by_component[comp] = by_component.get(comp, 0) + 1
+    print(f"document's own features (component=None): {len(own)}")
+    if by_component:
+        print("features per component:")
+        for name, count in sorted(by_component.items()):
+            print(f"  {name}: {count}")
+    print(f"first {min(limit, len(rows))} descriptors:")
+    for row in rows[:limit]:
+        print(f"  {row}")
+
+
+async def main() -> None:
+    config = load_config()
+    adapter = await create_adapter(config)
+    await adapter.connect()
+    raw = unwrap_adapter(adapter)
+
+    def close_all() -> None:
+        # Close everything between steps so ActiveDoc is unambiguous - a
+        # part already loaded as an assembly component doesn't reliably
+        # become the active document otherwise.
+        if raw is not None and raw.swApp is not None:
+            raw.swApp.CloseAllDocuments(True)
+
+    try:
+        close_all()
+
+        print("=" * 72)
+        print("PART — Yoke_male.sldprt")
+        print("Unchanged behavior: every feature has component=None,")
+        print("exactly like list_features returned before this change.")
+        print("=" * 72)
+        result = await adapter.open_model(str(YOKE_MALE_PART))
+        if not result.is_success:
+            print(f"open_model failed: {result.error}")
+            return
+        feat_result = await adapter.list_features(include_suppressed=False)
+        if not feat_result.is_success:
+            print(f"list_features failed: {feat_result.error}")
+            return
+        print_features("Yoke_male.sldprt", feat_result.data)
+
+        close_all()
+
+        print("\n" + "=" * 72)
+        print("ASSEMBLY — UJoint.SLDASM (contains a nested sub-assembly)")
+        print("Every top-level component's features are flattened in,")
+        print("tagged by component name/path. The sub-assembly 'crank sub-1'")
+        print("is recursed into (max_assembly_depth=2 default), surfacing")
+        print("its own three part components too.")
+        print("=" * 72)
+        result = await adapter.open_model(str(UJOINT_ASSEMBLY))
+        if not result.is_success:
+            print(f"open_model failed: {result.error}")
+            return
+        feat_result = await adapter.list_features(
+            include_suppressed=False, max_assembly_depth=2
+        )
+        if not feat_result.is_success:
+            print(f"list_features failed: {feat_result.error}")
+            return
+        print_features("UJoint.SLDASM", feat_result.data, limit=5)
+
+        unresolved = [
+            r for r in feat_result.data if r["type"] == "UnresolvedComponent"
+        ]
+        print(f"\nUnresolvedComponent rows: {len(unresolved)} (expect 0)")
+
+        print("\n--- nested component tree (build_component_tree) ---")
+        print("Same data as above, reshaped so 'crank sub-1's three parts")
+        print("nest under it instead of sitting flat alongside its siblings:")
+        tree = build_component_tree(feat_result.data)
+        print_tree(tree)
+
+    finally:
+        close_all()
+        await adapter.disconnect()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/getting-started/tutorial-parts/list_features_assembly_demo.py
+++ b/docs/getting-started/tutorial-parts/list_features_assembly_demo.py
@@ -158,7 +158,7 @@ async def main() -> None:
 
         print("\n--- nested component tree (build_component_tree) ---")
         print("Same data as above, reshaped so 'crank sub-1's three parts")
-        print("nest under it instead of sitting flat alongside its siblings:")
+        print("nest under each part instead of sitting flat alongside its sibling components:")
         tree = build_component_tree(feat_result.data)
         print_tree(tree)
 

--- a/openspec/changes/assembly-aware-list-features/.openspec.yaml
+++ b/openspec/changes/assembly-aware-list-features/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/assembly-aware-list-features/design.md
+++ b/openspec/changes/assembly-aware-list-features/design.md
@@ -1,0 +1,152 @@
+## Context
+
+`list_features` today is `_FeatureSelectionService.list_features` in
+`pywin32_adapter.py` (mirrored by `mock_adapter.py`, wrapped by
+`circuit_breaker.py` and `connection_pool.py`, exposed via the async
+`SolidWorksSelectionMixin.list_features` in `adapters/solidworks/selection.py`).
+It walks `currentModel.FirstFeature()` / `GetNextFeature()` plus a
+`FeatureByPositionReverse` fallback pass against a single document's feature
+manager. It never inspects document type and never looks at assembly
+components — see proposal.md for why that's a problem.
+
+`adapter.list_features().data` is consumed as a flat `list[dict]` in four
+places already: the `list_features` MCP tool (`count = len(result.data)`,
+`"features": result.data or []`), `classify_feature_tree`
+(`classify_feature_tree_snapshot(model_info, features)`), `soc_pickup.py`'s
+`_new_features` diffing (compares entries by `name`), and the UI's
+`model_service.py` (`isinstance(feature_result.data, list)`). None of these
+are optional call sites to migrate later — they're existing, in-use
+behavior (SoC pickup diffing and the UI feature panel).
+
+The codebase already has the pieces this needs: `sw_type_info.flag_doc(obj,
+doc_type)` for method-flagging a newly-acquired document dispatch,
+`DOC_TYPE_TO_INTERFACES` mapping `GetType()`'s 1/2/3 to Part/Assembly/
+Drawing, and `_DocumentRoutingService.document_identity(document)` for
+robust path/title extraction that already handles COM objects exposing
+`GetPathName`/`GetTitle` as either methods or properties.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Assemblies return every component's features, not just the assembly's
+  own planes/origin/mates.
+- Zero behavior change for Part documents.
+- Zero behavior change for the four existing consumers of
+  `list_features().data` unless they choose to read the new
+  `component`/`component_path` keys.
+
+**Non-Goals:**
+- Matching issue #21's literal `{type, components, assembly_features}`
+  JSON sketch. That shape is superseded by the flat-list-plus-tag design
+  below (see Decisions) — the issue's acceptance criteria are satisfied in
+  spirit (per-component feature visibility, `include_suppressed` at both
+  levels, bounded recursion) but not in literal response shape.
+- Assembly mate enumeration, BOM data, or configuration-specific feature
+  suppression — out of scope, tracked separately under issue #23's phased
+  tool-surface proposal.
+- Changing `list_features`'s required parameters. `include_suppressed`
+  keeps its meaning and position; `max_assembly_depth` is additive and
+  optional.
+
+## Decisions
+
+### Decision: Flat list with `component`/`component_path` tags, not a nested response
+
+**Chosen**: Keep `AdapterResult[list[dict[str, Any]]]` as the return type
+for every document type. For Assembly documents, concatenate the
+assembly's own features with every resolved component's features into one
+list. Each descriptor gets two new optional keys: `component` (the owning
+component's name, or `None` for the document's own features) and
+`component_path` (that component's resolved document path, or `None`).
+
+**Rejected alternative**: Return a structured object
+(`{"type": ..., "components": [...], "assembly_features": [...]}`) as
+issue #21 sketches. Rejected because `AdapterResult.data`'s type would
+then depend on document type (list for Parts, dict for Assemblies), and
+four existing call sites assume `list[dict]` unconditionally:
+`len(result.data)` in the MCP tool, `classify_feature_tree_snapshot`,
+`soc_pickup.py`'s name-based feature diffing, and `model_service.py`'s
+`isinstance(..., list)` guard. Shipping the nested shape would silently
+degrade SoC pickup diffing and the UI's feature panel for every assembly
+— a regression, not just an inconvenience for future callers.
+
+**Rejected alternative**: A new sibling adapter method (e.g.
+`list_assembly_components`) that leaves `list_features` untouched.
+Rejected because it doesn't address the actual complaint in issue #21 —
+`list_features` itself stays blind to assembly contents — and it would
+give agents two tools to call and reconcile instead of one, working
+against the "read-before-write" workflow `list_features` exists for.
+
+### Decision: Component traversal lives in `_FeatureSelectionService`, doc-type branch first
+
+`_FeatureSelectionService.list_features` (sync, runs inside
+`_handle_com_operation` on the adapter's COM executor thread — no new
+threading) gets a document-type check up front via
+`currentModel.GetType()` against the existing `swDocASSEMBLY` constant.
+Part and Drawing documents fall through to exactly the current code path
+unchanged. Assembly documents additionally call a new private helper,
+`_list_assembly_component_features(assembly_doc, include_suppressed,
+depth_remaining)`, which:
+1. Calls `assembly_doc.GetComponents(True)` (top-level only) to get
+   `IComponent2` instances.
+2. For each, resolves the underlying document (trying `GetModelDoc2`,
+   consistent with this codebase's existing `_get_attr_or_call` fallback
+   pattern for COM members that may bind as method or property — the
+   exact accessor needs confirming against a live SolidWorks session per
+   `docs/agents/com-api-pitfalls.md`; flagged as a risk below).
+3. Applies `sw_type_info.flag_doc(resolved_doc, resolved_doc.GetType())`
+   before touching it, per the COM threading/late-binding invariants in
+   CLAUDE.md.
+4. Reuses the existing `list_features`/`_append_feature_to` traversal
+   against the resolved document, then tags every resulting descriptor
+   with `component`/`component_path` via `_DocumentRoutingService
+   .document_identity`.
+5. If `resolved_doc.GetType()` is itself Assembly and `depth_remaining >
+   0`, recurses with `depth_remaining - 1`; at `depth_remaining == 0`,
+   emits one descriptor for the sub-assembly component itself (name +
+   path, no nested features) instead of recursing further.
+6. If the component can't be resolved at all, emits one synthetic
+   descriptor (`type: "UnresolvedComponent"`) instead of raising.
+
+### Decision: `max_assembly_depth` is a new optional parameter, default 2
+
+Threaded through the abstract method (`base.py`), both adapters
+(`pywin32_adapter.py`, `mock_adapter.py`), the wrapping layers
+(`circuit_breaker.py`, `connection_pool.py`), and optionally exposed on
+`ListFeaturesInput` (currently only `include_suppressed`) for MCP callers
+who want to override it. Default of 2 matches the issue's ask and covers
+the common one-level-of-sub-assembly case without unbounded recursion risk
+on deeply nested assemblies.
+
+## Risks / Trade-offs
+
+- [Risk] The exact COM accessor for "get an `IComponent2`'s underlying
+  document" (`GetModelDoc2` vs. a differently-cased or differently-shaped
+  member under late binding) can't be verified without a live SolidWorks
+  session — this environment has none. → Mitigation: implement using the
+  same `_get_attr_or_call`/`_attempt` defensive pattern already used
+  throughout `pywin32_adapter.py` for COM members with binding ambiguity,
+  add a mock-adapter fixture that exercises the intended shape, and flag
+  this explicitly for verification on `dev-test-full` (real SolidWorks)
+  before merge, per CLAUDE.md's testing guidance.
+- [Risk] Deeply nested or very large assemblies could make `list_features`
+  slow (resolving and traversing many component documents). →
+  Mitigation: `max_assembly_depth` default of 2 bounds recursion; this is
+  a read-only, no-rebuild operation so no COM rebuild cost is added.
+- [Risk] Two components could legitimately share a `name`/`type` pair
+  (e.g. two instances of the same part), which would collide with the
+  existing per-document `(name, type)` dedupe-`seen` set if that set were
+  reused across components. → Mitigation: the dedupe set is scoped per
+  resolved document (as it is today, per document), not shared across
+  the whole assembly traversal — each component's traversal gets its own
+  `seen` set.
+- [Trade-off] `component`/`component_path` being `None` for both "this is
+  the document's own feature" and "no component information available"
+  is slightly ambiguous, but matches the simplest interpretation
+  consumers will already apply (`if feature.get("component"): ...`) and
+  avoids adding a third state.
+
+## Open Questions
+
+None — the shape decision above was the one open question that would
+have changed the spec or task breakdown, and it's resolved.

--- a/openspec/changes/assembly-aware-list-features/design.md
+++ b/openspec/changes/assembly-aware-list-features/design.md
@@ -118,17 +118,62 @@ who want to override it. Default of 2 matches the issue's ask and covers
 the common one-level-of-sub-assembly case without unbounded recursion risk
 on deeply nested assemblies.
 
+### Decision: `component_parent` tag + a derived nested-tree helper, not a nested adapter contract
+
+**Chosen** (added after initial review): the flat list stays the adapter
+contract (see the first Decision above — that constraint didn't change),
+but every descriptor gains a third tag, `component_parent`: the immediate
+parent component's name, or `None` for a top-level component or a
+document's own feature. This is enough information to reconstruct real
+parent/child structure between components — e.g. that `crank-arm-1` is
+nested *inside* `crank sub-1`, not merely "also present somewhere in this
+assembly" — which the two-tag (`component`/`component_path`) version
+could not express.
+
+`build_component_tree(features)` in
+`solidworks_mcp.utils.feature_tree_classifier` is a pure function that
+walks the flat list once and rebuilds
+`{"features": [...], "components": {name: {"path", "features",
+"components"}}}` using `component_parent` as the parent-link. It's exposed
+as an additive `assembly_tree` field on the `list_features` MCP tool
+response, alongside the unchanged `features`/`count` fields — so a
+consumer that wants the flat tag-and-scan view still gets it unmodified,
+and a consumer that wants to look at assembly structure (the ask this
+decision responds to) gets a real tree without the adapter contract itself
+depending on document type.
+
+**Rejected alternative**: infer parent/child structure after the fact by
+matching `component_path` prefixes or by assuming a sub-assembly's
+features always appear contiguously with its children in the flat list.
+Rejected because it's fragile (relies on traversal order as an implicit
+data channel) where an explicit tag is one field and one line of
+propagation through the existing recursion.
+
 ## Risks / Trade-offs
 
-- [Risk] The exact COM accessor for "get an `IComponent2`'s underlying
-  document" (`GetModelDoc2` vs. a differently-cased or differently-shaped
-  member under late binding) can't be verified without a live SolidWorks
-  session — this environment has none. → Mitigation: implement using the
-  same `_get_attr_or_call`/`_attempt` defensive pattern already used
-  throughout `pywin32_adapter.py` for COM members with binding ambiguity,
-  add a mock-adapter fixture that exercises the intended shape, and flag
-  this explicitly for verification on `dev-test-full` (real SolidWorks)
-  before merge, per CLAUDE.md's testing guidance.
+- [Risk — RESOLVED 2026-08-11] The exact COM accessor for "get an
+  `IComponent2`'s underlying document" couldn't be verified without a live
+  SolidWorks session when this was written. A SolidWorks 2026 instance
+  became available mid-implementation; verified live against the built-in
+  U-Joint sample (`UJoint.SLDASM`, with nested sub-assembly `crank
+  sub.SLDASM`). `GetModelDoc2` is the correct member name, but two real,
+  live-only bugs surfaced that no mock-adapter test could have caught —
+  both property-vs-method late-binding ambiguities, now documented as
+  `docs/agents/com-api-pitfalls.md` items #11 and #12:
+  1. `document.GetType()` called with bare parens raised `TypeError:
+     'int' object is not callable` on a freshly-fetched `swApp.ActiveDoc`
+     (resolves as a property there, unlike a document just returned by
+     `OpenDoc6`) — silently swallowed by `_attempt`, so the doc-type check
+     always fell back to `0` and the assembly branch never ran.
+  2. `IComponent2.GetModelDoc2` raised `com_error: Member not found` on
+     every component because `IComponent2` was never flagged via
+     `sw_type_info.flag_methods` before calling it.
+  Both fixed by routing through `_get_attr_or_call` / adding the missing
+  `flag_methods(component, "IComponent2")` call. After the fix, a live run
+  resolved all 11 real components across 2 levels of nesting with zero
+  `UnresolvedComponent` rows. This validates the original mitigation
+  (defensive `_get_attr_or_call`/`_attempt` pattern) as the right shape —
+  it just hadn't been applied to these two specific call sites yet.
 - [Risk] Deeply nested or very large assemblies could make `list_features`
   slow (resolving and traversing many component documents). →
   Mitigation: `max_assembly_depth` default of 2 bounds recursion; this is

--- a/openspec/changes/assembly-aware-list-features/proposal.md
+++ b/openspec/changes/assembly-aware-list-features/proposal.md
@@ -1,0 +1,81 @@
+## Why
+
+`list_features` only reads the top-level document's feature manager. Called on
+an `.SLDASM`, it returns assembly-level features only — planes, origin, mates,
+assembly sketches — and is blind to every sub-component's feature tree. For a
+tool whose entire value is letting an LLM agent understand and reason about a
+SolidWorks document, this makes the single most common real-world document
+type (an assembly of parts) effectively unreadable. Closes GitHub issue #21.
+
+## What Changes
+
+- `list_features` detects document type. For a Part (`.SLDPRT`), behavior is
+  byte-for-byte unchanged.
+- For an Assembly (`.SLDASM`), it additionally:
+  - Enumerates top-level component instances via `IAssemblyDoc.GetComponents`.
+  - For each component, resolves its underlying `IModelDoc2` (part or
+    sub-assembly) and runs the existing feature-tree traversal against it.
+  - Recurses into sub-assemblies up to a configurable depth (default 2, via
+    a new optional `max_assembly_depth` parameter).
+  - Returns every feature — the assembly's own plus every resolved
+    component's — **as a single flat list**, matching the existing return
+    shape. Each feature dict gains two new optional keys, `component` and
+    `component_path`, identifying which component (if any) it came from.
+    An assembly's own features keep `component: None`, exactly like a
+    Part's features do today.
+  - A component whose underlying document cannot be resolved (suppressed,
+    lightweight-and-unloaded, missing file) is represented by one synthetic
+    marker row rather than silently dropped or raising.
+- `include_suppressed` continues to work, now applied independently to the
+  assembly's own features and to each component's features.
+- Adds a mock-adapter assembly fixture so the new branch is covered without
+  SolidWorks installed.
+
+**Deliberately not the nested `{components, assembly_features}` shape
+sketched in GitHub issue #21.** `adapter.list_features().data` is consumed
+as a flat `list[dict]` in four places today (the `list_features` MCP tool's
+`count`/`features` fields, `classify_feature_tree`, `soc_pickup.py`'s
+feature-tree diffing, and the UI's `model_service.py`), all typed or
+`isinstance`-checked as a list. Changing the top-level shape to a dict for
+assemblies would silently break every one of them. The flat-list-plus-tag
+shape below achieves the same goal (component-scoped feature visibility)
+without changing `AdapterResult.data`'s type. See design.md for the full
+rationale and the rejected alternative.
+
+## Capabilities
+
+### New Capabilities
+
+- `tools/list-features`: behavior of the `list_features` MCP tool across Part,
+  Assembly, and nested-Assembly documents, including suppression handling and
+  recursion depth.
+
+### Modified Capabilities
+
+(none — this is the first spec written for this tool; see New Capabilities)
+
+## Impact
+
+- `src/solidworks_mcp/adapters/pywin32_adapter.py` — extend `list_features`
+  (or its underlying implementation) to branch on document type and traverse
+  `GetComponents`. Touches real COM/adapter code: this uses
+  `dynamic.Dispatch`-style late binding and must apply `sw_type_info`
+  flagging to every intermediate `IModelDoc2`/`IAssemblyDoc` dispatch object
+  it acquires, per `docs/agents/com-api-pitfalls.md` and the COM threading
+  invariants in `CLAUDE.md`. All COM calls stay on the adapter's existing
+  `ComExecutor` thread — no new threading is introduced.
+- `src/solidworks_mcp/adapters/base.py` — abstract signature gains an
+  optional `max_assembly_depth: int = 2` parameter; return type stays
+  `AdapterResult[list[dict[str, Any]]]`. Each feature dict gains optional
+  `component`/`component_path` keys (both `None` for Part-document
+  features and for an Assembly's own top-level features).
+- `src/solidworks_mcp/adapters/mock_adapter.py` — add a mock assembly
+  fixture (two components, each with a small feature list) so the new branch
+  has deterministic, SolidWorks-free test coverage.
+- `tests/` — new unit tests for the assembly branch; existing part-level
+  `list_features` tests must keep passing unmodified.
+- No new external dependencies. No change to the MCP tool's public name or
+  required parameters — `include_suppressed` and the tool signature are
+  unchanged, only the response shape gains fields for assemblies.
+- Related: unblocks issue #20 (SolidWorks-as-Code `soc_pickup`) which needs
+  assembly traversal to detect which part changed inside an assembly context.

--- a/openspec/changes/assembly-aware-list-features/specs/tools/list-features/spec.md
+++ b/openspec/changes/assembly-aware-list-features/specs/tools/list-features/spec.md
@@ -1,0 +1,101 @@
+## Purpose
+
+Defines what the `list_features` adapter operation returns for Part,
+Assembly, and nested-Assembly SolidWorks documents, so an LLM agent can
+reliably read a document's full feature tree regardless of document type,
+without changing the flat-list response shape existing callers depend on.
+
+## ADDED Requirements
+
+### Requirement: Response is always a flat list of feature descriptors
+`list_features` SHALL always return a single flat list of feature
+descriptors, regardless of document type. Each descriptor SHALL contain
+`name`, `type`, `suppressed`, and `position`, exactly as it does today for
+Part documents. The response SHALL NOT be restructured into a nested
+object (for example, separate `components`/`assembly_features`
+collections) for any document type, because existing callers (feature-tree
+diffing, feature-family classification, and the MCP tool's `count` field)
+depend on the result being a flat list.
+
+#### Scenario: Listing features on a Part
+- **WHEN** `list_features` is called with the active document being a
+  `.SLDPRT` Part
+- **THEN** the result is a flat list of that Part's own feature
+  descriptors, in the same shape as before this change
+
+### Requirement: Feature descriptors identify their originating component
+Each feature descriptor SHALL carry a `component` field and a
+`component_path` field. For a feature that belongs to the document's own
+feature manager — every feature on a Part, and an Assembly's own
+top-level features (planes, origin, assembly sketches, mates) — both
+fields SHALL be `None`. For a feature belonging to a resolved component's
+underlying document, `component` SHALL be the component's name and
+`component_path` SHALL be that document's file path.
+
+#### Scenario: Assembly-level feature is unattributed
+- **WHEN** `list_features` is called on an Assembly and a feature belongs
+  to the assembly document itself (not to any component)
+- **THEN** that feature's descriptor has `component: None` and
+  `component_path: None`
+
+#### Scenario: Component feature is attributed to its component
+- **WHEN** `list_features` is called on an Assembly containing a
+  component instance, and that component's underlying document has its
+  own features
+- **THEN** each of those features appears in the flat result list with
+  `component` set to the component's name and `component_path` set to
+  the component's document path
+
+### Requirement: Suppression filtering applies independently per document
+The `include_suppressed` parameter SHALL be honored independently for the
+assembly's own features and for each component's features: a suppressed
+feature belonging to one component's document SHALL NOT affect whether a
+feature belonging to another component, or to the assembly itself, is
+included.
+
+#### Scenario: Suppressed feature in one component does not affect another
+- **WHEN** `list_features(include_suppressed=False)` is called on an
+  Assembly where Component A has one suppressed feature and Component B
+  has none
+- **THEN** Component A's suppressed feature is excluded from the result
+  while Component B's features are unaffected, and the assembly's own
+  features are filtered by the same rule independently
+
+### Requirement: Sub-assemblies are traversed up to a bounded depth
+When a component instance is itself an Assembly (a sub-assembly), its
+components SHALL be traversed the same way as top-level components — their
+features flattened into the same result list, tagged with their own
+component name — up to a configurable recursion depth via a new optional
+`max_assembly_depth` parameter. The default depth SHALL be 2 (top-level
+assembly, plus one level of sub-assembly). A component instance beyond the
+configured depth SHALL still appear in the result as a single descriptor
+identifying it by name and path, rather than being silently omitted.
+
+#### Scenario: Sub-assembly one level deep is traversed
+- **WHEN** `list_features` is called on a top-level Assembly containing a
+  sub-assembly component, and the sub-assembly's own components are Parts
+- **THEN** the result includes feature descriptors for the Parts inside
+  the sub-assembly, tagged with their own component name, not just the
+  sub-assembly's own assembly-level features
+
+#### Scenario: Recursion depth limit is respected
+- **WHEN** `list_features` is called with a component chain deeper than
+  the configured `max_assembly_depth`
+- **THEN** a component beyond the configured depth appears in the result
+  as one descriptor identified by name and path, rather than causing an
+  error, infinite recursion, or being silently dropped
+
+### Requirement: Unresolvable components do not fail the whole call
+When a component instance cannot be resolved to an underlying document
+(for example, it is suppressed, lightweight-and-not-loaded, or its
+referenced file is missing), `list_features` SHALL still include one
+descriptor for that component identifying it by name, rather than raising
+an error that discards results already gathered for other components.
+
+#### Scenario: One missing component does not block the others
+- **WHEN** `list_features` is called on an Assembly where one component's
+  referenced part file cannot be resolved and the other components
+  resolve normally
+- **THEN** the result still includes feature descriptors for the
+  components that resolved successfully, plus one descriptor identifying
+  the unresolved component by name

--- a/openspec/changes/assembly-aware-list-features/specs/tools/list-features/spec.md
+++ b/openspec/changes/assembly-aware-list-features/specs/tools/list-features/spec.md
@@ -99,3 +99,46 @@ an error that discards results already gathered for other components.
 - **THEN** the result still includes feature descriptors for the
   components that resolved successfully, plus one descriptor identifying
   the unresolved component by name
+
+### Requirement: Feature descriptors identify their component's parent component
+Each feature descriptor SHALL carry a `component_parent` field: the
+immediate parent component's name when `component` is itself nested inside
+another component (a sub-assembly), or `None` when `component` is a
+top-level component, or when `component` is itself `None` (the document's
+own feature). This SHALL be sufficient to reconstruct the real
+parent/child structure between components, distinguishing "nested inside"
+from "also present somewhere in this assembly."
+
+#### Scenario: Nested component identifies its parent
+- **WHEN** `list_features` is called on an Assembly containing a
+  sub-assembly component, and that sub-assembly's own component has
+  features in the result
+- **THEN** each of those features' `component_parent` equals the
+  sub-assembly component's name
+
+#### Scenario: Top-level component has no parent
+- **WHEN** `list_features` is called on an Assembly and a feature belongs
+  to a top-level component (not nested inside another component)
+- **THEN** that feature's `component_parent` is `None`
+
+### Requirement: A nested component tree can be derived from the flat result
+A pure function SHALL be available that reconstructs a nested
+component/sub-component tree — each node holding its own features and a
+mapping of its child components — from the flat list `list_features`
+returns, using `component`/`component_path`/`component_parent`. This
+SHALL NOT change `list_features`' own return shape; it is a derived view
+for callers that want to inspect assembly structure directly.
+
+#### Scenario: Building the tree from a nested assembly result
+- **WHEN** the tree-building function is given the flat result of
+  `list_features` on an Assembly containing a sub-assembly component with
+  its own child components
+- **THEN** the sub-assembly's child components appear nested under the
+  sub-assembly's node in the tree, not as siblings of the sub-assembly at
+  the top level
+
+#### Scenario: Building the tree from a Part result
+- **WHEN** the tree-building function is given the flat result of
+  `list_features` on a Part (no descriptor has a non-`None` `component`)
+- **THEN** the tree's top-level `components` mapping is empty and all
+  descriptors appear in the tree's own `features` list

--- a/openspec/changes/assembly-aware-list-features/tasks.md
+++ b/openspec/changes/assembly-aware-list-features/tasks.md
@@ -13,14 +13,15 @@
       `currentModel.GetType()` (existing `swDocASSEMBLY` constant) at the
       top of `list_features`; Part/Drawing path is unchanged.
 - [x] 2.2 Implement `_list_assembly_component_features(assembly_doc,
-      include_suppressed, depth_remaining)`: call `GetComponents(True)`,
-      resolve each `IComponent2`'s underlying document, flag it via
-      `sw_type_info.flag_doc`, and run the existing feature traversal
-      against it with its own `seen` dedupe set.
+      include_suppressed, depth_remaining, parent_component)`: call
+      `GetComponents(True)`, resolve each `IComponent2`'s underlying
+      document, flag it via `sw_type_info.flag_doc`, and run the existing
+      feature traversal against it with its own `seen` dedupe set.
 - [x] 2.3 Tag every component-derived feature descriptor with
-      `component`/`component_path` (via
+      `component`/`component_path`/`component_parent` (via
       `_DocumentRoutingService.document_identity`); tag the assembly's own
-      features with `component: None`, `component_path: None`.
+      features with `component: None`, `component_path: None`,
+      `component_parent: None`.
 - [x] 2.4 Recurse into sub-assembly components while
       `depth_remaining > 0`; at the depth limit, emit one descriptor for
       the sub-assembly component (name + path, no nested features)
@@ -28,12 +29,32 @@
 - [x] 2.5 Handle unresolvable components (suppressed, lightweight,
       missing file) by emitting one `type: "UnresolvedComponent"`
       descriptor instead of raising or dropping the component silently.
-- [ ] 2.6 Verify the `GetModelDoc2` accessor and `GetComponents` signature
-      against a live SolidWorks session (`dev-test-full`, Windows +
-      SolidWorks installed) — flagged as unverifiable in this environment
-      per design.md's Risks section. Adjust the accessor pattern if the
-      live session disagrees with the assumed member name/shape.
-      **Not done — no SolidWorks available in this environment.**
+- [x] 2.6 Verify the `GetModelDoc2` accessor and `GetComponents` signature
+      against a live SolidWorks session. **Done 2026-08-11 against a real,
+      running SolidWorks 2026 (build 34.3.0) instance and the built-in
+      U-Joint sample assembly (`UJoint.SLDASM`, containing nested
+      sub-assembly `crank sub.SLDASM`).** `GetComponents(True)` and
+      `IComponent2.GetModelDoc2` are confirmed correct — but the initial
+      implementation had two real, live-only bugs neither mock adapter nor
+      unit tests could have caught:
+      1. `document.GetType()` called with bare parens raises
+         `TypeError: 'int' object is not callable` on a freshly-fetched
+         `swApp.ActiveDoc` (unflagged dispatch resolves it as a property,
+         not a method) — silently swallowed by `_attempt`, which made
+         every Assembly look like doc_type 0 and skip the whole component
+         branch. Fixed by routing through `_get_attr_or_call`.
+      2. `IComponent2.GetModelDoc2` raised
+         `com_error: Member not found` on every component because
+         `IComponent2` was never flagged via `sw_type_info.flag_methods`
+         before calling it — every component silently became
+         `UnresolvedComponent`. Fixed by flagging `IComponent2` before
+         resolving.
+      Documented as pitfalls #11 and #12 in
+      `docs/agents/com-api-pitfalls.md`. After both fixes, a live run
+      resolved all 11 real components across 2 levels of nesting (8
+      top-level + 3 inside the sub-assembly) with zero
+      `UnresolvedComponent` rows — see
+      `docs/getting-started/tutorial-parts/list_features_assembly_demo.py`.
 
 ## 3. Mock adapter
 
@@ -77,9 +98,52 @@
 
 - [x] 6.1 Run `.\dev-commands.ps1 dev-lint` and `.\dev-commands.ps1
       dev-test`; confirm the full mock-only suite passes with the
-      existing coverage gate. **1898 passed, 0 failed, 40 skipped, 73
-      solidworks_only deselected; coverage 99.98%. ruff clean on all
-      changed files (one pre-existing, unrelated UP046 in base.py).**
-- [ ] 6.2 Update `docs/agents/com-api-pitfalls.md` if task 2.6 finds the
-      live `GetModelDoc2`/`GetComponents` behavior differs from what was
-      assumed during implementation. **Blocked on 2.6.**
+      existing coverage gate. **1898+ passed, 0 failed, coverage ~99.9%+.
+      ruff clean on all changed files (one pre-existing, unrelated UP046
+      in base.py, confirmed identical on main).**
+- [x] 6.2 Update `docs/agents/com-api-pitfalls.md` with the live findings
+      from 2.6. **Done — items #11 and #12.**
+- [x] 6.3 Run `.\dev-commands.ps1 dev-test-full` (real SolidWorks
+      integration, `SOLIDWORKS_MCP_RUN_REAL_INTEGRATION=true`,
+      `--cov-fail-under=99`). **1925 passed, 42 skipped, 49 failed,
+      coverage 99.91% (gate passed). Every `list_features`/assembly test
+      passed, including the new live-adjacent ones. The 49 failures are
+      all `create_part: Failed to create new part` — confirmed
+      pre-existing and unrelated: reproduces identically with this
+      branch's commits `git stash`-ed (clean `aee4297`), and persists
+      even after closing every open document, so it is not a
+      too-many-open-docs issue either. Root cause is degraded state in
+      the long-running `SLDWORKS.exe` process itself (this machine's
+      instance had been through hours of automation churn across this
+      session by the time `dev-test-full` ran) — out of scope for this
+      change, since it never touches `create_part`/`NewPart`/template
+      resolution. Flagged for the repo owner; a SolidWorks restart is
+      the likely fix per CLAUDE.md's troubleshooting runbook, but
+      restarting the user's live application wasn't done unprompted.**
+
+## 7. Nested component tree (added after initial review)
+
+The flat list-with-tags shape (see design.md's rejected-alternative
+analysis) is still the adapter contract, but it doesn't by itself capture
+parent/child structure between components — e.g. that `crank-arm-1` lives
+*inside* `crank sub-1`, not alongside it. Addressed additively:
+
+- [x] 7.1 Add a `component_parent` key to every feature descriptor (the
+      immediate parent component's name, or `None` for a top-level
+      component or a document's own feature) in both adapters.
+- [x] 7.2 Add `build_component_tree(features)` to
+      `src/solidworks_mcp/utils/feature_tree_classifier.py`: a pure
+      function that reconstructs the real nested
+      `{"features": [...], "components": {name: {"path", "features",
+      "components"}}}` tree from the flat, tagged list. Adapter contract
+      stays flat; this is a derived view for callers who want to look at
+      structure rather than scan tags.
+- [x] 7.3 Expose the tree as an additive `assembly_tree` field on the
+      `list_features` MCP tool response, alongside the unchanged
+      `features`/`count` fields.
+- [x] 7.4 Unit tests for `build_component_tree` (empty input, Part-only,
+      flat top-level siblings, nested sub-assembly, marker rows excluded
+      from `features` but present as nodes).
+- [x] 7.5 Re-verified live: `crank sub-1`'s three part components nest
+      correctly under it in the tree, not flattened alongside its
+      top-level siblings.

--- a/openspec/changes/assembly-aware-list-features/tasks.md
+++ b/openspec/changes/assembly-aware-list-features/tasks.md
@@ -1,0 +1,85 @@
+## 1. Adapter interface
+
+- [x] 1.1 Add optional `max_assembly_depth: int = 2` parameter to the
+      abstract `list_features` in `src/solidworks_mcp/adapters/base.py`;
+      document the new `component`/`component_path` keys on the returned
+      feature descriptors in the docstring.
+- [x] 1.2 Thread `max_assembly_depth` through `circuit_breaker.py` and
+      `connection_pool.py` wrapper methods.
+
+## 2. Real adapter: assembly traversal
+
+- [x] 2.1 In `_FeatureSelectionService` (`pywin32_adapter.py`), branch on
+      `currentModel.GetType()` (existing `swDocASSEMBLY` constant) at the
+      top of `list_features`; Part/Drawing path is unchanged.
+- [x] 2.2 Implement `_list_assembly_component_features(assembly_doc,
+      include_suppressed, depth_remaining)`: call `GetComponents(True)`,
+      resolve each `IComponent2`'s underlying document, flag it via
+      `sw_type_info.flag_doc`, and run the existing feature traversal
+      against it with its own `seen` dedupe set.
+- [x] 2.3 Tag every component-derived feature descriptor with
+      `component`/`component_path` (via
+      `_DocumentRoutingService.document_identity`); tag the assembly's own
+      features with `component: None`, `component_path: None`.
+- [x] 2.4 Recurse into sub-assembly components while
+      `depth_remaining > 0`; at the depth limit, emit one descriptor for
+      the sub-assembly component (name + path, no nested features)
+      instead of recursing.
+- [x] 2.5 Handle unresolvable components (suppressed, lightweight,
+      missing file) by emitting one `type: "UnresolvedComponent"`
+      descriptor instead of raising or dropping the component silently.
+- [ ] 2.6 Verify the `GetModelDoc2` accessor and `GetComponents` signature
+      against a live SolidWorks session (`dev-test-full`, Windows +
+      SolidWorks installed) — flagged as unverifiable in this environment
+      per design.md's Risks section. Adjust the accessor pattern if the
+      live session disagrees with the assumed member name/shape.
+      **Not done — no SolidWorks available in this environment.**
+
+## 3. Mock adapter
+
+- [x] 3.1 Add an assembly fixture to `mock_adapter.py`: a mock `.SLDASM`
+      with two top-level part components (each with a small feature list)
+      and one nested sub-assembly component one level deep.
+- [x] 3.2 Extend `mock_adapter.py`'s `list_features` to branch on the mock
+      document's type the same way the real adapter does, returning the
+      flattened, tagged list for the assembly fixture and honoring
+      `max_assembly_depth` and `include_suppressed`.
+
+## 4. Tool layer
+
+- [x] 4.1 Add optional `max_assembly_depth` field (default 2) to
+      `ListFeaturesInput` in `src/solidworks_mcp/tools/file_management.py`
+      and pass it through to `adapter.list_features`.
+- [x] 4.2 Confirm the `list_features` MCP tool handler needs no other
+      changes — `result.data or []` and `len(result.data or [])` already
+      work unmodified against the flattened list.
+
+## 5. Tests
+
+- [x] 5.1 Unit tests for the assembly branch: two-component assembly
+      returns both components' features tagged correctly; assembly-level
+      features carry `component: None`.
+- [x] 5.2 Unit test for `include_suppressed` applied independently per
+      component and at the assembly level.
+- [x] 5.3 Unit test for sub-assembly recursion at depth 1 (default depth
+      2) and for the depth-limit case (component appears as a single
+      descriptor, not expanded, not an infinite loop).
+- [x] 5.4 Unit test for an unresolvable component producing one
+      `UnresolvedComponent` descriptor without failing the whole call.
+- [x] 5.5 Regression test confirming existing Part-document
+      `list_features` output is byte-for-byte unchanged.
+- [x] 5.6 Regression test confirming `classify_feature_tree` and the
+      `list_features` MCP tool's `count`/`features` fields still work
+      against the flattened assembly result (guards the decision in
+      design.md against silent breakage).
+
+## 6. Verification
+
+- [x] 6.1 Run `.\dev-commands.ps1 dev-lint` and `.\dev-commands.ps1
+      dev-test`; confirm the full mock-only suite passes with the
+      existing coverage gate. **1898 passed, 0 failed, 40 skipped, 73
+      solidworks_only deselected; coverage 99.98%. ruff clean on all
+      changed files (one pre-existing, unrelated UP046 in base.py).**
+- [ ] 6.2 Update `docs/agents/com-api-pitfalls.md` if task 2.6 finds the
+      live `GetModelDoc2`/`GetComponents` behavior differs from what was
+      assumed during implementation. **Blocked on 2.6.**

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,56 @@
+schema: spec-driven
+
+context: |
+  SolidWorks MCP Server (Python 3.13+). MCP server exposing SolidWorks CAD
+  automation as tools for LLM agents, via COM automation on Windows.
+
+  Architecture:
+  - Server entrypoint: src/solidworks_mcp/server.py
+  - Adapters (src/solidworks_mcp/adapters/): pywin32_adapter.py (real SW COM),
+    mock_adapter.py (tests/CI), factory.py (adapter selection). Tool modules
+    must go through the adapter abstraction, never call COM directly.
+  - Tools (src/solidworks_mcp/tools/): modeling, sketching, drawing, export,
+    analysis, automation, templates, VBA, docs discovery.
+  - Agent harness (src/solidworks_mcp/agents/): prompt schemas, smoke tests,
+    run/error persistence.
+
+  Conventions:
+  - Tool response payloads keep a stable shape: status, message,
+    execution_time, plus a data payload.
+  - Real SolidWorks COM is single-threaded apartment (STA); all COM calls run
+    on a dedicated executor thread (see "COM threading architecture" in
+    CLAUDE.md) - never touch swApp/currentModel off that thread.
+  - Late binding is forced (win32com.client.dynamic.Dispatch); zero-arg SW
+    methods need explicit method-flagging via sw_type_info, or they resolve
+    as properties and raise TypeError.
+  - Mock adapter must mirror any new real-adapter behavior so tests run
+    without SolidWorks installed.
+  - Tests: `.\dev-commands.ps1 dev-test` (mock-only, default) vs
+    `dev-test-full` (real SolidWorks integration, Windows only). CI runs the
+    mock-only path.
+  - Full COM pitfall catalogue: docs/agents/com-api-pitfalls.md. Read it
+    before writing any new COM-touching adapter code.
+
+rules:
+  proposal:
+    - Reference the GitHub issue number this change addresses, if any.
+    - Call out whether the change touches COM/adapter code (pywin32_adapter,
+      base adapter interface, mock_adapter) since those changes carry extra
+      COM-threading and late-binding risk per CLAUDE.md.
+  specs:
+    - Express behavior in terms of the adapter interface (base.py) and
+      response payload shape, not raw COM calls.
+  tasks:
+    - Every task that adds or changes adapter behavior must include a
+      corresponding mock_adapter.py update and test as its own step, not
+      bundled silently into the pywin32_adapter task.
+
+operations:
+  apply:
+    guidance:
+      - Run `.\dev-commands.ps1 dev-lint` and `.\dev-commands.ps1 dev-test`
+        before considering an apply step done.
+      - Keep test summaries concise; report counts, not full pytest output.
+  archive:
+    guidance:
+      - Summarize the archive outcome before finishing.

--- a/src/solidworks_mcp/adapters/base.py
+++ b/src/solidworks_mcp/adapters/base.py
@@ -442,13 +442,14 @@ class SolidWorksAdapter(ABC):
         single flat list containing the assembly's own top-level features
         plus every resolved component's features, recursing into
         sub-assemblies up to ``max_assembly_depth``. Every descriptor gains
-        ``component`` and ``component_path`` keys: ``None`` for a
-        document's own features (Part features, or an Assembly's top-level
-        features), or the owning component's name/path for a
-        component-derived feature. A component that cannot be resolved
-        (suppressed, lightweight-and-unloaded, missing file) is represented
-        by one descriptor with ``type: "UnresolvedComponent"`` instead of
-        being silently dropped.
+        ``component``, ``component_path``, and ``component_parent`` keys:
+        ``None`` for a document's own features (Part features, or an Assembly's
+        top-level features), or the owning component's name/path for a
+        component-derived feature. ``component_parent`` is the immediate parent
+        component name when the component is nested inside a sub-assembly,
+        otherwise ``None``. A component that cannot be resolved (suppressed,
+        lightweight-and-unloaded, missing file) is represented by one descriptor
+        with ``type: "UnresolvedComponent"`` instead of being silently dropped.
 
         Args:
             include_suppressed (bool): The include suppressed value. Defaults to False.

--- a/src/solidworks_mcp/adapters/base.py
+++ b/src/solidworks_mcp/adapters/base.py
@@ -433,12 +433,31 @@ class SolidWorksAdapter(ABC):
 
     @abstractmethod
     async def list_features(
-        self, include_suppressed: bool = False
+        self, include_suppressed: bool = False, max_assembly_depth: int = 2
     ) -> AdapterResult[list[dict[str, Any]]]:
         """List model features from the feature tree.
 
+        For a Part document, returns that document's own feature list,
+        unchanged from prior behavior. For an Assembly document, returns a
+        single flat list containing the assembly's own top-level features
+        plus every resolved component's features, recursing into
+        sub-assemblies up to ``max_assembly_depth``. Every descriptor gains
+        ``component`` and ``component_path`` keys: ``None`` for a
+        document's own features (Part features, or an Assembly's top-level
+        features), or the owning component's name/path for a
+        component-derived feature. A component that cannot be resolved
+        (suppressed, lightweight-and-unloaded, missing file) is represented
+        by one descriptor with ``type: "UnresolvedComponent"`` instead of
+        being silently dropped.
+
         Args:
             include_suppressed (bool): The include suppressed value. Defaults to False.
+                Applied independently to the assembly's own features and to
+                each component's features.
+            max_assembly_depth (int): How many levels of sub-assembly to
+                recurse into. Defaults to 2. Ignored for Part documents. A
+                component beyond the configured depth still appears in the
+                result as a single descriptor (name + path), not expanded.
 
         Returns:
             AdapterResult[list[dict[str, Any]]]: The result produced by the operation.

--- a/src/solidworks_mcp/adapters/circuit_breaker.py
+++ b/src/solidworks_mcp/adapters/circuit_breaker.py
@@ -927,20 +927,24 @@ class CircuitBreakerAdapter(SolidWorksAdapter):
         )
 
     async def list_features(
-        self, include_suppressed: bool = False
+        self, include_suppressed: bool = False, max_assembly_depth: int = 2
     ) -> AdapterResult[list[dict[str, object]]]:
         """List model features through circuit breaker.
 
         Args:
             include_suppressed (bool): The include suppressed value. Defaults to False.
+            max_assembly_depth (int): Sub-assembly recursion depth. Defaults to 2.
 
         Returns:
             AdapterResult[list[dict[str, object]]]: The result produced by the operation.
         """
         return await self._execute_with_circuit_breaker(
             "list_features",
-            lambda: self.adapter.list_features(include_suppressed),
-            input_dict={"include_suppressed": include_suppressed},
+            lambda: self.adapter.list_features(include_suppressed, max_assembly_depth),
+            input_dict={
+                "include_suppressed": include_suppressed,
+                "max_assembly_depth": max_assembly_depth,
+            },
         )
 
     async def list_configurations(self) -> AdapterResult[list[str]]:

--- a/src/solidworks_mcp/adapters/connection_pool.py
+++ b/src/solidworks_mcp/adapters/connection_pool.py
@@ -863,19 +863,22 @@ class ConnectionPoolAdapter(SolidWorksAdapter):
         )
 
     async def list_features(
-        self, include_suppressed: bool = False
+        self, include_suppressed: bool = False, max_assembly_depth: int = 2
     ) -> AdapterResult[list[dict[str, object]]]:
         """List model features using pool.
 
         Args:
             include_suppressed (bool): The include suppressed value. Defaults to False.
+            max_assembly_depth (int): Sub-assembly recursion depth. Defaults to 2.
 
         Returns:
             AdapterResult[list[dict[str, object]]]: The result produced by the operation.
         """
         return await self._execute_with_pool(
             "list_features",
-            lambda adapter: adapter.list_features(include_suppressed),
+            lambda adapter: adapter.list_features(
+                include_suppressed, max_assembly_depth
+            ),
         )
 
     async def list_configurations(self) -> AdapterResult[list[str]]:

--- a/src/solidworks_mcp/adapters/mock_adapter.py
+++ b/src/solidworks_mcp/adapters/mock_adapter.py
@@ -30,6 +30,44 @@ from .base import (
 )
 from .solidworks.sketch import RELATION_NAME_MAP
 
+#: Canned assembly component tree used by ``list_features`` when a mock
+#: Assembly's ``_assembly_components`` hasn't been configured by a test.
+#: Two top-level Part components plus one nested sub-assembly one level
+#: deep, per ``docs/agents`` / OpenSpec change ``assembly-aware-list-features``.
+_DEFAULT_ASSEMBLY_COMPONENTS: dict[str, dict[str, Any]] = {
+    "PartA": {
+        "type": "Part",
+        "path": "Mock://PartA.sldprt",
+        "features": [
+            {"name": "Boss-Extrude1", "type": "Extrusion", "suppressed": False},
+            {"name": "Fillet1", "type": "Fillet", "suppressed": False},
+        ],
+    },
+    "PartB": {
+        "type": "Part",
+        "path": "Mock://PartB.sldprt",
+        "features": [
+            {"name": "Cut-Extrude1", "type": "Cut", "suppressed": False},
+        ],
+    },
+    "SubAssembly1": {
+        "type": "Assembly",
+        "path": "Mock://SubAssembly1.sldasm",
+        "features": [
+            {"name": "Mate1", "type": "Mate", "suppressed": False},
+        ],
+        "components": {
+            "PartC": {
+                "type": "Part",
+                "path": "Mock://PartC.sldprt",
+                "features": [
+                    {"name": "Boss-Extrude1", "type": "Extrusion", "suppressed": False},
+                ],
+            },
+        },
+    },
+}
+
 
 class _BoolCallable:
     """Compatibility shim that behaves as both bool and callable.
@@ -98,6 +136,10 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         self._current_model: SolidWorksModel | None = None
         self._models: dict[str, SolidWorksModel] = {}
         self._features: dict[str, SolidWorksFeature] = {}
+        # Component tree for an Assembly-type current model, keyed by
+        # component name. See ``_flatten_assembly_components`` for shape.
+        # Empty means "use the canned default fixture" (see list_features).
+        self._assembly_components: dict[str, dict[str, Any]] = {}
         self._sketches: dict[str, str] = {}
         self._current_sketch: str | None = None
         # Tracks IDs returned by add_line/add_arc/add_circle/add_centerline/
@@ -318,12 +360,22 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         )
 
     async def list_features(
-        self, include_suppressed: bool = False
+        self, include_suppressed: bool = False, max_assembly_depth: int = 2
     ) -> AdapterResult[list[dict[str, Any]]]:
         """Mock feature tree listing for the active model.
 
+        For an Assembly model, flattens in every configured component's
+        features (see ``_assembly_components``) alongside the document's own
+        features, tagged with ``component``/``component_path`` the same way
+        the real adapter does. Falls back to a small canned two-component
+        fixture (plus one nested sub-assembly) when no components have been
+        configured, mirroring the existing "seed realistic feature names"
+        behavior for an empty Part.
+
         Args:
             include_suppressed (bool): The include suppressed value. Defaults to False.
+            max_assembly_depth (int): Sub-assembly recursion budget. Ignored
+                for non-Assembly models. Defaults to 2.
 
         Returns:
             AdapterResult[list[dict[str, Any]]]: The result produced by the operation.
@@ -337,15 +389,54 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         await asyncio.sleep(self._delays["feature_operation"] / 2)
         self._operation_count += 1
 
+        is_assembly = self._current_model.type == "Assembly"
+
         # Seed realistic feature names for empty mock state.
         if not self._features:
-            seeded = [
-                {"name": "Origin", "type": "OriginProfileFeature", "suppressed": False},
-                {"name": "Front Plane", "type": "RefPlane", "suppressed": False},
-                {"name": "Right Plane", "type": "RefPlane", "suppressed": False},
-                {"name": "Top Plane", "type": "RefPlane", "suppressed": False},
-                {"name": "Sketch1", "type": "ProfileFeature", "suppressed": False},
+            seeded: list[dict[str, Any]] = [
+                {
+                    "name": "Origin",
+                    "type": "OriginProfileFeature",
+                    "suppressed": False,
+                    "component": None,
+                    "component_path": None,
+                },
+                {
+                    "name": "Front Plane",
+                    "type": "RefPlane",
+                    "suppressed": False,
+                    "component": None,
+                    "component_path": None,
+                },
+                {
+                    "name": "Right Plane",
+                    "type": "RefPlane",
+                    "suppressed": False,
+                    "component": None,
+                    "component_path": None,
+                },
+                {
+                    "name": "Top Plane",
+                    "type": "RefPlane",
+                    "suppressed": False,
+                    "component": None,
+                    "component_path": None,
+                },
+                {
+                    "name": "Sketch1",
+                    "type": "ProfileFeature",
+                    "suppressed": False,
+                    "component": None,
+                    "component_path": None,
+                },
             ]
+            if is_assembly:
+                components = self._assembly_components or _DEFAULT_ASSEMBLY_COMPONENTS
+                seeded.extend(
+                    self._flatten_assembly_components(
+                        components, include_suppressed, max_assembly_depth - 1
+                    )
+                )
             return AdapterResult(
                 status=AdapterResultStatus.SUCCESS,
                 data=seeded,
@@ -359,15 +450,107 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
                 "type": feature.type,
                 "suppressed": bool((feature.properties or {}).get("suppressed", False)),
                 "position": i,
+                "component": None,
+                "component_path": None,
             }
             if include_suppressed or not row["suppressed"]:
                 feature_rows.append(row)
+
+        if is_assembly:
+            feature_rows.extend(
+                self._flatten_assembly_components(
+                    self._assembly_components, include_suppressed, max_assembly_depth - 1
+                )
+            )
 
         return AdapterResult(
             status=AdapterResultStatus.SUCCESS,
             data=feature_rows,
             execution_time=self._delays["feature_operation"] / 2,
         )
+
+    def _flatten_assembly_components(
+        self,
+        components: dict[str, dict[str, Any]],
+        include_suppressed: bool,
+        depth_remaining: int,
+    ) -> list[dict[str, Any]]:
+        """Flatten a mock component tree into tagged feature descriptors.
+
+        Mirrors the real adapter's recursion rules: a sub-assembly component
+        is expanded (its own features plus a recursive pass over its
+        components) only while ``depth_remaining > 0``; beyond that it is
+        represented by a single bare descriptor. An unresolvable component
+        (``type: "Unresolved"`` in the fixture) always produces one
+        ``UnresolvedComponent`` descriptor.
+
+        Args:
+            components: Mapping of component name to a fixture dict with
+                ``type`` ("Part", "Assembly", or "Unresolved"), ``path``,
+                ``features`` (list of ``{name, type, suppressed}``), and,
+                for "Assembly" components, a nested ``components`` mapping.
+            include_suppressed: Include suppressed entries when ``True``.
+            depth_remaining: Sub-assembly recursion budget remaining.
+
+        Returns:
+            list[dict[str, Any]]: Flattened, component-tagged descriptors.
+        """
+        results: list[dict[str, Any]] = []
+        for name, comp in components.items():
+            comp_type = comp.get("type")
+            path = comp.get("path")
+
+            if comp_type == "Unresolved":
+                results.append(
+                    {
+                        "name": name,
+                        "type": "UnresolvedComponent",
+                        "suppressed": False,
+                        "position": -1,
+                        "component": name,
+                        "component_path": None,
+                    }
+                )
+                continue
+
+            if comp_type == "Assembly" and depth_remaining <= 0:
+                results.append(
+                    {
+                        "name": name,
+                        "type": "Component",
+                        "suppressed": False,
+                        "position": -1,
+                        "component": name,
+                        "component_path": path,
+                    }
+                )
+                continue
+
+            for i, feature in enumerate(comp.get("features", [])):
+                suppressed = bool(feature.get("suppressed", False))
+                if not include_suppressed and suppressed:
+                    continue
+                results.append(
+                    {
+                        "name": feature["name"],
+                        "type": feature["type"],
+                        "suppressed": suppressed,
+                        "position": i,
+                        "component": name,
+                        "component_path": path,
+                    }
+                )
+
+            if comp_type == "Assembly":
+                results.extend(
+                    self._flatten_assembly_components(
+                        comp.get("components", {}),
+                        include_suppressed,
+                        depth_remaining - 1,
+                    )
+                )
+
+        return results
 
     async def select_feature(self, feature_name: str) -> AdapterResult[dict[str, Any]]:
         """Mock feature selection/highlight — succeeds without COM side-effects.

--- a/src/solidworks_mcp/adapters/mock_adapter.py
+++ b/src/solidworks_mcp/adapters/mock_adapter.py
@@ -400,6 +400,7 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
                     "suppressed": False,
                     "component": None,
                     "component_path": None,
+                    "component_parent": None,
                 },
                 {
                     "name": "Front Plane",
@@ -407,6 +408,7 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
                     "suppressed": False,
                     "component": None,
                     "component_path": None,
+                    "component_parent": None,
                 },
                 {
                     "name": "Right Plane",
@@ -414,6 +416,7 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
                     "suppressed": False,
                     "component": None,
                     "component_path": None,
+                    "component_parent": None,
                 },
                 {
                     "name": "Top Plane",
@@ -421,6 +424,7 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
                     "suppressed": False,
                     "component": None,
                     "component_path": None,
+                    "component_parent": None,
                 },
                 {
                     "name": "Sketch1",
@@ -428,13 +432,14 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
                     "suppressed": False,
                     "component": None,
                     "component_path": None,
+                    "component_parent": None,
                 },
             ]
             if is_assembly:
                 components = self._assembly_components or _DEFAULT_ASSEMBLY_COMPONENTS
                 seeded.extend(
                     self._flatten_assembly_components(
-                        components, include_suppressed, max_assembly_depth - 1
+                        components, include_suppressed, max_assembly_depth - 1, None
                     )
                 )
             return AdapterResult(
@@ -452,6 +457,7 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
                 "position": i,
                 "component": None,
                 "component_path": None,
+                "component_parent": None,
             }
             if include_suppressed or not row["suppressed"]:
                 feature_rows.append(row)
@@ -459,7 +465,10 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         if is_assembly:
             feature_rows.extend(
                 self._flatten_assembly_components(
-                    self._assembly_components, include_suppressed, max_assembly_depth - 1
+                    self._assembly_components,
+                    include_suppressed,
+                    max_assembly_depth - 1,
+                    None,
                 )
             )
 
@@ -474,6 +483,7 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         components: dict[str, dict[str, Any]],
         include_suppressed: bool,
         depth_remaining: int,
+        parent_component: str | None,
     ) -> list[dict[str, Any]]:
         """Flatten a mock component tree into tagged feature descriptors.
 
@@ -491,6 +501,8 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
                 for "Assembly" components, a nested ``components`` mapping.
             include_suppressed: Include suppressed entries when ``True``.
             depth_remaining: Sub-assembly recursion budget remaining.
+            parent_component: Name of the component this level of
+                ``components`` is nested inside, or ``None`` for top-level.
 
         Returns:
             list[dict[str, Any]]: Flattened, component-tagged descriptors.
@@ -509,6 +521,7 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
                         "position": -1,
                         "component": name,
                         "component_path": None,
+                        "component_parent": parent_component,
                     }
                 )
                 continue
@@ -522,6 +535,7 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
                         "position": -1,
                         "component": name,
                         "component_path": path,
+                        "component_parent": parent_component,
                     }
                 )
                 continue
@@ -538,6 +552,7 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
                         "position": i,
                         "component": name,
                         "component_path": path,
+                        "component_parent": parent_component,
                     }
                 )
 
@@ -547,6 +562,7 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
                         comp.get("components", {}),
                         include_suppressed,
                         depth_remaining - 1,
+                        name,
                     )
                 )
 

--- a/src/solidworks_mcp/adapters/mock_adapter.py
+++ b/src/solidworks_mcp/adapters/mock_adapter.py
@@ -463,9 +463,10 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
                 feature_rows.append(row)
 
         if is_assembly:
+            components = self._assembly_components or _DEFAULT_ASSEMBLY_COMPONENTS
             feature_rows.extend(
                 self._flatten_assembly_components(
-                    self._assembly_components,
+                    components,
                     include_suppressed,
                     max_assembly_depth - 1,
                     None,

--- a/src/solidworks_mcp/adapters/pywin32_adapter.py
+++ b/src/solidworks_mcp/adapters/pywin32_adapter.py
@@ -1198,11 +1198,59 @@ class _FeatureSelectionService:
             "selected_name": feature_name,
         }
 
-    def list_features(self, include_suppressed: bool = False) -> list[dict[str, Any]]:
-        """Enumerate model features using primary and fallback traversal paths.
+    def list_features(
+        self, include_suppressed: bool = False, max_assembly_depth: int = 2
+    ) -> list[dict[str, Any]]:
+        """Enumerate model features, including assembly component trees.
+
+        For a Part document, returns that document's own feature list only
+        (unchanged from prior behavior). For an Assembly document, also
+        flattens in every resolved top-level component's features — and,
+        recursively, sub-assembly components' features up to
+        ``max_assembly_depth`` — tagged with ``component``/``component_path``
+        so callers can tell which document each descriptor came from.
 
         Args:
             include_suppressed: Include suppressed features when ``True``.
+            max_assembly_depth: Sub-assembly recursion budget. Ignored for
+                Part documents.
+
+        Returns:
+            list[dict[str, Any]]: Ordered, flattened feature descriptors.
+        """
+        document = self._adapter.currentModel
+        features = self._list_document_features(document, include_suppressed)
+
+        doc_type = self._adapter._attempt(
+            lambda: int(document.GetType() or 0),  # type: ignore[union-attr]
+            default=0,
+        )
+        if doc_type == self._adapter.constants.get("swDocASSEMBLY", 2):
+            features.extend(
+                self._list_assembly_component_features(
+                    document, include_suppressed, max_assembly_depth - 1
+                )
+            )
+
+        return features
+
+    def _list_document_features(
+        self,
+        document: Any,
+        include_suppressed: bool,
+        component: str | None = None,
+        component_path: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Enumerate one document's own features using primary and fallback
+        traversal paths.
+
+        Args:
+            document: SolidWorks ``IModelDoc2`` COM object to traverse.
+            include_suppressed: Include suppressed features when ``True``.
+            component: Owning component name to tag every descriptor with,
+                or ``None`` for the document's own (non-component) features.
+            component_path: Owning component's resolved document path, or
+                ``None`` to match ``component``.
 
         Returns:
             list[dict[str, Any]]: Ordered feature descriptors.
@@ -1210,9 +1258,7 @@ class _FeatureSelectionService:
         features: list[dict[str, Any]] = []
         seen: set[tuple[str, str]] = set()
 
-        feature = self._adapter._attempt(
-            lambda: self._adapter.currentModel.FirstFeature()  # type: ignore[union-attr]
-        )
+        feature = self._adapter._attempt(lambda: document.FirstFeature())
         # Flag the feature dispatch so methods like GetNextFeature work
         if feature is not None:
             self._adapter._attempt(
@@ -1222,7 +1268,15 @@ class _FeatureSelectionService:
         pos = 0
         guard = 0
         while feature and guard < 10000:
-            self._append_feature_to(features, seen, feature, pos, include_suppressed)
+            self._append_feature_to(
+                features,
+                seen,
+                feature,
+                pos,
+                include_suppressed,
+                component=component,
+                component_path=component_path,
+            )
             pos += 1
             guard += 1
             next_feature = self._adapter._attempt(
@@ -1243,7 +1297,7 @@ class _FeatureSelectionService:
         # the system folders even though later sketches and body features
         # exist. The dedupe set keeps this fallback safe when both traversals
         # return the same entries.
-        feature_manager = getattr(self._adapter.currentModel, "FeatureManager", None)
+        feature_manager = getattr(document, "FeatureManager", None)
         count = self._adapter._attempt(
             lambda: int(feature_manager.GetFeatureCount(True) or 0),  # type: ignore[union-attr]
             default=0,
@@ -1252,9 +1306,7 @@ class _FeatureSelectionService:
         # skipped the newest feature (typically the just-created extrusion).
         for reverse_pos in range(0, count or 0):
             feature = self._adapter._attempt(
-                lambda pos=reverse_pos: (  # type: ignore[misc]
-                    self._adapter.currentModel.FeatureByPositionReverse(pos)  # type: ignore[union-attr]
-                )
+                lambda pos=reverse_pos: document.FeatureByPositionReverse(pos)
             )
             if feature is None:
                 continue
@@ -1264,9 +1316,114 @@ class _FeatureSelectionService:
                 feature,
                 (count or 0) - reverse_pos - 1,
                 include_suppressed,
+                component=component,
+                component_path=component_path,
             )
 
         return features
+
+    def _list_assembly_component_features(
+        self,
+        assembly_doc: Any,
+        include_suppressed: bool,
+        depth_remaining: int,
+    ) -> list[dict[str, Any]]:
+        """Traverse an assembly's top-level components and flatten their
+        features into the same shape ``_list_document_features`` produces.
+
+        A component that resolves to another Assembly is expanded (its own
+        features plus a recursive pass over its components) only while
+        ``depth_remaining > 0``; beyond that it is represented by a single
+        bare descriptor (name + path) instead of being expanded further.
+        Part components are always expanded fully — they have no further
+        nesting, so there is no unbounded-recursion risk from doing so.
+
+        Args:
+            assembly_doc: SolidWorks ``IAssemblyDoc``/``IModelDoc2`` COM
+                object whose top-level components to traverse.
+            include_suppressed: Include suppressed features when ``True``.
+            depth_remaining: Sub-assembly recursion budget remaining.
+
+        Returns:
+            list[dict[str, Any]]: Flattened, component-tagged descriptors.
+        """
+        results: list[dict[str, Any]] = []
+        assembly_swdoc_type = self._adapter.constants.get("swDocASSEMBLY", 2)
+
+        components = self._adapter._attempt(
+            lambda: assembly_doc.GetComponents(True), default=None
+        )
+        if not components:
+            return results
+
+        for component in components:
+            component_name = str(
+                self._adapter._attempt(
+                    lambda c=component: self._adapter._get_attr_or_call(c, "Name2"),
+                    default="",
+                )
+                or ""
+            )
+
+            resolved_doc = self._adapter._attempt(
+                lambda c=component: self._adapter._get_attr_or_call(
+                    c, "GetModelDoc2"
+                ),
+                default=None,
+            )
+            if resolved_doc is None:
+                results.append(
+                    {
+                        "name": component_name,
+                        "type": "UnresolvedComponent",
+                        "suppressed": False,
+                        "position": -1,
+                        "component": component_name,
+                        "component_path": None,
+                    }
+                )
+                continue
+
+            resolved_doc_type = self._adapter._attempt(
+                lambda d=resolved_doc: int(d.GetType() or 0), default=0
+            )
+            sw_type_info.flag_doc(resolved_doc, resolved_doc_type)
+            component_path, _title = self._adapter._document_routing.document_identity(
+                resolved_doc
+            )
+
+            if resolved_doc_type == assembly_swdoc_type and depth_remaining <= 0:
+                # Depth limit reached: identify the sub-assembly component
+                # without expanding its own features or its components.
+                results.append(
+                    {
+                        "name": component_name,
+                        "type": "Component",
+                        "suppressed": False,
+                        "position": -1,
+                        "component": component_name,
+                        "component_path": component_path,
+                    }
+                )
+                continue
+
+            results.extend(
+                self._list_document_features(
+                    resolved_doc,
+                    include_suppressed,
+                    component=component_name,
+                    component_path=component_path,
+                )
+            )
+
+            if resolved_doc_type == assembly_swdoc_type:
+                results.extend(
+                    self._list_assembly_component_features(
+                        resolved_doc, include_suppressed, depth_remaining - 1
+                    )
+                )
+
+        return results
 
     def _append_feature_to(
         self,
@@ -1275,6 +1432,8 @@ class _FeatureSelectionService:
         feature: Any,
         position: int,
         include_suppressed: bool,
+        component: str | None = None,
+        component_path: str | None = None,
     ) -> None:
         """Append one feature descriptor when dedupe and suppression rules allow.
 
@@ -1284,6 +1443,10 @@ class _FeatureSelectionService:
             feature: Feature COM object.
             position: Display position index.
             include_suppressed: Include suppressed entries when ``True``.
+            component: Owning component name, or ``None`` for a document's
+                own (non-component) feature.
+            component_path: Owning component's resolved document path, or
+                ``None`` to match ``component``.
         """
         name = str(getattr(feature, "Name", ""))
         feature_type = str(
@@ -1307,6 +1470,8 @@ class _FeatureSelectionService:
                 "type": feature_type,
                 "suppressed": suppressed,
                 "position": position,
+                "component": component,
+                "component_path": component_path,
             }
         )
 

--- a/src/solidworks_mcp/adapters/pywin32_adapter.py
+++ b/src/solidworks_mcp/adapters/pywin32_adapter.py
@@ -1221,14 +1221,24 @@ class _FeatureSelectionService:
         document = self._adapter.currentModel
         features = self._list_document_features(document, include_suppressed)
 
+        # GetType resolves as a property (not a method) on some COM dispatch
+        # instances - notably a freshly-fetched swApp.ActiveDoc, as opposed
+        # to a document just returned by OpenDoc6/NewDocument. Calling it
+        # with parens unconditionally raises "'int' object is not callable"
+        # on those, silently swallowed by _attempt, which would otherwise
+        # make every Assembly document look like doc_type 0. Route through
+        # _get_attr_or_call so both forms work regardless of flagging state.
         doc_type = self._adapter._attempt(
-            lambda: int(document.GetType() or 0),  # type: ignore[union-attr]
+            lambda: int(
+                self._adapter._get_attr_or_call(document, "GetType") or 0
+            ),
             default=0,
         )
         if doc_type == self._adapter.constants.get("swDocASSEMBLY", 2):
+            sw_type_info.flag_doc(document, doc_type)
             features.extend(
                 self._list_assembly_component_features(
-                    document, include_suppressed, max_assembly_depth - 1
+                    document, include_suppressed, max_assembly_depth - 1, None
                 )
             )
 
@@ -1240,6 +1250,7 @@ class _FeatureSelectionService:
         include_suppressed: bool,
         component: str | None = None,
         component_path: str | None = None,
+        component_parent: str | None = None,
     ) -> list[dict[str, Any]]:
         """Enumerate one document's own features using primary and fallback
         traversal paths.
@@ -1251,6 +1262,11 @@ class _FeatureSelectionService:
                 or ``None`` for the document's own (non-component) features.
             component_path: Owning component's resolved document path, or
                 ``None`` to match ``component``.
+            component_parent: Immediate parent component's name (the
+                sub-assembly instance ``component`` is nested inside), or
+                ``None`` when ``component`` is a top-level component (or
+                itself ``None``). Lets callers reconstruct the component
+                tree from the flat result — see ``build_component_tree``.
 
         Returns:
             list[dict[str, Any]]: Ordered feature descriptors.
@@ -1276,6 +1292,7 @@ class _FeatureSelectionService:
                 include_suppressed,
                 component=component,
                 component_path=component_path,
+                component_parent=component_parent,
             )
             pos += 1
             guard += 1
@@ -1318,6 +1335,7 @@ class _FeatureSelectionService:
                 include_suppressed,
                 component=component,
                 component_path=component_path,
+                component_parent=component_parent,
             )
 
         return features
@@ -1327,6 +1345,7 @@ class _FeatureSelectionService:
         assembly_doc: Any,
         include_suppressed: bool,
         depth_remaining: int,
+        parent_component: str | None,
     ) -> list[dict[str, Any]]:
         """Traverse an assembly's top-level components and flatten their
         features into the same shape ``_list_document_features`` produces.
@@ -1343,6 +1362,10 @@ class _FeatureSelectionService:
                 object whose top-level components to traverse.
             include_suppressed: Include suppressed features when ``True``.
             depth_remaining: Sub-assembly recursion budget remaining.
+            parent_component: Name of the component ``assembly_doc`` itself
+                is nested inside, or ``None`` when ``assembly_doc`` is the
+                top-level document. Tags every descriptor produced here
+                with this as ``component_parent``.
 
         Returns:
             list[dict[str, Any]]: Flattened, component-tagged descriptors.
@@ -1365,6 +1388,16 @@ class _FeatureSelectionService:
                 or ""
             )
 
+            # IComponent2.GetModelDoc2 raises "Member not found" on an
+            # unflagged component dispatch under late binding - dynamic
+            # dispatch returns a speculative callable for unknown attribute
+            # names that only fails once actually invoked. Flag before
+            # resolving, per the CLAUDE.md convention of flagging every
+            # intermediate dispatch this code acquires.
+            self._adapter._attempt(
+                lambda c=component: sw_type_info.flag_methods(c, "IComponent2"),
+                default=0,
+            )
             resolved_doc = self._adapter._attempt(
                 lambda c=component: self._adapter._get_attr_or_call(
                     c, "GetModelDoc2"
@@ -1380,12 +1413,19 @@ class _FeatureSelectionService:
                         "position": -1,
                         "component": component_name,
                         "component_path": None,
+                        "component_parent": parent_component,
                     }
                 )
                 continue
 
+            # Same property-vs-method ambiguity as the top-level GetType
+            # check above - route through _get_attr_or_call rather than
+            # calling GetType() directly.
             resolved_doc_type = self._adapter._attempt(
-                lambda d=resolved_doc: int(d.GetType() or 0), default=0
+                lambda d=resolved_doc: int(
+                    self._adapter._get_attr_or_call(d, "GetType") or 0
+                ),
+                default=0,
             )
             sw_type_info.flag_doc(resolved_doc, resolved_doc_type)
             component_path, _title = self._adapter._document_routing.document_identity(
@@ -1403,6 +1443,7 @@ class _FeatureSelectionService:
                         "position": -1,
                         "component": component_name,
                         "component_path": component_path,
+                        "component_parent": parent_component,
                     }
                 )
                 continue
@@ -1413,13 +1454,17 @@ class _FeatureSelectionService:
                     include_suppressed,
                     component=component_name,
                     component_path=component_path,
+                    component_parent=parent_component,
                 )
             )
 
             if resolved_doc_type == assembly_swdoc_type:
                 results.extend(
                     self._list_assembly_component_features(
-                        resolved_doc, include_suppressed, depth_remaining - 1
+                        resolved_doc,
+                        include_suppressed,
+                        depth_remaining - 1,
+                        component_name,
                     )
                 )
 
@@ -1434,6 +1479,7 @@ class _FeatureSelectionService:
         include_suppressed: bool,
         component: str | None = None,
         component_path: str | None = None,
+        component_parent: str | None = None,
     ) -> None:
         """Append one feature descriptor when dedupe and suppression rules allow.
 
@@ -1447,6 +1493,9 @@ class _FeatureSelectionService:
                 own (non-component) feature.
             component_path: Owning component's resolved document path, or
                 ``None`` to match ``component``.
+            component_parent: Immediate parent component's name, or
+                ``None`` for a top-level component or a document's own
+                feature.
         """
         name = str(getattr(feature, "Name", ""))
         feature_type = str(
@@ -1472,6 +1521,7 @@ class _FeatureSelectionService:
                 "position": position,
                 "component": component,
                 "component_path": component_path,
+                "component_parent": component_parent,
             }
         )
 

--- a/src/solidworks_mcp/adapters/solidworks/selection.py
+++ b/src/solidworks_mcp/adapters/solidworks/selection.py
@@ -23,7 +23,7 @@ class SolidWorksSelectionMixin:
         ) -> AdapterResult[Any]: ...
 
     async def list_features(
-        self, include_suppressed: bool = False
+        self, include_suppressed: bool = False, max_assembly_depth: int = 2
     ) -> AdapterResult[list[dict[str, Any]]]:
         sw_app = getattr(self, "swApp", None)
         active_model = getattr(sw_app, "ActiveDoc", None) if sw_app else None
@@ -35,7 +35,10 @@ class SolidWorksSelectionMixin:
                 error="No active model",
             )
         return self._handle_com_operation(
-            "list_features", self._feature_selector.list_features, include_suppressed
+            "list_features",
+            self._feature_selector.list_features,
+            include_suppressed,
+            max_assembly_depth,
         )
 
     @staticmethod

--- a/src/solidworks_mcp/agents/soc_pickup.py
+++ b/src/solidworks_mcp/agents/soc_pickup.py
@@ -59,11 +59,27 @@ def _feature_map(feature_tree: list[dict[str, Any]]) -> dict[str, dict[str, Any]
     return {f.get("name", ""): f for f in feature_tree if f.get("name")}
 
 
+def _feature_key(feature: dict[str, Any]) -> tuple[Any, str] | None:
+    """Stable identity for a feature row: (owning component, name).
+
+    An assembly's flattened feature list commonly has the same name
+    (e.g. "Boss-Extrude1") in several different components, so bare name
+    alone isn't unique across an assembly. Pairing it with ``component``
+    (``None`` for a document's own features) disambiguates that while
+    leaving Part-only trees - where every row's ``component`` is ``None``
+    - behaving exactly as bare-name comparison did before.
+    """
+    name = feature.get("name")
+    if not name:
+        return None
+    return (feature.get("component"), name)
+
+
 def diff_feature_trees(
     old_tree: list[dict[str, Any]],
     new_tree: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Return features present in new_tree but not in old_tree (by name).
+    """Return features present in new_tree but not in old_tree (by component+name).
 
     Args:
         old_tree: Feature list from the last ModelStateSnapshot.
@@ -72,8 +88,8 @@ def diff_feature_trees(
     Returns:
         List of new feature dicts, in the order they appear in new_tree.
     """
-    old_names = set(_feature_names(old_tree))
-    return [f for f in new_tree if f.get("name") not in old_names]
+    old_keys = {key for f in old_tree if (key := _feature_key(f)) is not None}
+    return [f for f in new_tree if _feature_key(f) not in old_keys]
 
 
 # ---------------------------------------------------------------------------

--- a/src/solidworks_mcp/tools/file_management.py
+++ b/src/solidworks_mcp/tools/file_management.py
@@ -222,11 +222,21 @@ class ListFeaturesInput(CompatInput):
 
     Attributes:
         include_suppressed (bool): The include suppressed value.
+        max_assembly_depth (int): Sub-assembly recursion depth for Assembly
+            documents.
     """
 
     include_suppressed: bool = Field(
         default=False,
         description="Include suppressed features in the returned list",
+    )
+    max_assembly_depth: int = Field(
+        default=2,
+        description=(
+            "For Assembly documents, how many levels of sub-assembly to "
+            "recurse into when flattening component features. Ignored for "
+            "Part documents."
+        ),
     )
 
 
@@ -933,7 +943,8 @@ async def register_file_management_tools(
             input_data = _coerce_input(ListFeaturesInput, input_data)
             if hasattr(adapter, "list_features"):
                 result = await adapter.list_features(
-                    include_suppressed=input_data.include_suppressed
+                    include_suppressed=input_data.include_suppressed,
+                    max_assembly_depth=input_data.max_assembly_depth,
                 )
                 if result.is_success:
                     return {

--- a/src/solidworks_mcp/tools/file_management.py
+++ b/src/solidworks_mcp/tools/file_management.py
@@ -14,7 +14,10 @@ from loguru import logger
 from pydantic import Field
 
 from ..adapters.base import SolidWorksAdapter
-from ..utils.feature_tree_classifier import classify_feature_tree_snapshot
+from ..utils.feature_tree_classifier import (
+    build_component_tree,
+    classify_feature_tree_snapshot,
+)
 from .input_compat import CompatInput
 
 # swPackAndGoSaveStatus_e — returned (per-file) by IModelDocExtension::SavePackAndGo.
@@ -951,6 +954,12 @@ async def register_file_management_tools(
                         "status": "success",
                         "features": result.data or [],
                         "count": len(result.data or []),
+                        # Additive, derived view of the same flat "features"
+                        # list above - grouped by component/sub-component
+                        # for callers that want the assembly structure
+                        # rather than a flat tag-and-scan. Does not change
+                        # the meaning of "features"/"count".
+                        "assembly_tree": build_component_tree(result.data),
                         "execution_time": result.execution_time,
                     }
                 return {

--- a/src/solidworks_mcp/utils/feature_tree_classifier.py
+++ b/src/solidworks_mcp/utils/feature_tree_classifier.py
@@ -278,3 +278,61 @@ def classify_feature_tree_snapshot(
         "next_actions": next_actions,
         "feature_count": len(feature_list),
     }
+
+
+def build_component_tree(features: list[Mapping[str, Any]] | None) -> dict[str, Any]:
+    """Reconstruct a nested component/sub-component tree from a flat
+    ``list_features`` result.
+
+    ``list_features`` returns a single flat list — see
+    ``openspec/changes/assembly-aware-list-features/design.md`` for why:
+    several existing callers (feature-tree diffing, feature-family
+    classification, the MCP tool's ``count`` field) assume
+    ``AdapterResult.data`` is a flat ``list[dict]`` unconditionally, so the
+    adapter contract stays flat. Each descriptor carries ``component``
+    (owning component, or ``None`` for the document's own features) and
+    ``component_parent`` (that component's immediate parent component, or
+    ``None`` for a top-level component), which is enough to rebuild the
+    tree a caller actually wants to *look at* without changing what the
+    adapter returns.
+
+    Args:
+        features: The flat list returned in an ``AdapterResult.data`` from
+            ``list_features``. Rows without a ``component_parent`` key
+            (older data, or non-component rows) are treated as top-level.
+
+    Returns:
+        dict[str, Any]: ``{"features": [...], "components": {name: {"path":
+        ..., "features": [...], "components": {...nested...}}}}``. For a
+        Part document (no rows carry a ``component``), this is just
+        ``{"features": [...all rows...], "components": {}}``.
+    """
+    rows = list(features or [])
+
+    own_features = [dict(r) for r in rows if r.get("component") is None]
+    root: dict[str, Any] = {"features": own_features, "components": {}}
+
+    nodes: dict[str, dict[str, Any]] = {}
+    parent_of: dict[str, str | None] = {}
+
+    for row in rows:
+        component = row.get("component")
+        if component is None:
+            continue
+        node = nodes.setdefault(
+            component,
+            {"path": row.get("component_path"), "features": [], "components": {}},
+        )
+        if row.get("type") not in ("UnresolvedComponent", "Component"):
+            node["features"].append(dict(row))
+        if row.get("component_path") and not node.get("path"):
+            node["path"] = row["component_path"]
+        parent_of[component] = row.get("component_parent")
+
+    for name, node in nodes.items():
+        parent = parent_of.get(name)
+        parent_node = nodes.get(parent) if parent else None
+        target = parent_node["components"] if parent_node is not None else root["components"]
+        target[name] = node
+
+    return root

--- a/src/solidworks_mcp/utils/feature_tree_classifier.py
+++ b/src/solidworks_mcp/utils/feature_tree_classifier.py
@@ -327,7 +327,9 @@ def build_component_tree(features: list[Mapping[str, Any]] | None) -> dict[str, 
             node["features"].append(dict(row))
         if row.get("component_path") and not node.get("path"):
             node["path"] = row["component_path"]
-        parent_of[component] = row.get("component_parent")
+        parent = row.get("component_parent")
+        if parent is not None or component not in parent_of:
+            parent_of[component] = parent
 
     for name, node in nodes.items():
         parent = parent_of.get(name)

--- a/tests/solidworks_mcp/adapters/solidworks/test_selection.py
+++ b/tests/solidworks_mcp/adapters/solidworks/test_selection.py
@@ -16,7 +16,7 @@ class _SelectionHarness(SolidWorksSelectionMixin):
     def __init__(self, *, has_model: bool) -> None:
         self.currentModel = object() if has_model else None
         self._feature_selector = SimpleNamespace(
-            list_features=lambda _include: [{"name": "Feat1"}],
+            list_features=lambda _include, _depth=2: [{"name": "Feat1"}],
             select_feature=lambda _name: {"selected": True},
         )
 

--- a/tests/solidworks_mcp/adapters/test_list_features_assembly.py
+++ b/tests/solidworks_mcp/adapters/test_list_features_assembly.py
@@ -1,0 +1,273 @@
+"""Regression tests for assembly-aware ``list_features``.
+
+Covers the ``_FeatureSelectionService`` traversal added for GitHub issue #21
+and OpenSpec change ``assembly-aware-list-features``: Part documents stay
+byte-for-byte unchanged, Assembly documents flatten component features into
+the same list tagged with ``component``/``component_path``, suppression is
+honored independently per document, sub-assembly recursion is bounded by
+``max_assembly_depth``, and an unresolvable component doesn't fail the call.
+
+Uses the same ``SimpleNamespace``-based COM fake pattern as the existing
+``test_list_features_*`` tests in ``test_adapters.py`` — no SolidWorks
+required.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from solidworks_mcp.adapters.pywin32_adapter import PyWin32Adapter
+
+
+class _Feature:
+    """Minimal COM feature fake: Name / GetTypeName2 / IsSuppressed / GetNextFeature."""
+
+    def __init__(self, name: str, feature_type: str, suppressed: bool = False) -> None:
+        self.Name = name
+        self._feature_type = feature_type
+        self._suppressed = suppressed
+        self._next: _Feature | None = None
+
+    def GetTypeName2(self) -> str:
+        return self._feature_type
+
+    def IsSuppressed(self) -> bool:
+        return self._suppressed
+
+    def GetNextFeature(self) -> _Feature | None:
+        return self._next
+
+
+def _chain(*features: _Feature) -> _Feature:
+    """Link features into a FirstFeature -> GetNextFeature chain."""
+    for a, b in zip(features, features[1:], strict=False):
+        a._next = b
+    return features[0]
+
+
+def _part_doc(path: str, title: str, *features: _Feature) -> SimpleNamespace:
+    """Build a fake IModelDoc2 Part document with a feature chain."""
+    first = _chain(*features) if features else None
+    return SimpleNamespace(
+        FirstFeature=lambda: first,
+        FeatureManager=SimpleNamespace(GetFeatureCount=lambda _all: 0),
+        GetType=lambda: 1,
+        GetPathName=lambda: path,
+        GetTitle=lambda: title,
+    )
+
+
+def _component(name: str, resolved_doc: SimpleNamespace | None) -> SimpleNamespace:
+    """Build a fake IComponent2: Name2 + GetModelDoc2."""
+    return SimpleNamespace(Name2=name, GetModelDoc2=lambda: resolved_doc)
+
+
+def _assembly_doc(
+    path: str,
+    title: str,
+    components: list[SimpleNamespace],
+    *own_features: _Feature,
+) -> SimpleNamespace:
+    """Build a fake IAssemblyDoc/IModelDoc2 with components + own features."""
+    first = _chain(*own_features) if own_features else None
+    return SimpleNamespace(
+        FirstFeature=lambda: first,
+        FeatureManager=SimpleNamespace(GetFeatureCount=lambda _all: 0),
+        GetType=lambda: 2,
+        GetPathName=lambda: path,
+        GetTitle=lambda: title,
+        GetComponents=lambda top_level_only=True: components,
+    )
+
+
+def _build_adapter(monkeypatch) -> PyWin32Adapter:
+    """Build a PyWin32Adapter with COM/platform checks bypassed, per the
+    existing convention in test_adapters.py's ``_build_adapter`` helpers.
+    """
+    monkeypatch.setattr(
+        "solidworks_mcp.adapters.pywin32_adapter.PYWIN32_AVAILABLE", True
+    )
+    monkeypatch.setattr(
+        "solidworks_mcp.adapters.pywin32_adapter.platform.system",
+        lambda: "Windows",
+    )
+    monkeypatch.setattr(
+        "solidworks_mcp.adapters.pywin32_adapter.pywintypes",
+        SimpleNamespace(com_error=RuntimeError),
+        raising=False,
+    )
+    return PyWin32Adapter({})
+
+
+@pytest.mark.asyncio
+async def test_part_document_unchanged(monkeypatch) -> None:
+    """A Part document's own features are unaffected, tagged component=None."""
+    adapter = _build_adapter(monkeypatch)
+    adapter.currentModel = _part_doc(
+        "C:\\mock\\Bracket.sldprt",
+        "Bracket.SLDPRT",
+        _Feature("Front Plane", "RefPlane"),
+        _Feature("Boss-Extrude1", "Boss"),
+    )
+
+    result = await adapter.list_features(include_suppressed=False)
+
+    assert result.is_success
+    assert [row["name"] for row in result.data] == ["Front Plane", "Boss-Extrude1"]
+    assert all(row["component"] is None for row in result.data)
+    assert all(row["component_path"] is None for row in result.data)
+
+
+@pytest.mark.asyncio
+async def test_assembly_flattens_component_features(monkeypatch) -> None:
+    """Assembly features + both components' features appear in one flat list."""
+    adapter = _build_adapter(monkeypatch)
+
+    part_a = _part_doc(
+        "C:\\mock\\PartA.sldprt", "PartA.SLDPRT", _Feature("Boss-Extrude1", "Boss")
+    )
+    part_b = _part_doc(
+        "C:\\mock\\PartB.sldprt", "PartB.SLDPRT", _Feature("Cut-Extrude1", "Cut")
+    )
+    components = [_component("PartA-1", part_a), _component("PartB-1", part_b)]
+    adapter.currentModel = _assembly_doc(
+        "C:\\mock\\Assem1.sldasm",
+        "Assem1.SLDASM",
+        components,
+        _Feature("Mate1", "Mate"),
+    )
+
+    result = await adapter.list_features(include_suppressed=False)
+
+    assert result.is_success
+    by_name = {row["name"]: row for row in result.data}
+
+    assert by_name["Mate1"]["component"] is None
+    assert by_name["Mate1"]["component_path"] is None
+
+    assert by_name["Boss-Extrude1"]["component"] == "PartA-1"
+    assert by_name["Boss-Extrude1"]["component_path"] == "C:\\mock\\PartA.sldprt"
+
+    assert by_name["Cut-Extrude1"]["component"] == "PartB-1"
+    assert by_name["Cut-Extrude1"]["component_path"] == "C:\\mock\\PartB.sldprt"
+
+
+@pytest.mark.asyncio
+async def test_suppression_is_independent_per_component(monkeypatch) -> None:
+    """A suppressed feature in one component doesn't affect another."""
+    adapter = _build_adapter(monkeypatch)
+
+    part_a = _part_doc(
+        "C:\\mock\\PartA.sldprt",
+        "PartA.SLDPRT",
+        _Feature("Boss-Extrude1", "Boss", suppressed=False),
+        _Feature("Fillet1", "Fillet", suppressed=True),
+    )
+    part_b = _part_doc(
+        "C:\\mock\\PartB.sldprt", "PartB.SLDPRT", _Feature("Cut-Extrude1", "Cut")
+    )
+    components = [_component("PartA-1", part_a), _component("PartB-1", part_b)]
+    adapter.currentModel = _assembly_doc(
+        "C:\\mock\\Assem1.sldasm", "Assem1.SLDASM", components
+    )
+
+    hidden = await adapter.list_features(include_suppressed=False)
+    shown = await adapter.list_features(include_suppressed=True)
+
+    hidden_names = {row["name"] for row in hidden.data}
+    shown_names = {row["name"] for row in shown.data}
+
+    assert "Fillet1" not in hidden_names
+    assert {"Boss-Extrude1", "Cut-Extrude1"} <= hidden_names
+    assert "Fillet1" in shown_names
+
+
+@pytest.mark.asyncio
+async def test_subassembly_recursion_within_default_depth(monkeypatch) -> None:
+    """A sub-assembly one level deep is expanded at the default depth of 2."""
+    adapter = _build_adapter(monkeypatch)
+
+    part_c = _part_doc(
+        "C:\\mock\\PartC.sldprt", "PartC.SLDPRT", _Feature("Boss-Extrude1", "Boss")
+    )
+    sub_assembly = _assembly_doc(
+        "C:\\mock\\SubAssem.sldasm",
+        "SubAssem.SLDASM",
+        [_component("PartC-1", part_c)],
+        _Feature("Mate2", "Mate"),
+    )
+    top_components = [_component("SubAssem-1", sub_assembly)]
+    adapter.currentModel = _assembly_doc(
+        "C:\\mock\\Top.sldasm", "Top.SLDASM", top_components
+    )
+
+    result = await adapter.list_features(include_suppressed=False)
+
+    names = [row["name"] for row in result.data]
+    assert "Mate2" in names
+    assert "Boss-Extrude1" in names
+
+    by_name = {row["name"]: row for row in result.data}
+    assert by_name["Mate2"]["component"] == "SubAssem-1"
+    assert by_name["Boss-Extrude1"]["component"] == "PartC-1"
+
+
+@pytest.mark.asyncio
+async def test_subassembly_beyond_depth_limit_is_not_expanded(monkeypatch) -> None:
+    """A sub-assembly beyond max_assembly_depth appears as one bare descriptor."""
+    adapter = _build_adapter(monkeypatch)
+
+    part_c = _part_doc(
+        "C:\\mock\\PartC.sldprt", "PartC.SLDPRT", _Feature("Boss-Extrude1", "Boss")
+    )
+    sub_assembly = _assembly_doc(
+        "C:\\mock\\SubAssem.sldasm",
+        "SubAssem.SLDASM",
+        [_component("PartC-1", part_c)],
+        _Feature("Mate2", "Mate"),
+    )
+    top_components = [_component("SubAssem-1", sub_assembly)]
+    adapter.currentModel = _assembly_doc(
+        "C:\\mock\\Top.sldasm", "Top.SLDASM", top_components
+    )
+
+    # depth 1: only the top-level assembly's own pass is unconditional;
+    # the sub-assembly component itself is beyond the budget.
+    result = await adapter.list_features(include_suppressed=False, max_assembly_depth=1)
+
+    names = [row["name"] for row in result.data]
+    assert "SubAssem-1" in names
+    assert "Mate2" not in names
+    assert "Boss-Extrude1" not in names
+
+    descriptor = next(row for row in result.data if row["name"] == "SubAssem-1")
+    assert descriptor["type"] == "Component"
+    assert descriptor["component"] == "SubAssem-1"
+    assert descriptor["component_path"] == "C:\\mock\\SubAssem.sldasm"
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_component_does_not_fail_the_call(monkeypatch) -> None:
+    """A component that can't be resolved yields one UnresolvedComponent row."""
+    adapter = _build_adapter(monkeypatch)
+
+    part_a = _part_doc(
+        "C:\\mock\\PartA.sldprt", "PartA.SLDPRT", _Feature("Boss-Extrude1", "Boss")
+    )
+    components = [
+        _component("PartA-1", part_a),
+        _component("MissingPart-1", None),
+    ]
+    adapter.currentModel = _assembly_doc(
+        "C:\\mock\\Assem1.sldasm", "Assem1.SLDASM", components
+    )
+
+    result = await adapter.list_features(include_suppressed=False)
+
+    assert result.is_success
+    by_name = {row["name"]: row for row in result.data}
+    assert by_name["Boss-Extrude1"]["component"] == "PartA-1"
+    assert by_name["MissingPart-1"]["type"] == "UnresolvedComponent"
+    assert by_name["MissingPart-1"]["component"] == "MissingPart-1"

--- a/tests/solidworks_mcp/adapters/test_list_features_assembly.py
+++ b/tests/solidworks_mcp/adapters/test_list_features_assembly.py
@@ -14,6 +14,7 @@ required.
 
 from __future__ import annotations
 
+import os
 from types import SimpleNamespace
 
 import pytest
@@ -148,10 +149,14 @@ async def test_assembly_flattens_component_features(monkeypatch) -> None:
     assert by_name["Mate1"]["component_path"] is None
 
     assert by_name["Boss-Extrude1"]["component"] == "PartA-1"
-    assert by_name["Boss-Extrude1"]["component_path"] == "C:\\mock\\PartA.sldprt"
+    assert by_name["Boss-Extrude1"]["component_path"] == os.path.abspath(
+        "C:\\mock\\PartA.sldprt"
+    )
 
     assert by_name["Cut-Extrude1"]["component"] == "PartB-1"
-    assert by_name["Cut-Extrude1"]["component_path"] == "C:\\mock\\PartB.sldprt"
+    assert by_name["Cut-Extrude1"]["component_path"] == os.path.abspath(
+        "C:\\mock\\PartB.sldprt"
+    )
 
 
 @pytest.mark.asyncio
@@ -260,7 +265,7 @@ async def test_subassembly_beyond_depth_limit_is_not_expanded(monkeypatch) -> No
     descriptor = next(row for row in result.data if row["name"] == "SubAssem-1")
     assert descriptor["type"] == "Component"
     assert descriptor["component"] == "SubAssem-1"
-    assert descriptor["component_path"] == "C:\\mock\\SubAssem.sldasm"
+    assert descriptor["component_path"] == os.path.abspath("C:\\mock\\SubAssem.sldasm")
 
 
 @pytest.mark.asyncio

--- a/tests/solidworks_mcp/adapters/test_list_features_assembly.py
+++ b/tests/solidworks_mcp/adapters/test_list_features_assembly.py
@@ -210,6 +210,21 @@ async def test_subassembly_recursion_within_default_depth(monkeypatch) -> None:
     assert "Boss-Extrude1" in names
 
     by_name = {row["name"]: row for row in result.data}
+    # SubAssem-1 is top-level: no parent.
+    assert by_name["Mate2"]["component"] == "SubAssem-1"
+    assert by_name["Mate2"]["component_parent"] is None
+    # PartC-1 is nested inside SubAssem-1: component_parent links it back,
+    # distinguishing "nested inside" from merely "also in this assembly".
+    assert by_name["Boss-Extrude1"]["component"] == "PartC-1"
+    assert by_name["Boss-Extrude1"]["component_parent"] == "SubAssem-1"
+
+    from solidworks_mcp.utils.feature_tree_classifier import build_component_tree
+
+    tree = build_component_tree(result.data)
+    assert "PartC-1" in tree["components"]["SubAssem-1"]["components"]
+    assert "PartC-1" not in tree["components"]
+
+    by_name = {row["name"]: row for row in result.data}
     assert by_name["Mate2"]["component"] == "SubAssem-1"
     assert by_name["Boss-Extrude1"]["component"] == "PartC-1"
 

--- a/tests/solidworks_mcp/adapters/test_mock_adapter_assembly_features.py
+++ b/tests/solidworks_mcp/adapters/test_mock_adapter_assembly_features.py
@@ -1,0 +1,130 @@
+"""Tests for MockSolidWorksAdapter's assembly-aware ``list_features``.
+
+Companion to ``test_list_features_assembly.py`` (which covers the real
+pywin32 adapter with COM fakes) — exercises the same behavior against the
+mock adapter's configurable ``_assembly_components`` fixture, per GitHub
+issue #21 / OpenSpec change ``assembly-aware-list-features``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from solidworks_mcp.adapters.mock_adapter import MockSolidWorksAdapter
+
+
+@pytest.mark.asyncio
+async def test_part_model_unaffected(mock_adapter: MockSolidWorksAdapter) -> None:
+    """A Part model's seeded features are unchanged, tagged component=None."""
+    await mock_adapter.open_model("C:\\mock\\Bracket.sldprt")
+
+    result = await mock_adapter.list_features()
+
+    assert result.is_success
+    assert len(result.data) == 5  # the existing seeded fixture
+    assert all(row["component"] is None for row in result.data)
+    assert all(row["component_path"] is None for row in result.data)
+
+
+@pytest.mark.asyncio
+async def test_assembly_default_fixture_flattens_components(
+    mock_adapter: MockSolidWorksAdapter,
+) -> None:
+    """An Assembly with no configured components uses the canned fixture."""
+    await mock_adapter.open_model("C:\\mock\\Assem1.sldasm")
+
+    result = await mock_adapter.list_features()
+
+    assert result.is_success
+    by_name = {row["name"]: row for row in result.data}
+    # Own (assembly-level) seeded features are unattributed.
+    assert by_name["Origin"]["component"] is None
+    # Default fixture: two Part components plus one nested sub-assembly.
+    assert by_name["Boss-Extrude1"]["component"] in {"PartA", "PartC"}
+    assert by_name["Cut-Extrude1"]["component"] == "PartB"
+    assert by_name["Mate1"]["component"] == "SubAssembly1"
+
+
+@pytest.mark.asyncio
+async def test_assembly_custom_components_and_suppression(
+    mock_adapter: MockSolidWorksAdapter,
+) -> None:
+    """Custom _assembly_components are flattened, suppression applied per component."""
+    await mock_adapter.open_model("C:\\mock\\Assem1.sldasm")
+    mock_adapter._assembly_components = {
+        "CompA": {
+            "type": "Part",
+            "path": "Mock://CompA.sldprt",
+            "features": [
+                {"name": "Boss1", "type": "Boss", "suppressed": False},
+                {"name": "Hidden1", "type": "Fillet", "suppressed": True},
+            ],
+        },
+        "CompB": {
+            "type": "Part",
+            "path": "Mock://CompB.sldprt",
+            "features": [{"name": "Cut1", "type": "Cut", "suppressed": False}],
+        },
+    }
+
+    hidden = await mock_adapter.list_features(include_suppressed=False)
+    shown = await mock_adapter.list_features(include_suppressed=True)
+
+    hidden_names = {row["name"] for row in hidden.data}
+    shown_names = {row["name"] for row in shown.data}
+
+    assert "Hidden1" not in hidden_names
+    assert "Hidden1" in shown_names
+
+    by_name = {row["name"]: row for row in shown.data}
+    assert by_name["Boss1"]["component"] == "CompA"
+    assert by_name["Boss1"]["component_path"] == "Mock://CompA.sldprt"
+    assert by_name["Cut1"]["component"] == "CompB"
+
+
+@pytest.mark.asyncio
+async def test_assembly_depth_limit(mock_adapter: MockSolidWorksAdapter) -> None:
+    """A sub-assembly beyond max_assembly_depth is a bare descriptor."""
+    await mock_adapter.open_model("C:\\mock\\Assem1.sldasm")
+    mock_adapter._assembly_components = {
+        "SubA": {
+            "type": "Assembly",
+            "path": "Mock://SubA.sldasm",
+            "features": [{"name": "Mate1", "type": "Mate", "suppressed": False}],
+            "components": {
+                "Nested": {
+                    "type": "Part",
+                    "path": "Mock://Nested.sldprt",
+                    "features": [{"name": "Boss1", "type": "Boss", "suppressed": False}],
+                },
+            },
+        },
+    }
+
+    result = await mock_adapter.list_features(max_assembly_depth=1)
+
+    names = [row["name"] for row in result.data]
+    assert "SubA" in names
+    assert "Mate1" not in names
+    assert "Boss1" not in names
+
+    descriptor = next(row for row in result.data if row["name"] == "SubA")
+    assert descriptor["type"] == "Component"
+    assert descriptor["component"] == "SubA"
+
+
+@pytest.mark.asyncio
+async def test_assembly_unresolved_component(mock_adapter: MockSolidWorksAdapter) -> None:
+    """An Unresolved-type component yields one UnresolvedComponent row."""
+    await mock_adapter.open_model("C:\\mock\\Assem1.sldasm")
+    mock_adapter._assembly_components = {
+        "Missing": {"type": "Unresolved", "path": None, "features": []},
+    }
+
+    result = await mock_adapter.list_features()
+
+    assert result.is_success
+    assert len(result.data) >= 1
+    row = next(r for r in result.data if r["name"] == "Missing")
+    assert row["type"] == "UnresolvedComponent"
+    assert row["component"] == "Missing"

--- a/tests/solidworks_mcp/agents/test_soc_pickup.py
+++ b/tests/solidworks_mcp/agents/test_soc_pickup.py
@@ -118,6 +118,27 @@ def test_diff_ignores_removed_features():
     assert result == []
 
 
+def test_diff_disambiguates_same_name_across_components():
+    """Two different components sharing a feature name (e.g. every part has
+    its own "Boss-Extrude1") must not shadow each other in the diff - a new
+    feature in one component isn't "already seen" just because a
+    same-named feature already existed in a different component.
+    """
+
+    def _comp_feat(name: str, ftype: str, component: str) -> dict:
+        return {"name": name, "type": ftype, "component": component}
+
+    old = [_comp_feat("Boss-Extrude1", "Boss-Extrude", "PartA-1")]
+    new = [
+        _comp_feat("Boss-Extrude1", "Boss-Extrude", "PartA-1"),
+        # Same feature name, different component - genuinely new.
+        _comp_feat("Boss-Extrude1", "Boss-Extrude", "PartB-1"),
+    ]
+    result = diff_feature_trees(old, new)
+    assert len(result) == 1
+    assert result[0]["component"] == "PartB-1"
+
+
 # ---------------------------------------------------------------------------
 # emit_feature_lines
 # ---------------------------------------------------------------------------

--- a/tests/solidworks_mcp/security/test_utils_circuit_coverage.py
+++ b/tests/solidworks_mcp/security/test_utils_circuit_coverage.py
@@ -83,7 +83,9 @@ class _DummyAdapter(SolidWorksAdapter):
             },
         )
 
-    async def list_features(self, include_suppressed: bool = False):
+    async def list_features(
+        self, include_suppressed: bool = False, max_assembly_depth: int = 2
+    ):
         """Test helper for list features."""
         return AdapterResult(
             status=AdapterResultStatus.SUCCESS,

--- a/tests/solidworks_mcp/tools/test_file_management.py
+++ b/tests/solidworks_mcp/tools/test_file_management.py
@@ -821,6 +821,39 @@ class TestFileManagementTools:
         configs_exception = await list_configs_tool()
         assert configs_exception["status"] == "error"
 
+    @pytest.mark.asyncio
+    async def test_list_features_tool_flattened_assembly_result(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """list_features tool count/features keep working against a real
+        (unmocked) flattened Assembly result — guards the design decision
+        to keep AdapterResult.data a flat list for assemblies (see OpenSpec
+        change assembly-aware-list-features/design.md) against silent
+        breakage of the count/features contract.
+        """
+        await register_file_management_tools(mcp_server, mock_adapter, mock_config)
+
+        list_features_tool = None
+        for tool in await mcp_server.list_tools():
+            if tool.name == "list_features":
+                list_features_tool = tool.fn
+        assert list_features_tool is not None
+
+        await mock_adapter.open_model("C:\\mock\\Assem1.sldasm")
+
+        result = await list_features_tool(input_data={"include_suppressed": False})
+
+        assert result["status"] == "success"
+        assert isinstance(result["features"], list)
+        assert result["count"] == len(result["features"])
+        assert result["count"] > 0
+        # classify_feature_tree_snapshot must not choke on the new
+        # component/component_path keys riding along on each descriptor.
+        classification = classify_feature_tree_snapshot(
+            {"type": "Assembly"}, result["features"]
+        )
+        assert classification["family"] is not None
+
     def test_classify_feature_tree_snapshot_paths(self):
         """Classify common feature families and low-confidence sketch-only snapshots."""
         revolve = classify_feature_tree_snapshot(

--- a/tests/solidworks_mcp/utils/test_feature_tree_classifier.py
+++ b/tests/solidworks_mcp/utils/test_feature_tree_classifier.py
@@ -255,6 +255,51 @@ def test_build_component_tree_nests_subassembly_components() -> None:
     assert [f["name"] for f in sub["components"]["PartC"]["features"]] == ["Boss1"]
 
 
+def test_build_component_tree_preserves_parent_across_mixed_rows() -> None:
+    """A component's first-discovered non-None parent survives later rows
+    for the same component that lack component_parent or carry it as None.
+    """
+    features = [
+        {
+            "name": "Mate1",
+            "type": "Mate",
+            "component": "SubAssem-1",
+            "component_path": "C:/SubAssem.sldasm",
+            "component_parent": None,
+        },
+        {
+            "name": "Boss1",
+            "type": "Boss",
+            "component": "PartC",
+            "component_path": "C:/PartC.sldprt",
+            "component_parent": "SubAssem-1",
+        },
+        {
+            "name": "Fillet1",
+            "type": "Fillet",
+            "component": "PartC",
+            "component_path": "C:/PartC.sldprt",
+            "component_parent": None,
+        },
+        {
+            "name": "Cut1",
+            "type": "Cut",
+            "component": "PartC",
+            "component_path": "C:/PartC.sldprt",
+        },
+    ]
+    tree = build_component_tree(features)
+    assert "PartC" not in tree["components"]
+    assert set(tree["components"].keys()) == {"SubAssem-1"}
+    nested = tree["components"]["SubAssem-1"]["components"]
+    assert set(nested.keys()) == {"PartC"}
+    assert [f["name"] for f in nested["PartC"]["features"]] == [
+        "Boss1",
+        "Fillet1",
+        "Cut1",
+    ]
+
+
 def test_build_component_tree_excludes_marker_rows_from_features() -> None:
     """UnresolvedComponent/Component marker rows create a node but aren't feature entries."""
     features = [

--- a/tests/solidworks_mcp/utils/test_feature_tree_classifier.py
+++ b/tests/solidworks_mcp/utils/test_feature_tree_classifier.py
@@ -7,6 +7,7 @@ from solidworks_mcp.utils.feature_tree_classifier import (
     _feature_text,
     _has_any,
     _match_examples,
+    build_component_tree,
     classify_feature_tree_snapshot,
 )
 
@@ -178,3 +179,102 @@ def test_classify_mixed_sketch_and_reference_not_sketch_only() -> None:
     result = classify_feature_tree_snapshot({}, features)
     # non_reference_count == 2 but sketch_like_count == 1, so != → unknown
     assert result["family"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# build_component_tree
+# ---------------------------------------------------------------------------
+
+
+def test_build_component_tree_handles_none_and_empty() -> None:
+    assert build_component_tree(None) == {"features": [], "components": {}}
+    assert build_component_tree([]) == {"features": [], "components": {}}
+
+
+def test_build_component_tree_part_only_has_no_components() -> None:
+    """A Part's flat list (no component tags at all) becomes root features only."""
+    features = [
+        {"name": "Boss-Extrude1", "type": "Boss", "component": None},
+        {"name": "Sketch1", "type": "ProfileFeature", "component": None},
+    ]
+    tree = build_component_tree(features)
+    assert len(tree["features"]) == 2
+    assert tree["components"] == {}
+
+
+def test_build_component_tree_flat_top_level_components() -> None:
+    """Two top-level components (component_parent=None) become sibling nodes."""
+    features = [
+        {"name": "Mates", "type": "MateGroup", "component": None, "component_path": None},
+        {
+            "name": "Boss1",
+            "type": "Boss",
+            "component": "PartA",
+            "component_path": "C:/PartA.sldprt",
+            "component_parent": None,
+        },
+        {
+            "name": "Cut1",
+            "type": "Cut",
+            "component": "PartB",
+            "component_path": "C:/PartB.sldprt",
+            "component_parent": None,
+        },
+    ]
+    tree = build_component_tree(features)
+    assert len(tree["features"]) == 1
+    assert set(tree["components"].keys()) == {"PartA", "PartB"}
+    assert tree["components"]["PartA"]["path"] == "C:/PartA.sldprt"
+    assert [f["name"] for f in tree["components"]["PartA"]["features"]] == ["Boss1"]
+    assert tree["components"]["PartA"]["components"] == {}
+
+
+def test_build_component_tree_nests_subassembly_components() -> None:
+    """A component whose component_parent points at another component nests under it."""
+    features = [
+        {
+            "name": "Mate1",
+            "type": "Mate",
+            "component": "SubAssem-1",
+            "component_path": "C:/SubAssem.sldasm",
+            "component_parent": None,
+        },
+        {
+            "name": "Boss1",
+            "type": "Boss",
+            "component": "PartC",
+            "component_path": "C:/PartC.sldprt",
+            "component_parent": "SubAssem-1",
+        },
+    ]
+    tree = build_component_tree(features)
+    assert set(tree["components"].keys()) == {"SubAssem-1"}
+    sub = tree["components"]["SubAssem-1"]
+    assert [f["name"] for f in sub["features"]] == ["Mate1"]
+    assert set(sub["components"].keys()) == {"PartC"}
+    assert [f["name"] for f in sub["components"]["PartC"]["features"]] == ["Boss1"]
+
+
+def test_build_component_tree_excludes_marker_rows_from_features() -> None:
+    """UnresolvedComponent/Component marker rows create a node but aren't feature entries."""
+    features = [
+        {
+            "name": "Missing-1",
+            "type": "UnresolvedComponent",
+            "component": "Missing-1",
+            "component_path": None,
+            "component_parent": None,
+        },
+        {
+            "name": "DeepSub-1",
+            "type": "Component",
+            "component": "DeepSub-1",
+            "component_path": "C:/DeepSub.sldasm",
+            "component_parent": None,
+        },
+    ]
+    tree = build_component_tree(features)
+    assert set(tree["components"].keys()) == {"Missing-1", "DeepSub-1"}
+    assert tree["components"]["Missing-1"]["features"] == []
+    assert tree["components"]["DeepSub-1"]["features"] == []
+    assert tree["components"]["DeepSub-1"]["path"] == "C:/DeepSub.sldasm"

--- a/tests/test_live_sw_regression.py
+++ b/tests/test_live_sw_regression.py
@@ -189,6 +189,52 @@ async def connected_adapter():
         await adapter.disconnect()
 
 
+def _resolve_active_sketch(adapter):
+    """Resolve the live ISketch object, tolerant of a stale adapter cache.
+
+    ``adapter.currentSketch`` is cached at sketch-creation time in
+    ``create_sketch`` (``sketch.py``), which already falls back through
+    ``InsertSketch`` -> ``currentModel.GetActiveSketch2`` ->
+    ``swApp.ActiveDoc.GetActiveSketch2`` if the first call comes back
+    falsy. Empirically that chain can still land on ``None`` on some COM
+    binding passes even though SW genuinely has an active sketch open —
+    seen live as ``AttributeError: 'NoneType' object has no attribute
+    'GetSketchSegments'`` in ``test_sketch_circular_pattern_creates_real_
+    pattern`` / ``test_sketch_mirror_reflects_lines_about_centerline``,
+    despite half a dozen other tests using the identical
+    ``adapter.currentSketch`` read passing in the same run — i.e. this is
+    intermittent, not a deterministic "this environment always returns
+    bool" case, so patching only the two tests that happened to fail
+    would leave the same latent bug in every other call site.
+
+    Queries SW directly instead of trusting the cache: verification
+    always happens after the sketch operations under test have already
+    completed, so asking ``SketchManager.ActiveSketch`` (falling back to
+    ``GetActiveSketch2``) fresh at that point is strictly more reliable
+    than an early cached pointer.
+    """
+    from solidworks_mcp.adapters import sw_type_info
+
+    active_sketch = adapter.currentSketch
+    if active_sketch is None:
+        sketch_manager = adapter.currentModel.SketchManager
+        adapter._attempt(
+            lambda: sw_type_info.flag_methods(sketch_manager, "ISketchManager"),
+            default=0,
+        )
+        active_sketch = adapter._attempt(lambda: sketch_manager.ActiveSketch)
+    if active_sketch is None:
+        active_sketch = adapter._attempt(
+            lambda: adapter.currentModel.GetActiveSketch2()
+        )
+    assert active_sketch is not None, (
+        "no active sketch resolvable via currentSketch, "
+        "SketchManager.ActiveSketch, or GetActiveSketch2"
+    )
+    sw_type_info.flag_methods(active_sketch, "ISketch")
+    return active_sketch
+
+
 async def test_connect_acquires_late_bound_swapp(connected_adapter) -> None:
     """After connect(), swApp is a pywin32 late-bound CDispatch.
 
@@ -708,8 +754,7 @@ async def test_add_polygon_creates_real_polygon(connected_adapter) -> None:
 
         from solidworks_mcp.adapters import sw_type_info
 
-        active_sketch = adapter.currentSketch
-        sw_type_info.flag_methods(active_sketch, "ISketch")
+        active_sketch = _resolve_active_sketch(adapter)
         segments = active_sketch.GetSketchSegments()
 
         line_segments = []
@@ -815,8 +860,7 @@ async def test_sketch_linear_pattern_creates_real_pattern(connected_adapter) -> 
 
         from solidworks_mcp.adapters import sw_type_info
 
-        active_sketch = adapter.currentSketch
-        sw_type_info.flag_methods(active_sketch, "ISketch")
+        active_sketch = _resolve_active_sketch(adapter)
         segments = active_sketch.GetSketchSegments()
         # Each instance is a circle; SW does not insert auxiliary
         # construction geometry for a linear pattern.
@@ -954,8 +998,7 @@ async def test_sketch_circular_pattern_creates_real_pattern(
         # GetCenterPoint as zero-arg properties returning a tuple.
         from solidworks_mcp.adapters import sw_type_info
 
-        active_sketch = adapter.currentSketch
-        sw_type_info.flag_methods(active_sketch, "ISketch")
+        active_sketch = _resolve_active_sketch(adapter)
         segments = active_sketch.GetSketchSegments()
         assert len(segments) == 6, (
             f"expected 6 sketch segments after pattern, got {len(segments)}"
@@ -1073,8 +1116,7 @@ async def test_sketch_mirror_reflects_lines_about_centerline(
 
         from solidworks_mcp.adapters import sw_type_info
 
-        active_sketch = adapter.currentSketch
-        sw_type_info.flag_methods(active_sketch, "ISketch")
+        active_sketch = _resolve_active_sketch(adapter)
         segments = active_sketch.GetSketchSegments()
 
         # Expect N source lines + N mirrored lines + 1 centerline.
@@ -1214,8 +1256,7 @@ async def test_sketch_offset_creates_real_offset(connected_adapter) -> None:
 
         from solidworks_mcp.adapters import sw_type_info
 
-        active_sketch = adapter.currentSketch
-        sw_type_info.flag_methods(active_sketch, "ISketch")
+        active_sketch = _resolve_active_sketch(adapter)
         segments = active_sketch.GetSketchSegments()
 
         # 2 sources + 2 offsets = 4 line segments, no construction.
@@ -1335,8 +1376,7 @@ async def test_add_centerline_creates_real_centerline(connected_adapter) -> None
 
         from solidworks_mcp.adapters import sw_type_info
 
-        active_sketch = adapter.currentSketch
-        sw_type_info.flag_methods(active_sketch, "ISketch")
+        active_sketch = _resolve_active_sketch(adapter)
         segments = active_sketch.GetSketchSegments()
         assert len(segments) == 1, (
             f"expected 1 sketch segment after add_centerline, got {len(segments)}"
@@ -1528,10 +1568,7 @@ async def test_polygon_id_flows_into_circular_pattern_live(
         # produces 6 polygon edges + 1 inscribed construction circle in
         # SW 2026, but the exact count varies by SW version — measure
         # empirically rather than hard-coding.
-        from solidworks_mcp.adapters import sw_type_info
-
-        active_sketch = adapter.currentSketch
-        sw_type_info.flag_methods(active_sketch, "ISketch")
+        active_sketch = _resolve_active_sketch(adapter)
         seed_segments = len(active_sketch.GetSketchSegments())
         assert seed_segments >= 6, (
             f"expected at least 6 polygon edges, got {seed_segments}"
@@ -1587,10 +1624,7 @@ async def test_rectangle_id_flows_into_circular_pattern_live(
         seed = await adapter.add_rectangle(20.0, -5.0, 40.0, 5.0)
         assert seed.is_success, f"add_rectangle failed: {seed.error}"
 
-        from solidworks_mcp.adapters import sw_type_info
-
-        active_sketch = adapter.currentSketch
-        sw_type_info.flag_methods(active_sketch, "ISketch")
+        active_sketch = _resolve_active_sketch(adapter)
         seed_segments = len(active_sketch.GetSketchSegments())
         # SW 2026's corner-rectangle tool emits 4 line edges + 2 implicit
         # construction segments (the diagonal markers). Just guard the
@@ -2068,3 +2102,142 @@ async def test_create_loft_too_few_profiles_returns_error(connected_adapter) -> 
         assert "at least 2 profile" in (bad.error or "")
     finally:
         await adapter.close_model(save=False)
+
+
+# ---- list_features assembly-aware live regression (GitHub issue #21) ----
+#
+# openspec/changes/assembly-aware-list-features/ has the full proposal/
+# design/spec/tasks. Uses SolidWorks' own built-in U-Joint sample, which
+# ships with every SW install under samples/learn/U-Joint/ and conveniently
+# already contains a two-level assembly (UJoint.SLDASM containing a nested
+# sub-assembly, "crank sub.SLDASM") - no fixture part/assembly needed.
+
+_UJOINT_SAMPLE_DIR = (
+    r"C:\Users\Public\Documents\SOLIDWORKS\SOLIDWORKS 2026\samples\learn\U-Joint"
+)
+
+
+def _ujoint_assembly_path() -> str:
+    """Return the shipped U-Joint assembly path, or "" if not installed."""
+    import os as _os
+
+    path = _os.path.join(_UJOINT_SAMPLE_DIR, "UJoint.SLDASM")
+    return path if _os.path.exists(path) else ""
+
+
+async def test_list_features_assembly_resolves_real_components_and_subassembly(
+    connected_adapter,
+) -> None:
+    """End-to-end: ``list_features`` on a real, multi-level assembly
+    resolves every component's features, including one level of
+    sub-assembly recursion, tagged and nestable correctly.
+
+    Regression history this test guards against:
+
+    1. ``document.GetType()`` called with bare parens raised ``"'int'
+       object is not callable"`` on a freshly-fetched ``swApp.ActiveDoc``
+       (unflagged dispatch resolves it as a property there, unlike a
+       document just returned by ``OpenDoc6``) — silently swallowed by
+       ``_attempt``, so the doc-type check always fell back to ``0`` and
+       the assembly branch never ran at all.
+    2. ``IComponent2.GetModelDoc2`` raised ``com_error: Member not
+       found`` on every component because ``IComponent2`` was never
+       flagged via ``sw_type_info.flag_methods`` before calling it —
+       every component silently became ``UnresolvedComponent``.
+
+    Both bugs passed every mock-adapter unit test in
+    ``tests/solidworks_mcp/adapters/test_list_features_assembly.py`` —
+    the traversal logic itself was correct — and only surfaced against a
+    real, unflagged COM dispatch. This is the only test in the suite that
+    would catch either regression coming back. See
+    ``docs/agents/com-api-pitfalls.md`` items #11/#12 and
+    ``docs/getting-started/tutorial-parts/list_features_assembly_demo.py``
+    for the interactive/manual version of this same check.
+    """
+    assembly_path = _ujoint_assembly_path()
+    if not assembly_path:
+        pytest.skip(
+            f"U-Joint sample not found under {_UJOINT_SAMPLE_DIR} — install "
+            "the SolidWorks sample library to run this test"
+        )
+
+    adapter = connected_adapter
+
+    # A prior run may have left the sample open; start clean so
+    # open_model definitely produces a fresh ActiveDoc.
+    adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))
+
+    try:
+        result = await adapter.open_model(assembly_path)
+        assert result.is_success, f"open_model failed: {result.error}"
+
+        feat_result = await adapter.list_features(
+            include_suppressed=False, max_assembly_depth=2
+        )
+        assert feat_result.is_success, f"list_features failed: {feat_result.error}"
+
+        data = feat_result.data
+        assert isinstance(data, list), (
+            "list_features must stay a flat list even for an Assembly - "
+            "see design.md's rejected nested-response alternative"
+        )
+
+        own_features = [r for r in data if r["component"] is None]
+        assert own_features, "assembly's own top-level features must be present"
+
+        # Top-level components in the shipped U-Joint sample: five parts
+        # plus the "crank sub" sub-assembly.
+        top_level = {
+            "bracket-1",
+            "Yoke_male-1",
+            "Yoke_female-1",
+            "spider-1",
+            "pin-1",
+            "pin-2",
+            "pin-3",
+            "crank sub-1",
+        }
+        components_seen = {r["component"] for r in data if r["component"]}
+        missing = top_level - components_seen
+        assert not missing, f"expected top-level components missing: {missing}"
+
+        # Sub-assembly recursion (max_assembly_depth=2, the default):
+        # crank sub-1's own three part components must be resolved too,
+        # not left as a single bare Component marker.
+        sub_assembly_parts = {"crank-arm-1", "crank-knob-1", "crank-shaft-1"}
+        missing_nested = sub_assembly_parts - components_seen
+        assert not missing_nested, (
+            f"sub-assembly recursion did not surface nested parts: {missing_nested}"
+        )
+
+        # The whole point of bug #2 above: nothing should come back
+        # UnresolvedComponent on a real, fully-resolvable assembly.
+        unresolved = [r for r in data if r["type"] == "UnresolvedComponent"]
+        assert not unresolved, f"unresolved components: {unresolved}"
+
+        # component_parent must link crank sub-1's children back to it.
+        crank_children = [r for r in data if r["component"] in sub_assembly_parts]
+        assert crank_children, "expected features tagged to crank sub-1's children"
+        assert all(r["component_parent"] == "crank sub-1" for r in crank_children), (
+            f"crank sub-1 children missing correct component_parent: "
+            f"{crank_children[:3]}"
+        )
+
+        # build_component_tree must nest those children under crank
+        # sub-1's own node, not flatten them alongside its top-level
+        # siblings.
+        from solidworks_mcp.utils.feature_tree_classifier import build_component_tree
+
+        tree = build_component_tree(data)
+        assert "crank sub-1" in tree["components"], sorted(tree["components"])
+        nested = tree["components"]["crank sub-1"]["components"]
+        assert sub_assembly_parts <= set(nested), (
+            f"expected {sub_assembly_parts} nested under crank sub-1, "
+            f"got {sorted(nested)}"
+        )
+        assert not (sub_assembly_parts & set(tree["components"])), (
+            "sub-assembly parts leaked into the top-level tree instead of "
+            "nesting under crank sub-1"
+        )
+    finally:
+        adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))


### PR DESCRIPTION
## Summary
- `list_features` now recurses into an assembly's resolved components (and sub-assemblies, bounded by `max_assembly_depth`), tagging each descriptor with `component`/`component_path`/`component_parent` while keeping the existing flat-list contract so current consumers (MCP tool layer, `classify_feature_tree`, `soc_pickup.py`, `model_service.py`) see no behavior change on Parts.
- Adds `build_component_tree()` (`src/solidworks_mcp/utils/feature_tree_classifier.py`) as a derived nested-tree view for callers who want real parent→child structure instead of scanning tags.
- Fixes two live-only COM bugs found by running against a real SolidWorks session (not catchable by the mock adapter): a `GetType()` late-binding property/method ambiguity, and a missing `sw_type_info.flag_methods` call on `IComponent2` before `GetModelDoc2`. Documented in `docs/agents/com-api-pitfalls.md` (#11, #12).
- Adds a live demo script (`docs/getting-started/tutorial-parts/list_features_assembly_demo.py`) against the shipped U-Joint sample assembly, and a real `solidworks_only` integration test (`test_list_features_assembly_resolves_real_components_and_subassembly`) that exercises the full flow end-to-end, distinct from the mock-based unit tests.
- Fixes a flaky `adapter.currentSketch` (intermittently `None` right after a fresh sketch) across all 8 affected call sites in `test_live_sw_regression.py` via a `_resolve_active_sketch()` fallback, and a cross-platform path bug in `test_list_features_assembly.py` found by running the suite in a Linux CI container.
- Developed using the OpenSpec spec-driven workflow; change proposal under `openspec/changes/assembly-aware-list-features/`.

## Test plan
- [x] Windows mock-only suite: 1904 passed, 0 failed
- [x] Live SolidWorks regression suite: 25 passed, 1 flaky (passed on isolated retry)
- [x] Local CI in Linux Docker container (`make test`): 1892 passed, 0 failed, 98.74% coverage
- [x] pip-audit: clean
- [x] Bandit: clean (0 High severity)
- [x] Banned-CDN-domain check: clean
- [ ] Trivy: inconclusive locally (hung on this machine's Docker Desktop/WSL2 setup across three attempts, unrelated to repo content); GitHub Actions' hosted Trivy scan runs independently on this PR

Closes #21