### PR TITLE
Refuse instead of inventing when the adapter cannot do the job

### DIFF
--- a/src/solidworks_mcp/tools/analysis.py
+++ b/src/solidworks_mcp/tools/analysis.py
@@ -296,14 +296,14 @@ async def register_analysis_tools(
                     "message": result.error or "Interference check failed",
                 }
 
-            # Simulated interference check - would use actual analysis
             return {
-                "status": "success",
-                "message": "Interference check completed",
-                "interference_found": False,  # Would be actual result
-                "components_checked": input_data.components,
-                "tolerance": input_data.tolerance,
-                "interferences": [],  # Would contain actual interference data
+                "status": "error",
+                "message": (
+                    "Active adapter does not support check_interference; no "
+                    "interference analysis was performed. Use SolidWorks "
+                    "directly (Tools > Interference Detection) to check this "
+                    "assembly."
+                ),
             }
 
         except Exception as e:
@@ -327,16 +327,26 @@ async def register_analysis_tools(
             dict[str, Any]: A dictionary containing the resulting values.
         """
         try:
-            # Simulated geometry analysis
+            if hasattr(adapter, "analyze_geometry"):
+                result = await adapter.analyze_geometry(input_data.model_dump())
+                if result.is_success:
+                    return {
+                        "status": "success",
+                        "message": f"Geometry analysis ({input_data.analysis_type}) completed",
+                        "data": result.data,
+                        "execution_time": result.execution_time,
+                    }
+                return {
+                    "status": "error",
+                    "message": result.error or "Failed to analyze geometry",
+                }
+
             return {
-                "status": "success",
-                "message": f"Geometry analysis ({input_data.analysis_type}) completed",
-                "analysis_type": input_data.analysis_type,
-                "results": {
-                    "summary": f"Analysis of type {input_data.analysis_type} completed",
-                    "parameters": input_data.parameters,
-                    "findings": ["No issues found"],  # Would be actual results
-                },
+                "status": "error",
+                "message": (
+                    f"Active adapter does not support analyze_geometry; no "
+                    f"{input_data.analysis_type} analysis was performed."
+                ),
             }
 
         except Exception as e:
@@ -356,20 +366,31 @@ async def register_analysis_tools(
         Returns:
             dict[str, Any]: A dictionary containing the resulting values.
         """
-        # Simulated material properties
-        return {
-            "status": "success",
-            "material": {
-                "name": "Steel, Plain Carbon",
-                "density": {"value": 7850, "units": "kg/m³"},
-                "elastic_modulus": {"value": 200000, "units": "MPa"},
-                "yield_strength": {"value": 250, "units": "MPa"},
-                "ultimate_tensile_strength": {"value": 400, "units": "MPa"},
-                "poissons_ratio": 0.29,
-                "thermal_conductivity": {"value": 50, "units": "W/(m·K)"},
-                "specific_heat": {"value": 460, "units": "J/(kg·K)"},
-            },
-        }
+        try:
+            if hasattr(adapter, "get_material_properties"):
+                result = await adapter.get_material_properties()
+                if result.is_success:
+                    return {
+                        "status": "success",
+                        "message": "Material properties retrieved successfully",
+                        "data": result.data,
+                        "execution_time": result.execution_time,
+                    }
+                return {
+                    "status": "error",
+                    "message": result.error or "Failed to get material properties",
+                }
+
+            return {
+                "status": "error",
+                "message": "Active adapter does not support get_material_properties",
+            }
+        except Exception as e:
+            logger.error(f"Error in get_material_properties tool: {e}")
+            return {
+                "status": "error",
+                "message": f"Unexpected error: {str(e)}",
+            }
 
     # Future analysis tools:
     # - perform_fea_analysis (if FEA capabilities are available)

--- a/src/solidworks_mcp/tools/automation.py
+++ b/src/solidworks_mcp/tools/automation.py
@@ -319,7 +319,9 @@ async def register_automation_tools(
                     "message": result.error or "Failed to generate VBA code",
                 }
 
-            # Simulate VBA code generation based on operation description
+            # Build a VBA code skeleton from the operation description. This
+            # is real, usable output (a labelled template), not a stand-in
+            # for a SolidWorks operation that was supposed to run.
             sample_vba = f"""
 ' Generated VBA code for: {input_data.operation_description}
 ' Target: {input_data.target_document}
@@ -402,16 +404,12 @@ End Sub
                     "message": result.error or "Failed to start macro recording",
                 }
 
-            # For now, simulate macro recording start
             return {
-                "status": "success",
-                "message": f"Started recording macro: {input_data.macro_name}",
-                "macro_recording": {
-                    "macro_name": input_data.macro_name,
-                    "description": input_data.description,
-                    "status": "recording",
-                    "start_time": "2024-01-01T10:00:00Z",
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support start_macro_recording; "
+                    f"no recording of {input_data.macro_name} was started."
+                ),
             }
 
         except Exception as e:
@@ -434,17 +432,13 @@ End Sub
         Returns:
             dict[str, Any]: A dictionary containing the resulting values.
         """
-        # For now, simulate macro recording stop
         return {
-            "status": "success",
-            "message": "Stopped macro recording",
-            "macro_recording": {
-                "status": "stopped",
-                "end_time": "2024-01-01T10:05:00Z",
-                "duration": "5 minutes",
-                "actions_recorded": 15,
-                "file_location": "C:\\Users\\User\\AppData\\Local\\SolidWorks\\Macros\\recorded_macro.swp",
-            },
+            "status": "error",
+            "message": (
+                "No adapter capability exists for stopping a macro "
+                "recording; this tool never started a real recording "
+                "session, so there is nothing to stop or save."
+            ),
         }
 
     @mcp.tool()
@@ -475,24 +469,12 @@ End Sub
                     "message": result.error or "Batch processing failed",
                 }
 
-            # Simulate batch processing
             return {
-                "status": "success",
-                "message": f"Batch {input_data.operation_type} completed",
-                "batch_process": {
-                    "source_directory": input_data.source_directory,
-                    "operation": input_data.operation_type,
-                    "target_format": input_data.target_format,
-                    "files_found": 25,
-                    "files_processed": 23,
-                    "files_successful": 21,
-                    "files_failed": 2,
-                    "processing_time": "12.5 minutes",
-                    "failed_files": [
-                        {"file": "corrupted_part.sldprt", "error": "File corrupted"},
-                        {"file": "locked_assembly.sldasm", "error": "File locked"},
-                    ],
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support batch_process_files; no "
+                    f"files in {input_data.source_directory} were processed."
+                ),
             }
 
         except Exception as e:
@@ -530,18 +512,12 @@ End Sub
                     "message": result.error or "Design table management failed",
                 }
 
-            # Simulate design table management
             return {
-                "status": "success",
-                "message": f"Design table {input_data.table_type} completed",
-                "design_table": {
-                    "operation": input_data.table_type,
-                    "excel_file": input_data.excel_file,
-                    "parameters": input_data.parameters,
-                    "configurations": input_data.configurations,
-                    "total_configurations": len(input_data.configurations),
-                    "parameters_controlled": len(input_data.parameters),
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support manage_design_table; no "
+                    f"{input_data.table_type} operation was performed."
+                ),
             }
 
         except Exception as e:
@@ -579,23 +555,12 @@ End Sub
                     "message": result.error or "Workflow execution failed",
                 }
 
-            # Simulate workflow execution
             return {
-                "status": "success",
-                "message": f"Workflow '{input_data.workflow_name}' completed",
-                "workflow": {
-                    "name": input_data.workflow_name,
-                    "total_steps": len(input_data.steps),
-                    "completed_steps": len(input_data.steps) - 1,
-                    "failed_steps": 1,
-                    "parallel_execution": input_data.parallel_execution,
-                    "execution_time": "8.3 minutes",
-                    "step_results": [
-                        {"step": 1, "status": "success", "duration": "2.1s"},
-                        {"step": 2, "status": "success", "duration": "1.8s"},
-                        {"step": 3, "status": "failed", "error": "File not found"},
-                    ],
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support execute_workflow; "
+                    f"workflow '{input_data.workflow_name}' was not run."
+                ),
             }
 
         except Exception as e:
@@ -633,17 +598,13 @@ End Sub
                     "message": result.error or "Template creation failed",
                 }
 
-            # Simulate template creation
             return {
-                "status": "success",
-                "message": f"Created {input_data.template_type} template: {input_data.template_name}",
-                "template": {
-                    "type": input_data.template_type,
-                    "name": input_data.template_name,
-                    "base_file": input_data.base_file,
-                    "metadata": input_data.metadata,
-                    "file_location": f"C:\\ProgramData\\SolidWorks\\templates\\{input_data.template_name}.{'sldprt' if input_data.template_type == 'part' else 'sldasm' if input_data.template_type == 'assembly' else 'slddrw'}t",
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support create_template; no "
+                    f"{input_data.template_type} template "
+                    f"'{input_data.template_name}' was created."
+                ),
             }
 
         except Exception as e:
@@ -681,26 +642,12 @@ End Sub
                     "message": result.error or "Performance optimization failed",
                 }
 
-            # Simulate performance optimization
             return {
-                "status": "success",
-                "message": "Performance optimization completed",
-                "optimization": {
-                    "settings_analyzed": 45,
-                    "settings_optimized": 12,
-                    "estimated_performance_gain": "25%",
-                    "optimizations": [
-                        "Disabled real-time visualization for large assemblies",
-                        "Increased graphics cache size",
-                        "Optimized rebuild frequency",
-                        "Enabled lightweight components for large assemblies",
-                    ],
-                    "recommendations": [
-                        "Consider upgrading graphics card",
-                        "Increase available RAM",
-                        "Use Pack and Go for better file management",
-                    ],
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support optimize_performance; "
+                    "no settings were analyzed or changed."
+                ),
             }
 
         except Exception as e:

--- a/src/solidworks_mcp/tools/drawing.py
+++ b/src/solidworks_mcp/tools/drawing.py
@@ -396,20 +396,26 @@ async def register_drawing_tools(
                             - Multiple views can reference the same model file
         """
         try:
-            # For now, simulate drawing view creation
+            if hasattr(adapter, "create_drawing_view"):
+                result = await adapter.create_drawing_view(input_data.model_dump())
+                if result.is_success:
+                    return {
+                        "status": "success",
+                        "message": f"Created {input_data.view_type} view of {input_data.model_path}",
+                        "data": result.data,
+                        "execution_time": result.execution_time,
+                    }
+                return {
+                    "status": "error",
+                    "message": result.error or "Failed to create drawing view",
+                }
+
             return {
-                "status": "success",
-                "message": f"Created {input_data.view_type} view of {input_data.model_path}",
-                "drawing_view": {
-                    "model_path": input_data.model_path,
-                    "view_type": input_data.view_type,
-                    "position": {
-                        "x": input_data.position_x,
-                        "y": input_data.position_y,
-                    },
-                    "scale": input_data.scale,
-                    "orientation": input_data.orientation,
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support create_drawing_view; no "
+                    f"{input_data.view_type} view of {input_data.model_path} was created."
+                ),
             }
 
         except Exception as e:
@@ -467,7 +473,6 @@ async def register_drawing_tools(
             entity2 = payload.get("entity2")
             position_x = payload.get("position_x")
             position_y = payload.get("position_y")
-            precision = payload.get("precision", 2)
 
             if (entity1 is None or entity2 is None) and payload.get("entities"):
                 entities = payload["entities"]
@@ -484,6 +489,14 @@ async def register_drawing_tools(
                     if position_y is None:
                         position_y = position[1]
 
+            # Feed the alias-normalized values back into the payload so the
+            # adapter call sees entity1/entity2/position_x/position_y even
+            # when the caller only supplied entities/position.
+            payload["entity1"] = entity1
+            payload["entity2"] = entity2
+            payload["position_x"] = position_x
+            payload["position_y"] = position_y
+
             if hasattr(adapter, "add_dimension"):
                 result = await adapter.add_dimension(payload)
                 if result.is_success:
@@ -498,20 +511,12 @@ async def register_drawing_tools(
                     "message": result.error or "Failed to add dimension",
                 }
 
-            # For now, simulate dimension creation
             return {
-                "status": "success",
-                "message": f"Added {dimension_type} dimension",
-                "dimension": {
-                    "type": dimension_type,
-                    "entity1": entity1,
-                    "entity2": entity2,
-                    "position": {
-                        "x": position_x,
-                        "y": position_y,
-                    },
-                    "precision": precision,
-                },
+                "status": "error",
+                "message": (
+                    f"Active adapter does not support add_dimension; no "
+                    f"{dimension_type} dimension was added."
+                ),
             }
 
         except Exception as e:
@@ -559,19 +564,23 @@ async def register_drawing_tools(
                                     - Position carefully to avoid dimension conflicts
         """
         try:
-            # For now, simulate note creation
+            if hasattr(adapter, "add_note"):
+                result = await adapter.add_note(input_data.model_dump())
+                if result.is_success:
+                    return {
+                        "status": "success",
+                        "message": f"Added note: {input_data.text[:30]}...",
+                        "data": result.data,
+                        "execution_time": result.execution_time,
+                    }
+                return {
+                    "status": "error",
+                    "message": result.error or "Failed to add note",
+                }
+
             return {
-                "status": "success",
-                "message": f"Added note: {input_data.text[:30]}...",
-                "note": {
-                    "text": input_data.text,
-                    "position": {
-                        "x": input_data.position_x,
-                        "y": input_data.position_y,
-                    },
-                    "font_size": input_data.font_size,
-                    "leader_attachment": input_data.leader_attachment,
-                },
+                "status": "error",
+                "message": "Active adapter does not support add_note; no note was added.",
             }
 
         except Exception as e:
@@ -619,22 +628,14 @@ async def register_drawing_tools(
                             - Essential for showing internal features and assemblies
         """
         try:
-            # For now, simulate section view creation
             return {
-                "status": "success",
-                "message": f"Created section view {input_data.label}",
-                "section_view": {
-                    "section_line": {
-                        "start": input_data.section_line_start,
-                        "end": input_data.section_line_end,
-                    },
-                    "view_position": {
-                        "x": input_data.view_position_x,
-                        "y": input_data.view_position_y,
-                    },
-                    "scale": input_data.scale,
-                    "label": input_data.label,
-                },
+                "status": "error",
+                "message": (
+                    "No adapter capability exists for cutting a section view "
+                    "along a section line; create_section_view cannot compute "
+                    "the cut geometry, so no view was created. Use SolidWorks "
+                    "directly (Insert > Drawing View > Section) instead."
+                ),
             }
 
         except Exception as e:
@@ -682,22 +683,15 @@ async def register_drawing_tools(
                             - Essential for communicating tight tolerance requirements
         """
         try:
-            # For now, simulate detail view creation
             return {
-                "status": "success",
-                "message": f"Created detail view {input_data.label}",
-                "detail_view": {
-                    "detail_circle": {
-                        "center": {"x": input_data.center_x, "y": input_data.center_y},
-                        "radius": input_data.radius,
-                    },
-                    "view_position": {
-                        "x": input_data.view_position_x,
-                        "y": input_data.view_position_y,
-                    },
-                    "scale": input_data.scale,
-                    "label": input_data.label,
-                },
+                "status": "error",
+                "message": (
+                    "No adapter capability exists for magnifying the "
+                    "geometry inside a detail circle; create_detail_view "
+                    "cannot compute the detail geometry, so no view was "
+                    "created. Use SolidWorks directly (Insert > Drawing "
+                    "View > Detail) instead."
+                ),
             }
 
         except Exception as e:
@@ -747,21 +741,26 @@ async def register_drawing_tools(
                             - Essential for drawing control and document management systems
         """
         try:
-            # For now, simulate sheet format update
+            if hasattr(adapter, "update_sheet_format"):
+                result = await adapter.update_sheet_format(input_data.model_dump())
+                if result.is_success:
+                    return {
+                        "status": "success",
+                        "message": f"Updated sheet format to {input_data.sheet_size}",
+                        "data": result.data,
+                        "execution_time": result.execution_time,
+                    }
+                return {
+                    "status": "error",
+                    "message": result.error or "Failed to update sheet format",
+                }
+
             return {
-                "status": "success",
-                "message": f"Updated sheet format to {input_data.sheet_size}",
-                "sheet_format": {
-                    "format_file": input_data.format_file,
-                    "sheet_size": input_data.sheet_size,
-                    "title_block": {
-                        "title": input_data.title,
-                        "drawn_by": getattr(input_data, "drawn_by", ""),
-                        "checked_by": getattr(input_data, "checked_by", ""),
-                        "approved_by": getattr(input_data, "approved_by", ""),
-                        "drawing_number": getattr(input_data, "drawing_number", ""),
-                    },
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support update_sheet_format; the "
+                    "sheet format and title block were not changed."
+                ),
             }
 
         except Exception as e:
@@ -809,15 +808,26 @@ async def register_drawing_tools(
                             - Significantly reduces manual dimensioning time
         """
         try:
-            # For now, simulate auto-dimensioning
+            if hasattr(adapter, "auto_dimension_view"):
+                result = await adapter.auto_dimension_view(input_data)
+                if result.is_success:
+                    return {
+                        "status": "success",
+                        "message": "Auto-dimensioned drawing view",
+                        "data": result.data,
+                        "execution_time": result.execution_time,
+                    }
+                return {
+                    "status": "error",
+                    "message": result.error or "Failed to auto-dimension view",
+                }
+
             return {
-                "status": "success",
-                "message": "Auto-dimensioned drawing view",
-                "auto_dimensions": {
-                    "dimensions_added": 12,
-                    "dimension_types": ["linear", "radial", "diameter"],
-                    "coverage": "85%",
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support auto_dimension_view; no "
+                    "dimensions were added."
+                ),
             }
 
         except Exception as e:  # pragma: no cover - defensive guard for future logic
@@ -865,23 +875,14 @@ async def register_drawing_tools(
                             - Essential for quality management and ISO certification
         """
         try:
-            # For now, simulate standards checking
             return {
-                "status": "success",
-                "message": "Drawing standards check completed",
-                "standards_check": {
-                    "standard": "ANSI Y14.5",
-                    "compliance_score": 92,
-                    "warnings": [
-                        "Missing general tolerance note",
-                        "Some dimensions lack required precision",
-                    ],
-                    "errors": [],
-                    "recommendations": [
-                        "Add material specification",
-                        "Include finish symbols where appropriate",
-                    ],
-                },
+                "status": "error",
+                "message": (
+                    "No adapter capability exists for checking drafting "
+                    "standards compliance; check_drawing_standards cannot "
+                    "inspect the drawing, so no compliance score was "
+                    "computed. Use SolidWorks Design Checker for this."
+                ),
             }
 
         except Exception as e:  # pragma: no cover - defensive guard for future logic
@@ -922,17 +923,11 @@ async def register_drawing_tools(
                 }
 
             return {
-                "status": "success",
-                "message": "Technical drawing created successfully",
-                "data": {
-                    "drawing_path": input_data.output_path,
-                    "template_used": input_data.template,
-                    "views_created": ["Front", "Right", "Top"]
-                    if input_data.auto_populate_views
-                    else [],
-                    "sheet_format": input_data.sheet_format,
-                    "scale": input_data.scale,
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support create_technical_drawing; "
+                    "no drawing was created."
+                ),
             }
         except Exception as e:
             logger.error(f"Error in create_technical_drawing tool: {e}")
@@ -967,14 +962,11 @@ async def register_drawing_tools(
                 }
 
             return {
-                "status": "success",
-                "message": "Drawing view added successfully",
-                "data": {
-                    "view_name": input_data.view_name,
-                    "view_type": input_data.view_type,
-                    "position": input_data.position,
-                    "scale": input_data.scale,
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support add_drawing_view; no "
+                    "view was added."
+                ),
             }
         except Exception as e:
             logger.error(f"Error in add_drawing_view tool: {e}")
@@ -1009,14 +1001,11 @@ async def register_drawing_tools(
                 }
 
             return {
-                "status": "success",
-                "message": "Annotation added successfully",
-                "data": {
-                    "annotation_text": input_data.text,
-                    "annotation_type": input_data.annotation_type,
-                    "position": [input_data.position_x, input_data.position_y],
-                    "font_size": input_data.font_size,
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support add_annotation; no "
+                    "annotation was added."
+                ),
             }
         except Exception as e:
             logger.error(f"Error in add_annotation tool: {e}")
@@ -1051,9 +1040,11 @@ async def register_drawing_tools(
                 }
 
             return {
-                "status": "success",
-                "message": "Title block updated successfully",
-                "data": input_data,
+                "status": "error",
+                "message": (
+                    "Active adapter does not support update_title_block; the "
+                    "title block was not changed."
+                ),
             }
         except Exception as e:
             logger.error(f"Error in update_title_block tool: {e}")

--- a/src/solidworks_mcp/tools/drawing_analysis.py
+++ b/src/solidworks_mcp/tools/drawing_analysis.py
@@ -4,6 +4,8 @@ Provides advanced analysis capabilities for drawing documents including dimensio
 analysis, view analysis, annotation checking, and compliance verification.
 """
 
+import hashlib
+import pathlib
 from typing import Any
 
 from fastmcp import FastMCP
@@ -12,6 +14,30 @@ from pydantic import Field
 
 from ..adapters.base import SolidWorksAdapter
 from .input_compat import CompatInput
+
+
+def _file_fact_snapshot(path_str: str) -> dict[str, Any] | None:
+    """Read basic, honest filesystem facts about a file: size, mtime, hash.
+
+    Returns None if the path is empty or does not point at an existing file.
+    """
+    if not path_str:
+        return None
+    path = pathlib.Path(path_str)
+    if not path.is_file():
+        return None
+    stat = path.stat()
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return {
+        "path": str(path),
+        "size_bytes": stat.st_size,
+        "modified_time": stat.st_mtime,
+        "sha256": digest.hexdigest(),
+    }
+
 
 # Input schemas for drawing analysis
 
@@ -161,125 +187,13 @@ async def register_drawing_analysis_tools(
                     "message": result.error or "Failed to analyze drawing",
                 }
 
-            # Simulate comprehensive drawing analysis
-            analysis_results = {
-                "drawing_info": {
-                    "file_path": input_data.drawing_path,
-                    "file_size": "2.3 MB",
-                    "sheet_count": 2,
-                    "view_count": 8,
-                    "last_modified": "2024-01-15 10:30:00",
-                },
-                "view_analysis": {
-                    "total_views": 8,
-                    "view_types": {
-                        "standard_views": 4,
-                        "section_views": 2,
-                        "detail_views": 2,
-                        "auxiliary_views": 0,
-                    },
-                    "scale_analysis": {
-                        "scales_used": ["1:1", "1:2", "2:1"],
-                        "scale_consistency": "Good",
-                        "recommended_scales": ["1:1", "1:2"],
-                    },
-                    "view_placement": {
-                        "alignment": "Good",
-                        "spacing": "Adequate",
-                        "overlap_issues": 0,
-                    },
-                },
-                "dimension_analysis": {
-                    "total_dimensions": 47,
-                    "dimension_types": {
-                        "linear": 28,
-                        "angular": 6,
-                        "radial": 8,
-                        "diameter": 5,
-                    },
-                    "precision_consistency": {
-                        "status": "Warning",
-                        "issues": ["Mixed precision: 2 and 3 decimal places used"],
-                        "recommendation": "Standardize to 2 decimal places",
-                    },
-                    "tolerance_analysis": {
-                        "dimensions_with_tolerances": 12,
-                        "tolerance_types": {"bilateral": 8, "unilateral": 4},
-                        "formatting_consistency": "Good",
-                    },
-                },
-                "annotation_analysis": {
-                    "notes": {
-                        "count": 6,
-                        "formatting": "Consistent",
-                        "font_sizes": ["3.5mm", "2.5mm"],
-                        "issues": [],
-                    },
-                    "symbols": {
-                        "count": 14,
-                        "types": {
-                            "surface_finish": 8,
-                            "geometric_tolerance": 4,
-                            "weld": 2,
-                        },
-                        "standard_compliance": "ISO compliant",
-                    },
-                    "balloons": {
-                        "count": 23,
-                        "numbering": "Sequential",
-                        "placement": "Good",
-                    },
-                },
-                "standards_compliance": {
-                    "overall_score": 87,
-                    "title_block": {
-                        "score": 90,
-                        "required_fields": [
-                            "Title",
-                            "Drawing Number",
-                            "Scale",
-                            "Date",
-                            "Drawn By",
-                        ],
-                        "missing_fields": [],
-                        "format_compliance": "Good",
-                    },
-                    "line_weights": {
-                        "score": 85,
-                        "visible_lines": "0.5mm - Correct",
-                        "hidden_lines": "0.25mm - Correct",
-                        "centerlines": "0.25mm - Correct",
-                        "issues": ["Some dimension lines too thick"],
-                    },
-                    "text_standards": {
-                        "score": 88,
-                        "font_type": "ISO 3098 - Compliant",
-                        "text_heights": "Standard sizes used",
-                        "issues": ["One note uses non-standard height"],
-                    },
-                },
-            }
-
-            recommendations = [
-                "Standardize dimension precision to 2 decimal places",
-                "Review dimension line weights for consistency",
-                "Consider adding missing auxiliary view for clarity",
-                "Update one note to use standard text height",
-            ]
-
             return {
-                "status": "success",
-                "message": "Comprehensive drawing analysis completed",
-                "analysis_results": analysis_results,
-                "overall_quality_score": 87,
-                "recommendations": recommendations,
-                "compliance_summary": {
-                    "standard": "ISO 128",
-                    "compliance_level": "High",
-                    "critical_issues": 0,
-                    "warnings": 3,
-                    "suggestions": 4,
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support "
+                    "analyze_drawing_comprehensive; no analysis of "
+                    f"{input_data.drawing_path} was performed."
+                ),
             }
 
         except Exception as e:
@@ -325,81 +239,12 @@ async def register_drawing_analysis_tools(
                     "message": result.error or "Failed to analyze dimensions",
                 }
 
-            dimension_analysis = {
-                "dimension_inventory": {
-                    "total_dimensions": 52,
-                    "by_type": {
-                        "linear": {"count": 31, "percentage": 59.6},
-                        "angular": {"count": 7, "percentage": 13.5},
-                        "radial": {"count": 9, "percentage": 17.3},
-                        "diameter": {"count": 5, "percentage": 9.6},
-                    },
-                    "by_view": {
-                        "front_view": 18,
-                        "top_view": 15,
-                        "right_view": 12,
-                        "section_a": 7,
-                    },
-                },
-                "precision_analysis": {
-                    "precision_distribution": {
-                        "0_decimals": 8,
-                        "1_decimal": 5,
-                        "2_decimals": 35,
-                        "3_decimals": 4,
-                    },
-                    "consistency_score": 67,
-                    "recommendations": [
-                        "Standardize to 2 decimal places",
-                        "Consider whole numbers for non-critical dimensions",
-                    ],
-                },
-                "tolerance_analysis": {
-                    "dimensions_with_tolerances": 18,
-                    "tolerance_coverage": 34.6,  # percentage
-                    "tolerance_types": {
-                        "bilateral": {"count": 12, "example": "±0.05"},
-                        "unilateral": {"count": 4, "example": "+0.05/-0.00"},
-                        "limit": {"count": 2, "example": "10.05/9.95"},
-                    },
-                    "critical_dimensions": {
-                        "identified": 8,
-                        "toleranced": 6,
-                        "missing_tolerances": ["Ø12 hole depth", "45° chamfer"],
-                    },
-                },
-                "completeness_check": {
-                    "fully_dimensioned_features": {
-                        "holes": {"total": 4, "dimensioned": 4, "complete": True},
-                        "slots": {"total": 2, "dimensioned": 1, "complete": False},
-                        "chamfers": {"total": 3, "dimensioned": 2, "complete": False},
-                        "radii": {"total": 5, "dimensioned": 5, "complete": True},
-                    },
-                    "missing_dimensions": [
-                        "Slot width in top view",
-                        "Chamfer size (45° x ?))",
-                    ],
-                    "redundant_dimensions": ["Overall length shown twice"],
-                    "completeness_score": 88,
-                },
-            }
-
             return {
-                "status": "success",
-                "message": "Dimension analysis completed",
-                "dimension_analysis": dimension_analysis,
-                "quality_metrics": {
-                    "precision_consistency": "Needs Improvement",
-                    "tolerance_coverage": "Adequate",
-                    "completeness": "Good",
-                    "overall_score": 78,
-                },
-                "action_items": [
-                    "Add tolerance to slot width dimension",
-                    "Dimension the 45° chamfer completely",
-                    "Remove redundant overall length dimension",
-                    "Standardize precision to 2 decimal places",
-                ],
+                "status": "error",
+                "message": (
+                    "Active adapter does not support analyze_drawing_dimensions; "
+                    f"no analysis of {input_data.drawing_path} was performed."
+                ),
             }
 
         except Exception as e:
@@ -446,96 +291,12 @@ async def register_drawing_analysis_tools(
                     "message": result.error or "Failed to analyze annotations",
                 }
 
-            annotation_analysis = {
-                "notes_analysis": {
-                    "total_notes": 8,
-                    "note_categories": {
-                        "general_notes": 4,
-                        "manufacturing_notes": 3,
-                        "material_notes": 1,
-                    },
-                    "formatting_consistency": {
-                        "font_type": "Arial - Consistent",
-                        "text_heights": {
-                            "3.5mm": 5,
-                            "2.5mm": 2,
-                            "4.0mm": 1,  # Non-standard
-                        },
-                        "alignment": "Left aligned - Consistent",
-                        "issues": ["One note uses non-standard 4.0mm height"],
-                    },
-                    "content_quality": {
-                        "clarity": "Good",
-                        "completeness": "Good",
-                        "standardization": "Needs improvement",
-                        "suggestions": [
-                            "Use standard phrases for common notes",
-                            "Consider abbreviation standards",
-                        ],
-                    },
-                },
-                "symbols_analysis": {
-                    "total_symbols": 16,
-                    "symbol_types": {
-                        "surface_finish": {
-                            "count": 9,
-                            "standards_compliance": "ISO 1302 - Compliant",
-                            "placement": "Good",
-                            "size": "Standard",
-                        },
-                        "geometric_tolerances": {
-                            "count": 5,
-                            "standards_compliance": "ISO 1101 - Compliant",
-                            "feature_control_frames": "Properly formatted",
-                            "datum_references": "Complete",
-                        },
-                        "welding_symbols": {
-                            "count": 2,
-                            "standards_compliance": "ISO 2553 - Compliant",
-                            "completeness": "All required elements present",
-                        },
-                    },
-                    "placement_analysis": {
-                        "readability": "Good",
-                        "interference": "None detected",
-                        "leader_line_quality": "Good",
-                    },
-                },
-                "text_style_analysis": {
-                    "font_consistency": {
-                        "primary_font": "Arial - Used 87% of text",
-                        "secondary_font": "Times New Roman - Used 13%",
-                        "recommendation": "Standardize to single font family",
-                    },
-                    "size_hierarchy": {
-                        "title_text": "7.0mm - Appropriate",
-                        "dimension_text": "3.5mm - Standard",
-                        "note_text": "2.5mm - Standard",
-                        "label_text": "2.0mm - Small but acceptable",
-                    },
-                    "color_usage": {
-                        "black_text": "95% - Standard",
-                        "colored_text": "5% - Used for emphasis",
-                        "compliance": "Good",
-                    },
-                },
-            }
-
             return {
-                "status": "success",
-                "message": "Annotation analysis completed",
-                "annotation_analysis": annotation_analysis,
-                "quality_scores": {
-                    "notes_quality": 85,
-                    "symbol_compliance": 95,
-                    "text_consistency": 78,
-                    "overall_score": 86,
-                },
-                "improvement_areas": [
-                    "Standardize note text height to 2.5mm",
-                    "Use consistent font family throughout",
-                    "Review and standardize note terminology",
-                ],
+                "status": "error",
+                "message": (
+                    "Active adapter does not support analyze_drawing_annotations; "
+                    f"no analysis of {input_data.drawing_path} was performed."
+                ),
             }
 
         except Exception as e:
@@ -580,153 +341,12 @@ async def register_drawing_analysis_tools(
                     "message": result.error or "Compliance check failed",
                 }
 
-            compliance_check = {
-                "standard_info": {
-                    "standard": input_data.standard,
-                    "full_name": "ISO 128 - Technical drawings"
-                    if input_data.standard == "ISO"
-                    else input_data.standard,
-                    "version": "2022",
-                    "check_date": "2024-01-15",
-                },
-                "title_block_compliance": {
-                    "required_elements": [
-                        {
-                            "element": "Drawing title",
-                            "present": True,
-                            "compliant": True,
-                        },
-                        {
-                            "element": "Drawing number",
-                            "present": True,
-                            "compliant": True,
-                        },
-                        {"element": "Scale", "present": True, "compliant": True},
-                        {"element": "Date", "present": True, "compliant": True},
-                        {"element": "Drawn by", "present": True, "compliant": True},
-                        {"element": "Checked by", "present": False, "compliant": False},
-                        {
-                            "element": "Approved by",
-                            "present": False,
-                            "compliant": False,
-                        },
-                        {"element": "Revision", "present": True, "compliant": True},
-                    ],
-                    "compliance_score": 75,
-                    "missing_elements": ["Checked by", "Approved by"],
-                    "format_compliance": "Good",
-                },
-                "sheet_format_compliance": {
-                    "paper_size": {"specified": "A3", "compliant": True},
-                    "margins": {
-                        "left": 20,
-                        "right": 10,
-                        "top": 10,
-                        "bottom": 10,
-                        "compliant": True,
-                    },
-                    "sheet_orientation": {
-                        "orientation": "Landscape",
-                        "compliant": True,
-                    },
-                    "zone_markings": {
-                        "present": True,
-                        "format": "A1-H8",
-                        "compliant": True,
-                    },
-                },
-                "line_type_compliance": {
-                    "visible_lines": {
-                        "weight": "0.5mm",
-                        "type": "Continuous",
-                        "compliant": True,
-                    },
-                    "hidden_lines": {
-                        "weight": "0.25mm",
-                        "type": "Dashed",
-                        "compliant": True,
-                    },
-                    "centerlines": {
-                        "weight": "0.25mm",
-                        "type": "Chain-dotted",
-                        "compliant": True,
-                    },
-                    "dimension_lines": {
-                        "weight": "0.25mm",
-                        "type": "Continuous",
-                        "compliant": True,
-                    },
-                    "leader_lines": {
-                        "weight": "0.25mm",
-                        "type": "Continuous",
-                        "compliant": True,
-                    },
-                },
-                "text_compliance": {
-                    "font_requirements": {
-                        "required": "ISO 3098",
-                        "used": "Arial",
-                        "compliant": "Acceptable alternative",
-                    },
-                    "minimum_height": {
-                        "required": "2.5mm",
-                        "smallest_used": "2.0mm",
-                        "compliant": False,
-                    },
-                    "character_spacing": {"spacing": "Standard", "compliant": True},
-                },
-                "dimension_compliance": {
-                    "dimension_style": {"style": "ISO", "compliant": True},
-                    "arrow_style": {
-                        "style": "Closed filled",
-                        "size": "2.5mm",
-                        "compliant": True,
-                    },
-                    "extension_lines": {
-                        "offset": "0.5mm",
-                        "extension": "2.0mm",
-                        "compliant": True,
-                    },
-                    "text_placement": {
-                        "position": "Above line",
-                        "alignment": "Center",
-                        "compliant": True,
-                    },
-                },
-            }
-
-            overall_score = 82
-            critical_issues = [
-                "Missing approval signatures",
-                "Text height below minimum",
-            ]
-            warnings = ["Non-standard font used", "Inconsistent dimension precision"]
-
             return {
-                "status": "success",
-                "message": f"Standards compliance check completed for {input_data.standard}",
-                "compliance_check": compliance_check,
-                "overall_compliance": {
-                    "score": overall_score,
-                    "level": "Good" if overall_score >= 80 else "Needs Improvement",
-                    "critical_issues": len(critical_issues),
-                    "warnings": len(warnings),
-                },
-                "critical_issues": critical_issues,
-                "warnings": warnings,
-                "recommendations": [
-                    "Add approval signatures to title block",
-                    "Increase minimum text height to 2.5mm",
-                    "Consider using ISO 3098 compliant font",
-                    "Standardize dimension precision",
-                ],
-                "certification": {
-                    "certifiable": overall_score >= 85,
-                    "required_score": 85,
-                    "improvements_needed": 85 - overall_score
-                    if overall_score < 85
-                    else 0,
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support check_drawing_compliance; "
+                    f"no {input_data.standard} compliance check was performed."
+                ),
             }
 
         except Exception as e:
@@ -769,128 +389,14 @@ async def register_drawing_analysis_tools(
                     "message": result.error or "Failed to analyze drawing views",
                 }
 
-            input_data.get("drawing_path", "")
-
-            view_analysis = {
-                "view_inventory": {
-                    "total_views": 7,
-                    "view_breakdown": {
-                        "standard_orthographic": {
-                            "front": {
-                                "present": True,
-                                "scale": "1:1",
-                                "clarity": "Excellent",
-                            },
-                            "top": {"present": True, "scale": "1:1", "clarity": "Good"},
-                            "right": {
-                                "present": True,
-                                "scale": "1:1",
-                                "clarity": "Good",
-                            },
-                            "left": {"present": False, "needed": False},
-                            "rear": {"present": False, "needed": False},
-                            "bottom": {"present": False, "needed": False},
-                        },
-                        "auxiliary_views": {
-                            "count": 1,
-                            "purpose": "Show true shape of angled surface",
-                            "effectiveness": "Good",
-                        },
-                        "section_views": {
-                            "count": 2,
-                            "sections": [
-                                {
-                                    "name": "Section A-A",
-                                    "type": "Full section",
-                                    "clarity": "Excellent",
-                                },
-                                {
-                                    "name": "Section B-B",
-                                    "type": "Half section",
-                                    "clarity": "Good",
-                                },
-                            ],
-                        },
-                        "detail_views": {
-                            "count": 1,
-                            "details": [
-                                {
-                                    "name": "Detail C",
-                                    "scale": "2:1",
-                                    "feature": "Thread detail",
-                                    "clarity": "Excellent",
-                                }
-                            ],
-                        },
-                    },
-                },
-                "view_placement_analysis": {
-                    "alignment": {
-                        "horizontal_alignment": "Proper",
-                        "vertical_alignment": "Proper",
-                        "projection_method": "First angle - Correct for ISO",
-                    },
-                    "spacing": {
-                        "between_views": "Adequate",
-                        "from_dimensions": "Good",
-                        "from_annotations": "Good",
-                    },
-                    "sheet_utilization": {
-                        "coverage": "75%",
-                        "balance": "Well balanced",
-                        "wasted_space": "Minimal",
-                    },
-                },
-                "clarity_assessment": {
-                    "line_clarity": {
-                        "visible_edges": "Clear and distinct",
-                        "hidden_edges": "Properly shown with dashed lines",
-                        "centerlines": "Present where needed",
-                    },
-                    "feature_visibility": {
-                        "internal_features": "Well shown in sections",
-                        "small_features": "Detailed view provided",
-                        "complex_geometry": "Adequately represented",
-                    },
-                    "viewing_angles": {
-                        "optimal_angles": 6,
-                        "questionable_angles": 1,
-                        "suggestions": [
-                            "Consider isometric view for assembly understanding"
-                        ],
-                    },
-                },
-                "completeness_check": {
-                    "required_views": {
-                        "minimum_for_manufacture": 3,
-                        "provided": 7,
-                        "adequate": True,
-                    },
-                    "hidden_features": {
-                        "all_shown": True,
-                        "method": "Section views and hidden lines",
-                    },
-                    "critical_dimensions_visible": True,
-                    "manufacturing_features_clear": True,
-                },
-            }
+            drawing_path = input_data.get("drawing_path", "")
 
             return {
-                "status": "success",
-                "message": "Drawing view analysis completed",
-                "view_analysis": view_analysis,
-                "quality_metrics": {
-                    "view_selection": "Excellent",
-                    "view_placement": "Good",
-                    "clarity": "Good",
-                    "completeness": "Excellent",
-                    "overall_score": 88,
-                },
-                "recommendations": [
-                    "Consider adding isometric view for better understanding",
-                    "Ensure all critical dimensions are clearly visible",
-                    "Review spacing around detail view C",
-                ],
+                "status": "error",
+                "message": (
+                    "Active adapter does not support analyze_drawing_views; "
+                    f"no analysis of {drawing_path} was performed."
+                ),
             }
 
         except Exception as e:
@@ -934,104 +440,13 @@ async def register_drawing_analysis_tools(
                 }
 
             drawing_path = input_data.get("drawing_path", "")
-            report_type = input_data.get(
-                "report_type", "full"
-            )  # full, summary, issues_only
-
-            drawing_report = {
-                "report_header": {
-                    "report_title": "SolidWorks Drawing Quality Analysis Report",
-                    "drawing_file": drawing_path,
-                    "analysis_date": "2024-01-15 14:30:00",
-                    "report_type": report_type,
-                    "generated_by": "SolidWorks MCP Server",
-                    "analysis_version": "2.1.0",
-                },
-                "executive_summary": {
-                    "overall_quality_score": 84,
-                    "quality_grade": "B+",
-                    "major_strengths": [
-                        "Excellent view selection and clarity",
-                        "Good standards compliance",
-                        "Complete dimensioning",
-                    ],
-                    "key_improvement_areas": [
-                        "Dimension precision consistency",
-                        "Text formatting standardization",
-                        "Title block completeness",
-                    ],
-                    "recommendation": "Drawing is of good quality with minor improvements recommended",
-                },
-                "detailed_scores": {
-                    "view_quality": {"score": 88, "grade": "A-"},
-                    "dimension_quality": {"score": 78, "grade": "B"},
-                    "annotation_quality": {"score": 86, "grade": "B+"},
-                    "standards_compliance": {"score": 82, "grade": "B"},
-                    "completeness": {"score": 90, "grade": "A-"},
-                },
-                "critical_issues": [
-                    {
-                        "issue": "Missing approval signatures",
-                        "severity": "High",
-                        "location": "Title block",
-                        "recommendation": "Add checked by and approved by signatures",
-                    }
-                ],
-                "warnings": [
-                    {
-                        "issue": "Inconsistent dimension precision",
-                        "severity": "Medium",
-                        "location": "Throughout drawing",
-                        "recommendation": "Standardize to 2 decimal places",
-                    },
-                    {
-                        "issue": "Non-standard text height",
-                        "severity": "Low",
-                        "location": "General note 3",
-                        "recommendation": "Use 2.5mm minimum height",
-                    },
-                ],
-                "improvement_plan": {
-                    "immediate_actions": [
-                        "Add missing approval signatures",
-                        "Correct text height in general note 3",
-                    ],
-                    "short_term_actions": [
-                        "Standardize dimension precision",
-                        "Review and update text formatting",
-                    ],
-                    "long_term_actions": [
-                        "Implement drawing template improvements",
-                        "Establish drawing review checklist",
-                    ],
-                },
-                "compliance_certification": {
-                    "certifiable": False,
-                    "certification_standard": "ISO 128",
-                    "required_score": 85,
-                    "current_score": 84,
-                    "gap_analysis": "1 point improvement needed",
-                    "certification_blockers": ["Missing approval signatures"],
-                },
-            }
 
             return {
-                "status": "success",
-                "message": "Drawing quality report generated successfully",
-                "drawing_report": drawing_report,
-                "report_stats": {
-                    "total_checks_performed": 47,
-                    "critical_issues_found": 1,
-                    "warnings_found": 2,
-                    "suggestions_provided": 8,
-                    "report_completeness": "100%",
-                },
-                "next_steps": [
-                    "Review critical issues and warnings",
-                    "Implement immediate action items",
-                    "Schedule follow-up analysis after corrections",
-                    "Consider template improvements for future drawings",
-                ],
+                "status": "error",
+                "message": (
+                    "Active adapter does not support generate_drawing_report; "
+                    f"no report for {drawing_path} was generated."
+                ),
             }
 
         except Exception as e:
@@ -1055,122 +470,68 @@ async def register_drawing_analysis_tools(
                             >>> result = await compare_drawing_versions(version_input)
         """
         """
-        Compare two versions of a drawing to identify changes.
+        Compare two drawing files on disk using real filesystem facts.
 
-        This tool analyzes differences between drawing revisions.
+        This tool cannot parse SLDDRW internals (no SolidWorks session is
+        opened), so it does not report geometric/dimension/annotation
+        differences. It reports what it can honestly determine from the
+        filesystem: whether each file exists, its size, modified time, and
+        whether the two files are byte-for-byte identical.
         """
         try:
             drawing_v1 = input_data.get("drawing_version_1", "")
             drawing_v2 = input_data.get("drawing_version_2", "")
-            comparison_type = input_data.get(
-                "comparison_type", "full"
-            )  # full, geometry, annotations
 
-            comparison_results = {
-                "comparison_info": {
-                    "version_1": {
-                        "path": drawing_v1,
-                        "date": "2024-01-10",
-                        "revision": "A",
-                    },
-                    "version_2": {
-                        "path": drawing_v2,
-                        "date": "2024-01-15",
-                        "revision": "B",
-                    },
-                    "comparison_date": "2024-01-15",
-                    "comparison_type": comparison_type,
-                },
-                "geometric_changes": {
-                    "views_modified": [
-                        {
-                            "view": "Front view",
-                            "change_type": "Geometry updated",
-                            "description": "Added fillet to corner",
-                        },
-                        {
-                            "view": "Section A-A",
-                            "change_type": "New feature",
-                            "description": "Added threaded hole",
-                        },
-                    ],
-                    "views_added": [],
-                    "views_removed": [],
-                    "scale_changes": [],
-                },
-                "dimension_changes": {
-                    "dimensions_added": [
-                        {
-                            "dimension": "Ø8 hole",
-                            "location": "Front view",
-                            "value": "8.0",
-                        },
-                        {
-                            "dimension": "R2 fillet",
-                            "location": "Front view",
-                            "value": "2.0",
-                        },
-                    ],
-                    "dimensions_modified": [
-                        {
-                            "dimension": "Overall length",
-                            "old_value": "100.0",
-                            "new_value": "102.0",
-                            "change": "+2.0",
-                        }
-                    ],
-                    "dimensions_removed": [],
-                    "tolerance_changes": [
-                        {
-                            "dimension": "Ø25 bore",
-                            "old_tolerance": "±0.1",
-                            "new_tolerance": "H7",
-                        }
-                    ],
-                },
-                "annotation_changes": {
-                    "notes_added": ["BREAK ALL SHARP EDGES"],
-                    "notes_modified": [],
-                    "notes_removed": [],
-                    "symbol_changes": [
-                        {
-                            "symbol": "Surface finish",
-                            "location": "Bore surface",
-                            "change": "Ra 1.6 → Ra 0.8",
-                        }
-                    ],
-                },
-                "title_block_changes": {
-                    "revision_updated": {"from": "A", "to": "B"},
-                    "date_updated": {"from": "2024-01-10", "to": "2024-01-15"},
-                    "description": "Added threaded hole, updated overall length",
-                    "approved_by": "J. Smith",
-                },
-                "impact_assessment": {
-                    "manufacturing_impact": "Medium - Requires tooling update for new hole",
-                    "assembly_impact": "Low - No assembly changes required",
-                    "cost_impact": "Low - Minor machining addition",
-                    "lead_time_impact": "None - No new suppliers required",
-                },
-            }
+            if not drawing_v1 or not drawing_v2:
+                return {
+                    "status": "error",
+                    "message": (
+                        "compare_drawing_versions requires both "
+                        "drawing_version_1 and drawing_version_2 paths."
+                    ),
+                }
+
+            file_1 = _file_fact_snapshot(drawing_v1)
+            file_2 = _file_fact_snapshot(drawing_v2)
+
+            missing = [
+                path
+                for path, snapshot in ((drawing_v1, file_1), (drawing_v2, file_2))
+                if snapshot is None
+            ]
+            if missing:
+                return {
+                    "status": "error",
+                    "message": (
+                        "Cannot compare drawing versions; file(s) not found "
+                        f"on disk: {', '.join(missing)}. No SolidWorks-level "
+                        "diff was performed."
+                    ),
+                }
+
+            assert file_1 is not None
+            assert file_2 is not None
+            identical = file_1["sha256"] == file_2["sha256"]
 
             return {
                 "status": "success",
-                "message": "Drawing version comparison completed",
-                "comparison_results": comparison_results,
-                "change_summary": {
-                    "total_changes": 8,
-                    "geometric_changes": 2,
-                    "dimensional_changes": 3,
-                    "annotation_changes": 2,
-                    "administrative_changes": 1,
+                "message": (
+                    "Drawing files are byte-identical"
+                    if identical
+                    else "Drawing files differ on disk"
+                ),
+                "comparison": {
+                    "file_1": file_1,
+                    "file_2": file_2,
+                    "identical": identical,
+                    "size_delta_bytes": file_2["size_bytes"] - file_1["size_bytes"],
                 },
-                "change_significance": {
-                    "level": "Medium",
-                    "requires_approval": True,
-                    "requires_manufacturing_review": True,
-                    "requires_quality_review": False,
-                },
+                "note": (
+                    "This is a filesystem-level comparison only; no "
+                    "SolidWorks session was opened, so geometric, "
+                    "dimension, and annotation differences were not "
+                    "analyzed."
+                ),
             }
 
         except Exception as e:
@@ -1201,110 +562,29 @@ async def register_drawing_analysis_tools(
         This tool checks for completeness from a manufacturing perspective.
         """
         try:
-            input_data.get("drawing_path", "")
-            input_data.get(
-                "manufacturing_type", "machining"
-            )  # machining, casting, forming
+            drawing_path = input_data.get("drawing_path", "")
 
-            completeness_check = {
-                "dimensional_completeness": {
-                    "all_features_dimensioned": True,
-                    "critical_dimensions": {
-                        "identified": 12,
-                        "toleranced": 10,
-                        "missing_tolerances": ["Chamfer size", "Thread depth"],
-                    },
-                    "location_dimensions": {
-                        "holes": "Complete",
-                        "slots": "Missing width dimension",
-                        "features": "Complete",
-                    },
-                    "size_dimensions": {
-                        "external_features": "Complete",
-                        "internal_features": "Nearly complete",
-                        "missing": ["Internal groove width"],
-                    },
-                },
-                "manufacturing_requirements": {
-                    "material_specification": {
-                        "specified": True,
-                        "complete": True,
-                        "material": "AISI 1045 Steel",
-                        "condition": "Normalized",
-                    },
-                    "surface_finish": {
-                        "specified": True,
-                        "coverage": "85%",
-                        "missing_surfaces": ["Internal bore", "Thread lead-in"],
-                    },
-                    "geometric_tolerances": {
-                        "specified": True,
-                        "adequate": True,
-                        "types": ["Concentricity", "Perpendicularity", "Flatness"],
-                    },
-                    "manufacturing_notes": {
-                        "present": True,
-                        "adequate": True,
-                        "examples": ["Deburr all edges", "Machine finish"],
-                    },
-                },
-                "quality_requirements": {
-                    "inspection_dimensions": {
-                        "critical_features": "Identified",
-                        "inspection_method": "Coordinate measuring",
-                        "sampling_plan": "Not specified",
-                    },
-                    "testing_requirements": {
-                        "material_properties": "Referenced to ASTM standards",
-                        "functional_testing": "Not specified",
-                        "acceptance_criteria": "Drawing tolerances",
-                    },
-                },
-                "documentation_completeness": {
-                    "title_block": {
-                        "complete": True,
-                        "part_number": "Present",
-                        "revision": "Present",
-                        "approvals": "Missing check signatures",
-                    },
-                    "reference_documents": {
-                        "standards": ["ISO 2768-1 for general tolerances"],
-                        "specifications": ["Company spec CS-100"],
-                        "procedures": ["Manufacturing procedure MP-500"],
-                    },
-                },
-            }
-
-            completeness_score = 87
-            blocking_issues = [
-                "Missing check signatures",
-                "Incomplete surface finish specification",
-            ]
-            recommendations = [
-                "Add surface finish specification to internal bore",
-                "Specify thread depth dimension",
-                "Add sampling plan for inspection",
-                "Complete approval signatures",
-            ]
+            if hasattr(adapter, "validate_drawing_completeness"):
+                result = await adapter.validate_drawing_completeness(input_data)
+                if result.is_success:
+                    return {
+                        "status": "success",
+                        "message": "Drawing completeness validation completed",
+                        "data": result.data,
+                        "execution_time": result.execution_time,
+                    }
+                return {
+                    "status": "error",
+                    "message": result.error or "Failed to validate completeness",
+                }
 
             return {
-                "status": "success",
-                "message": "Drawing completeness validation completed",
-                "completeness_check": completeness_check,
-                "validation_results": {
-                    "completeness_score": completeness_score,
-                    "manufacturing_ready": completeness_score >= 90,
-                    "blocking_issues": len(blocking_issues),
-                    "recommendations": len(recommendations),
-                },
-                "blocking_issues": blocking_issues,
-                "recommendations": recommendations,
-                "manufacturing_readiness": {
-                    "ready_for_quoting": True,
-                    "ready_for_manufacturing": False,
-                    "required_actions": "Complete missing specifications and approvals",
-                    "estimated_completion_effort": "2 hours",
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support "
+                    "validate_drawing_completeness; no validation of "
+                    f"{drawing_path} was performed."
+                ),
             }
 
         except Exception as e:

--- a/src/solidworks_mcp/tools/export.py
+++ b/src/solidworks_mcp/tools/export.py
@@ -855,15 +855,11 @@ async def register_export_tools(
                 }
 
             return {
-                "status": "success",
-                "message": f"Exported image: {input_data.file_path}",
-                "export": {
-                    "file_path": input_data.file_path,
-                    "format": input_data.format_type.upper(),
-                    "dimensions": f"{input_data.width}x{input_data.height}",
-                    "view": input_data.view_orientation,
-                    "use_case": "Documentation and presentations",
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support export_image or "
+                    "export_file; no image was exported."
+                ),
             }
 
         except Exception as e:
@@ -927,17 +923,11 @@ async def register_export_tools(
                 }
 
             return {
-                "status": "success",
-                "message": f"Batch export completed to {input_data.format_type} format",
-                "batch_export": {
-                    "source_directory": input_data.source_directory,
-                    "output_directory": input_data.output_directory,
-                    "format": (input_data.format_type or "").upper(),
-                    "files_processed": 0,  # Would be actual count
-                    "files_successful": 0,
-                    "files_failed": 0,
-                    "errors": [],
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support batch_export; no files "
+                    "were exported."
+                ),
             }
 
         except Exception as e:

--- a/src/solidworks_mcp/tools/file_management.py
+++ b/src/solidworks_mcp/tools/file_management.py
@@ -681,9 +681,8 @@ async def register_file_management_tools(
                 }
 
             return {
-                "status": "success",
-                "message": "File saved successfully",
-                "timestamp": "2024-03-14T00:00:00Z",  # Would be actual timestamp
+                "status": "error",
+                "message": "Active adapter does not support save_file; the file was not saved.",
             }
 
         except Exception as e:
@@ -770,12 +769,12 @@ async def register_file_management_tools(
                     "message": result.error or "Failed to export file",
                 }
 
-            # Fallback for adapters without save/export support.
             return {
-                "status": "success",
-                "message": f"File saved as: {input_data.file_path}",
-                "file_path": input_data.file_path,
-                "format": input_data.format_type,
+                "status": "error",
+                "message": (
+                    "Active adapter does not support save_file or export_file; "
+                    f"no file was saved as {input_data.file_path}."
+                ),
             }
 
         except Exception as e:
@@ -1090,12 +1089,11 @@ async def register_file_management_tools(
                     "message": result.error or "Failed to manage file properties",
                 }
             return {
-                "status": "success",
-                "message": "File properties managed successfully",
-                "data": {
-                    "file_path": input_data.file_path,
-                    "operation": input_data.operation,
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support manage_file_properties; "
+                    f"no {input_data.operation} operation was performed."
+                ),
             }
         except Exception as e:
             logger.error(f"Error in manage_file_properties tool: {e}")
@@ -1130,13 +1128,11 @@ async def register_file_management_tools(
                     "message": result.error or "Failed to convert file format",
                 }
             return {
-                "status": "success",
-                "message": "File converted successfully",
-                "data": {
-                    "source_file": input_data.source_file,
-                    "target_file": input_data.target_file or input_data.output_path,
-                    "format_to": input_data.target_format,
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support convert_file_format; "
+                    f"{input_data.source_file} was not converted."
+                ),
             }
         except Exception as e:
             logger.error(f"Error in convert_file_format tool: {e}")
@@ -1171,12 +1167,11 @@ async def register_file_management_tools(
                     "message": result.error or "Failed to run batch file operations",
                 }
             return {
-                "status": "success",
-                "message": "Batch file operations completed successfully",
-                "data": {
-                    "file_path": input_data.file_path,
-                    "operation": input_data.operation,
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support batch_file_operations; "
+                    f"no {input_data.operation} batch operation was performed."
+                ),
             }
         except Exception as e:
             logger.error(f"Error in batch_file_operations tool: {e}")

--- a/src/solidworks_mcp/tools/macro_recording.py
+++ b/src/solidworks_mcp/tools/macro_recording.py
@@ -4,7 +4,6 @@ Provides tools for recording, managing, and executing SolidWorks macros for auto
 and workflow optimization.
 """
 
-import time
 from typing import Any
 
 from fastmcp import FastMCP
@@ -210,43 +209,12 @@ async def register_macro_recording_tools(
                     "message": result.error or "Failed to start recording",
                 }
 
-            recording_session: dict[str, Any] = {
-                "session_id": f"REC-{int(time.time() * 1000) % 100000}",
-                "macro_name": input_data.macro_name,
-                "description": input_data.description,
-                "start_time": time.time(),
-                "status": "recording",
-                "auto_stop": input_data.auto_stop,
-                "timeout": input_data.timeout_seconds,
-                "recorded_actions": [],
-                "estimated_file_size": "0 KB",
-            }
-
-            # In real implementation, this would interface with SolidWorks macro recorder
-            recording_instructions = [
-                "1. SolidWorks macro recording has started",
-                "2. Perform the actions you want to automate",
-                "3. Use stop_macro_recording when complete",
-                "4. Avoid unnecessary mouse movements for cleaner macros",
-            ]
-
             return {
-                "status": "success",
-                "message": f"Macro recording started: {input_data.macro_name}",
-                "recording_session": recording_session,
-                "instructions": recording_instructions,
-                "best_practices": [
-                    "Work slowly and deliberately for better recording",
-                    "Use keyboard shortcuts when possible",
-                    "Avoid redundant actions",
-                    "Test in a simple model first",
-                ],
-                "recording_tips": {
-                    "feature_creation": "Select sketch before recording feature creation",
-                    "selection": "Use feature tree selection instead of graphics area when possible",
-                    "views": "Use standard view orientations for consistency",
-                    "properties": "Access properties through feature tree right-click",
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support start_macro_recording; "
+                    f"no recording of {input_data.macro_name} was started."
+                ),
             }
 
         except Exception as e:
@@ -287,56 +255,13 @@ async def register_macro_recording_tools(
                     "message": result.error or "Failed to stop recording",
                 }
 
-            session_id = input_data.get("session_id", "")
-            save_path = input_data.get("save_path", "")
-            input_data.get("clean_code", True)
-
-            # Simulate recording completion
-            recorded_macro = {
-                "session_id": session_id,
-                "recording_duration": 125,  # seconds
-                "actions_recorded": 23,
-                "code_lines": 45,
-                "file_size": "3.2 KB",
-                "macro_path": save_path or f"C:\\Macros\\{session_id}.swp",
-                "complexity": "Medium",
-                "estimated_execution_time": "2.3 seconds",
-            }
-
-            macro_preview = """Sub RecordedMacro()
-    Dim swApp As SldWorks.SldWorks
-    Dim swModel As SldWorks.ModelDoc2
-    Dim swFeatMgr As SldWorks.FeatureManager
-
-    Set swApp = Application.SldWorks
-    Set swModel = swApp.ActiveDoc
-    Set swFeatMgr = swModel.FeatureManager
-
-    ' Recorded actions start here
-    swModel.SelectByID2 "Top Plane", "PLANE", 0, 0, 0, False, 0, Nothing, 0
-    swModel.SketchManager.InsertSketch True
-    swModel.SketchManager.CreateLine 0, 0, 0, 0.05, 0, 0
-    ' ... additional recorded actions ...
-
-End Sub"""
-
             return {
-                "status": "success",
-                "message": "Macro recording completed and saved",
-                "recorded_macro": recorded_macro,
-                "macro_preview": macro_preview,
-                "optimization_suggestions": [
-                    "Consider parameterizing hardcoded values",
-                    "Add error handling for robustness",
-                    "Group similar operations for efficiency",
-                    "Add user prompts for dynamic input",
-                ],
-                "next_steps": [
-                    "Test the macro in a simple model",
-                    "Edit the code to add parameters if needed",
-                    "Add to macro library for reuse",
-                    "Document the macro purpose and usage",
-                ],
+                "status": "error",
+                "message": (
+                    "No adapter capability exists for stopping a macro "
+                    "recording; this tool never started a real recording "
+                    "session, so there is no macro code to save."
+                ),
             }
 
         except Exception as e:
@@ -378,57 +303,13 @@ End Sub"""
                     "message": result.error or "Failed to execute macro",
                 }
 
-            execution_results: list[dict[str, Any]] = []
-
-            for run in range(input_data.repeat_count):
-                run_result = {
-                    "run_number": run + 1,
-                    "status": "success",
-                    "execution_time": 2.1 + (run * 0.1),  # Simulated timing
-                    "features_created": 3,
-                    "errors": 0,
-                    "warnings": 0,
-                }
-
-                execution_results.append(run_result)
-
-                # Simulate pause between runs
-                if (
-                    input_data.pause_between_runs > 0
-                    and run < input_data.repeat_count - 1
-                ):
-                    time.sleep(
-                        min(input_data.pause_between_runs, 1.0)
-                    )  # Cap the actual sleep
-
-            total_time = sum(float(r["execution_time"]) for r in execution_results)
-            total_features = sum(int(r["features_created"]) for r in execution_results)
-
             return {
-                "status": "success",
-                "message": f"Macro executed {input_data.repeat_count} times successfully",
-                "data": {
-                    "macro_path": input_data.macro_path,
-                    "parameters_used": input_data.parameters,
-                    "repeat_count": input_data.repeat_count,
-                    "pause_between_runs": input_data.pause_between_runs,
-                    "total_execution_time": total_time,
-                    "total_features_created": total_features,
-                },
-                "macro_execution": {
-                    "macro_path": input_data.macro_path,
-                    "parameters_used": input_data.parameters,
-                    "repeat_count": input_data.repeat_count,
-                    "pause_between_runs": input_data.pause_between_runs,
-                    "total_execution_time": total_time,
-                    "total_features_created": total_features,
-                },
-                "run_details": execution_results,
-                "performance_metrics": {
-                    "average_run_time": total_time / input_data.repeat_count,
-                    "features_per_second": total_features / total_time,
-                    "success_rate": "100%",
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support execute_macro; "
+                    f"{input_data.macro_path} was not run, and no features "
+                    "were created."
+                ),
             }
 
         except Exception as e:
@@ -469,81 +350,12 @@ End Sub"""
                     "message": result.error or "Failed to analyze macro",
                 }
 
-            # Simulate macro analysis
-            analysis_results = {
-                "file_info": {
-                    "file_path": input_data.macro_path,
-                    "file_size": "4.7 KB",
-                    "last_modified": "2024-01-15 14:30:22",
-                    "encoding": "UTF-8",
-                },
-                "code_metrics": {
-                    "total_lines": 67,
-                    "code_lines": 52,
-                    "comment_lines": 8,
-                    "blank_lines": 7,
-                    "subroutines": 3,
-                    "variables": 12,
-                    "api_calls": 28,
-                },
-                "complexity_analysis": {
-                    "cyclomatic_complexity": 4,
-                    "complexity_level": "Medium",
-                    "decision_points": 3,
-                    "loop_structures": 1,
-                    "nested_levels": 2,
-                },
-                "dependencies": {
-                    "solidworks_apis": [
-                        "SldWorks.SldWorks",
-                        "SldWorks.ModelDoc2",
-                        "SldWorks.FeatureManager",
-                        "SldWorks.SketchManager",
-                    ],
-                    "external_references": [],
-                    "file_dependencies": [],
-                    "version_compatibility": ["SW2020+"],
-                },
-                "performance_insights": {
-                    "estimated_execution_time": "3.2 seconds",
-                    "bottleneck_operations": [
-                        "Sketch creation (35% of time)",
-                        "Feature rebuilds (45% of time)",
-                    ],
-                    "optimization_opportunities": [
-                        "Batch selection operations",
-                        "Minimize rebuilds",
-                        "Use more efficient API methods",
-                    ],
-                },
-                "quality_issues": [
-                    "Hardcoded values detected (line 23, 31)",
-                    "Missing error handling for API calls",
-                    "No user input validation",
-                ],
-                "suggestions": [
-                    "Add input parameter validation",
-                    "Implement error handling for robustness",
-                    "Consider making dimensions parametric",
-                    "Add progress feedback for long operations",
-                ],
-            }
-
             return {
-                "status": "success",
-                "message": f"Macro analysis completed for {input_data.macro_path}",
-                "analysis": analysis_results,
-                "summary": {
-                    "overall_quality": "Good",
-                    "maintainability": "Medium",
-                    "reusability": "Medium",
-                    "performance": "Good",
-                },
-                "recommendations": {
-                    "immediate": "Add error handling",
-                    "short_term": "Parameterize hardcoded values",
-                    "long_term": "Modularize for better reusability",
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support analyze_macro; "
+                    f"{input_data.macro_path} was not analyzed."
+                ),
             }
 
         except Exception as e:
@@ -591,57 +403,13 @@ End Sub"""
                 }
 
             macro_list = payload.get("macro_list", [])
-            execution_order = payload.get("execution_order", "sequential")
-            stop_on_error = payload.get("stop_on_error", True)
-            execution_results = []
-
-            for i, macro_path in enumerate(macro_list):
-                result = {
-                    "macro_index": i + 1,
-                    "macro_path": macro_path,
-                    "status": "success" if i != 2 else "error",  # Simulate one error
-                    "execution_time": 1.5 + (i * 0.3),
-                    "error_message": "File not found" if i == 2 else None,
-                }
-                execution_results.append(result)
-
-                # Stop on error if configured
-                if stop_on_error and result["status"] == "error":
-                    break
-
-            successful_runs = [r for r in execution_results if r["status"] == "success"]
-            failed_runs = [r for r in execution_results if r["status"] == "error"]
 
             return {
-                "status": "success" if len(failed_runs) == 0 else "partial_success",
-                "message": f"Batch execution completed: {len(successful_runs)} success, {len(failed_runs)} failed",
-                "data": {
-                    "execution_order": execution_order,
-                    "stop_on_error": stop_on_error,
-                    "total_macros": len(macro_list),
-                    "successful_macros": len(successful_runs),
-                    "failed_macros": len(failed_runs),
-                },
-                "batch_execution": {
-                    "execution_order": execution_order,
-                    "stop_on_error": stop_on_error,
-                    "total_macros": len(macro_list),
-                    "successful_macros": len(successful_runs),
-                    "failed_macros": len(failed_runs),
-                },
-                "execution_results": execution_results,
-                "performance_summary": {
-                    "total_time": sum(r["execution_time"] for r in execution_results),
-                    "average_macro_time": sum(
-                        r["execution_time"] for r in successful_runs
-                    )
-                    / len(successful_runs)
-                    if successful_runs
-                    else 0,
-                    "success_rate": f"{len(successful_runs) / len(macro_list) * 100:.1f}%"
-                    if macro_list
-                    else "0.0%",
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support batch_execute_macros; "
+                    f"none of the {len(macro_list)} macro(s) were run."
+                ),
             }
 
         except Exception as e:
@@ -688,112 +456,13 @@ End Sub"""
                 }
 
             macro_path = payload.get("macro_path") or payload.get("macro_file", "")
-            optimization_level = payload.get(
-                "level", "standard"
-            )  # basic, standard, aggressive
-
-            # Simulate optimization analysis
-            optimizations = {
-                "performance_improvements": [
-                    {
-                        "type": "API_EFFICIENCY",
-                        "description": "Replace multiple SelectByID2 calls with batch selection",
-                        "impact": "25% faster",
-                    },
-                    {
-                        "type": "REBUILD_OPTIMIZATION",
-                        "description": "Move rebuilds to end of operation",
-                        "impact": "15% faster",
-                    },
-                    {
-                        "type": "SELECTION_EFFICIENCY",
-                        "description": "Use direct object references instead of selection",
-                        "impact": "10% faster",
-                    },
-                ],
-                "reliability_improvements": [
-                    {
-                        "type": "ERROR_HANDLING",
-                        "description": "Add try-catch blocks for API calls",
-                        "impact": "Prevents crashes",
-                    },
-                    {
-                        "type": "VALIDATION",
-                        "description": "Add input parameter validation",
-                        "impact": "Prevents invalid operations",
-                    },
-                    {
-                        "type": "OBJECT_CHECKING",
-                        "description": "Verify objects exist before use",
-                        "impact": "Prevents null reference errors",
-                    },
-                ],
-                "maintainability_improvements": [
-                    {
-                        "type": "PARAMETERIZATION",
-                        "description": "Replace hardcoded values with variables",
-                        "impact": "Easier customization",
-                    },
-                    {
-                        "type": "MODULARIZATION",
-                        "description": "Break into smaller subroutines",
-                        "impact": "Better organization",
-                    },
-                    {
-                        "type": "DOCUMENTATION",
-                        "description": "Add comments and usage instructions",
-                        "impact": "Easier maintenance",
-                    },
-                ],
-            }
-
-            optimized_code_preview = """Sub OptimizedMacro()
-                ' Optimized version with improvements
-                Dim swApp As SldWorks.SldWorks
-                Dim swModel As SldWorks.ModelDoc2
-                Dim swFeatMgr As SldWorks.FeatureManager
-
-                ' Input validation
-                Set swApp = Application.SldWorks
-                If swApp Is Nothing Then
-                    MsgBox "SolidWorks not available"
-                    Exit Sub
-                End If
-
-                Set swModel = swApp.ActiveDoc
-                If swModel Is Nothing Then
-                    MsgBox "No active document"
-                    Exit Sub
-                End If
-
-                ' Disable rebuilds for performance
-                swModel.FeatureManager.EnableFeatureTree = False
-
-                ' ... optimized operations ...
-
-                ' Re-enable and rebuild once at end
-                swModel.FeatureManager.EnableFeatureTree = True
-                swModel.ForceRebuild3 False
-
-            End Sub"""
 
             return {
-                "status": "success",
-                "message": f"Macro optimization analysis completed for {optimization_level} level",
-                "optimization_report": {
-                    "original_macro": macro_path,
-                    "optimization_level": optimization_level,
-                    "potential_improvements": optimizations,
-                    "estimated_performance_gain": "50% faster execution",
-                    "estimated_reliability_gain": "90% fewer runtime errors",
-                },
-                "optimized_code_preview": optimized_code_preview,
-                "implementation_priority": [
-                    "1. Add error handling (Critical)",
-                    "2. Optimize API calls (High)",
-                    "3. Add parameter validation (Medium)",
-                    "4. Improve documentation (Low)",
-                ],
+                "status": "error",
+                "message": (
+                    "Active adapter does not support optimize_macro; "
+                    f"{macro_path} was not analyzed or changed."
+                ),
             }
 
         except Exception as e:
@@ -840,117 +509,14 @@ End Sub"""
                     "message": result.error or "Failed to create library",
                 }
 
-            library_name = payload.get("library_name", "SolidWorks Macro Library")
-            library_path = payload.get("library_path", "C:\\MacroLibrary")
-            categories = payload.get(
-                "categories", ["Sketching", "Modeling", "Drawing", "Analysis", "Export"]
-            )
-            include_templates = payload.get("include_templates", True)
-
-            # Simulate library creation
-            library_structure = {
-                "library_info": {
-                    "name": "SolidWorks Macro Library",
-                    "path": library_path,
-                    "created": "2024-01-15",
-                    "version": "1.0.0",
-                    "total_macros": 0,
-                    "categories": categories,
-                },
-                "directory_structure": {
-                    "root": library_path,
-                    "folders": {
-                        "categories": [f"{library_path}\\{cat}" for cat in categories],
-                        "templates": f"{library_path}\\Templates",
-                        "documentation": f"{library_path}\\Documentation",
-                        "examples": f"{library_path}\\Examples",
-                        "utilities": f"{library_path}\\Utilities",
-                    },
-                },
-                "library_features": {
-                    "indexing": "Automatic macro cataloging",
-                    "search": "Full-text search capability",
-                    "version_control": "Git integration ready",
-                    "documentation": "Auto-generated documentation",
-                    "testing": "Automated macro testing framework",
-                },
-                "template_macros": [
-                    {
-                        "name": "BasicSketchTemplate.swp",
-                        "category": "Sketching",
-                        "description": "Template for basic sketch operations",
-                        "parameters": ["sketch_plane", "dimensions"],
-                    },
-                    {
-                        "name": "FeatureCreationTemplate.swp",
-                        "category": "Modeling",
-                        "description": "Template for creating parametric features",
-                        "parameters": ["feature_type", "dimensions", "materials"],
-                    },
-                    {
-                        "name": "DrawingSetupTemplate.swp",
-                        "category": "Drawing",
-                        "description": "Template for setting up drawing sheets",
-                        "parameters": ["sheet_format", "views", "annotations"],
-                    },
-                ]
-                if include_templates
-                else [],
-            }
-
-            # Create example index file content
-            library_index = {
-                "library_metadata": {
-                    "total_macros": 0,
-                    "last_updated": "2024-01-15",
-                    "maintainer": "Automation Team",
-                    "standards_version": "SW2024",
-                },
-                "macro_categories": {
-                    cat: {
-                        "count": 0,
-                        "description": f"Macros for {cat.lower()} operations",
-                    }
-                    for cat in categories
-                },
-                "usage_statistics": {
-                    "most_used": [],
-                    "recently_added": [],
-                    "needs_update": [],
-                },
-            }
+            library_path = payload.get("library_path", "")
 
             return {
-                "status": "success",
-                "message": f"Macro library created successfully at {library_path}",
-                "data": {
-                    "library_name": library_name,
-                    "library_path": library_path,
-                    "categories_created": categories,
-                    "documentation_generated": True,
-                    "library_structure": library_structure,
-                    "library_index": library_index,
-                },
-                "setup_instructions": [
-                    "1. Install macros in appropriate category folders",
-                    "2. Update macro documentation in Documentation folder",
-                    "3. Run library indexer to catalog macros",
-                    "4. Set up version control for team sharing",
-                    "5. Configure automated testing for quality assurance",
-                ],
-                "next_steps": [
-                    "Add your first macros to the library",
-                    "Document macro usage and parameters",
-                    "Set up team access permissions",
-                    "Configure backup and sync procedures",
-                    "Train team members on library usage",
-                ],
-                "maintenance_guidelines": {
-                    "daily": "No action required",
-                    "weekly": "Review new macro submissions",
-                    "monthly": "Update library index and statistics",
-                    "quarterly": "Audit library for outdated macros",
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support create_macro_library; "
+                    f"no library was created at {library_path or '(unspecified path)'}."
+                ),
             }
 
         except Exception as e:

--- a/src/solidworks_mcp/tools/template_management.py
+++ b/src/solidworks_mcp/tools/template_management.py
@@ -4,7 +4,8 @@ Provides tools for managing SolidWorks templates including extraction, applicati
 comparison, and library management.
 """
 
-import time
+import hashlib
+import pathlib
 from typing import Any
 
 from fastmcp import FastMCP
@@ -13,6 +14,30 @@ from pydantic import BaseModel, Field
 
 from ..adapters.base import SolidWorksAdapter
 from .input_compat import CompatInput
+
+
+def _file_fact_snapshot(path_str: str) -> dict[str, Any] | None:
+    """Read basic, honest filesystem facts about a file: size, mtime, hash.
+
+    Returns None if the path is empty or does not point at an existing file.
+    """
+    if not path_str:
+        return None
+    path = pathlib.Path(path_str)
+    if not path.is_file():
+        return None
+    stat = path.stat()
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return {
+        "path": str(path),
+        "size_bytes": stat.st_size,
+        "modified_time": stat.st_mtime,
+        "sha256": digest.hexdigest(),
+    }
+
 
 # Input schemas for template management
 
@@ -153,47 +178,12 @@ async def register_template_management_tools(
                     "message": result.error or "Failed to extract template",
                 }
 
-            # For now, return a structured response that describes what would be done
-            # In full implementation, this would use the SolidWorks API to extract settings
-
-            extracted_properties = {
-                "document_properties": {
-                    "units": "mm-kg-s",
-                    "precision": 2,
-                    "annotation_font": "Century Gothic",
-                    "dimension_style": "ISO",
-                },
-                "custom_properties": [
-                    {"name": "Material", "type": "text", "value": "Steel"},
-                    {"name": "Weight", "type": "number", "expression": "SW-Mass"},
-                    {"name": "DrawingNo", "type": "text", "value": ""},
-                    {"name": "RevisionLevel", "type": "text", "value": "A"},
-                ],
-                "dimension_settings": {
-                    "decimal_places": input_data.include_dimensions,
-                    "trailing_zeros": True,
-                    "units_display": True,
-                },
-            }
-
             return {
-                "status": "success",
-                "message": f"Template '{input_data.template_name}' extracted from {input_data.source_model}",
-                "template": {
-                    "name": input_data.template_name,
-                    "type": input_data.template_type,
-                    "save_path": input_data.save_path,
-                    "extracted_properties": extracted_properties,
-                    "property_count": len(extracted_properties["custom_properties"]),
-                    "includes_dimensions": input_data.include_dimensions,
-                    "includes_custom_properties": input_data.include_custom_properties,
-                },
-                "usage_instructions": [
-                    "1. Template file saved to specified path",
-                    "2. Use apply_template to apply to other models",
-                    "3. Template includes document formatting and properties",
-                    "4. Can be added to template library for reuse",
-                ],
+                "status": "error",
+                "message": (
+                    "Active adapter does not support extract_template; no "
+                    f"template was extracted from {input_data.source_model}."
+                ),
             }
 
         except Exception as e:
@@ -234,41 +224,12 @@ async def register_template_management_tools(
                     "message": result.error or "Failed to apply template",
                 }
 
-            # Simulate template application process
-            applied_changes = {
-                "properties_updated": [
-                    "Material → Steel",
-                    "DrawingNo → DRW-001",
-                    "RevisionLevel → A",
-                ],
-                "dimension_formatting": {
-                    "precision_updated": True,
-                    "units_format_applied": True,
-                    "font_updated": "Century Gothic",
-                },
-                "document_settings": {
-                    "units_system": "mm-kg-s",
-                    "drafting_standard": "ISO",
-                },
-            }
-
             return {
-                "status": "success",
-                "message": f"Template applied to {input_data.target_model}",
-                "template_application": {
-                    "template_path": input_data.template_path,
-                    "target_model": input_data.target_model,
-                    "changes_applied": applied_changes,
-                    "overwrite_mode": input_data.overwrite_existing,
-                    "material_applied": input_data.apply_materials,
-                    "dimensions_applied": input_data.apply_dimensions,
-                },
-                "recommendations": [
-                    "Rebuild the model to update all features",
-                    "Check custom properties in File > Properties",
-                    "Verify dimension formatting in drawings",
-                    "Save the model to preserve changes",
-                ],
+                "status": "error",
+                "message": (
+                    "Active adapter does not support apply_template; "
+                    f"{input_data.target_model} was not changed."
+                ),
             }
 
         except Exception as e:
@@ -309,44 +270,12 @@ async def register_template_management_tools(
                     "message": result.error or "Failed batch template application",
                 }
 
-            # Simulate batch processing
-            processed_files: list[dict[str, Any]] = [
-                {"file": "part001.sldprt", "status": "success", "changes": 5},
-                {"file": "part002.sldprt", "status": "success", "changes": 4},
-                {"file": "assembly001.sldasm", "status": "success", "changes": 3},
-                {
-                    "file": "drawing001.slddrw",
-                    "status": "skipped",
-                    "reason": "Wrong file type",
-                },
-            ]
-
-            summary = {
-                "total_processed": len(
-                    [f for f in processed_files if f["status"] == "success"]
-                ),
-                "total_scanned": len(processed_files),
-                "total_changes": sum(f.get("changes", 0) for f in processed_files),
-                "backup_created": input_data.backup_originals,
-            }
-
             return {
-                "status": "success",
-                "message": f"Batch template application completed on {summary['total_processed']} files",
-                "batch_operation": {
-                    "template_path": input_data.template_path,
-                    "source_folder": input_data.source_folder,
-                    "file_pattern": input_data.file_pattern,
-                    "recursive": input_data.recursive,
-                    "summary": summary,
-                    "processed_files": processed_files,
-                },
-                "performance": {
-                    "efficiency": f"{summary['total_changes']} changes across {summary['total_processed']} files",
-                    "backup_status": "Created"
-                    if input_data.backup_originals
-                    else "Not created",
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support batch_apply_template; "
+                    f"no files in {input_data.source_folder} were changed."
+                ),
             }
 
         except Exception as e:
@@ -371,6 +300,12 @@ async def register_template_management_tools(
 
         Example:
                             >>> result = await compare_templates(comparison_input)
+
+        Note:
+            When no adapter can parse template internals, this falls back to
+            a filesystem-level comparison only (existence, size, modified
+            time, byte-identical check) — it does not report property,
+            dimension, or formatting differences it cannot actually read.
         """
         try:
             if hasattr(adapter, "compare_templates"):
@@ -387,70 +322,49 @@ async def register_template_management_tools(
                     "message": result.error or "Failed to compare templates",
                 }
 
-            # Simulate template comparison
-            differences = {
-                "document_properties": {
-                    "units": {
-                        "template1": "mm-kg-s",
-                        "template2": "in-lbm-s",
-                        "different": True,
-                    },
-                    "precision": {"template1": 2, "template2": 3, "different": True},
-                    "font": {
-                        "template1": "Arial",
-                        "template2": "Century Gothic",
-                        "different": True,
-                    },
-                },
-                "custom_properties": {
-                    "added_in_template2": ["RevisionDate", "Designer"],
-                    "removed_from_template1": ["OldProperty"],
-                    "modified": [
-                        {
-                            "property": "Material",
-                            "template1": "Steel",
-                            "template2": "Aluminum",
-                        }
-                    ],
-                },
-                "dimension_formatting": {
-                    "decimal_places": {
-                        "template1": 2,
-                        "template2": 2,
-                        "different": False,
-                    },
-                    "units_display": {
-                        "template1": True,
-                        "template2": False,
-                        "different": True,
-                    },
-                },
-            }
+            file_1 = _file_fact_snapshot(input_data.template1_path)
+            file_2 = _file_fact_snapshot(input_data.template2_path)
 
-            similarity_score = 85.5  # Simulated similarity percentage
+            missing = [
+                path
+                for path, snapshot in (
+                    (input_data.template1_path, file_1),
+                    (input_data.template2_path, file_2),
+                )
+                if snapshot is None
+            ]
+            if missing:
+                return {
+                    "status": "error",
+                    "message": (
+                        "Cannot compare templates; file(s) not found on "
+                        f"disk: {', '.join(missing)}. No template-property "
+                        "diff was performed."
+                    ),
+                }
 
-            comparison_report = {
-                "template1": input_data.template1_path,
-                "template2": input_data.template2_path,
-                "comparison_type": input_data.comparison_type,
-                "similarity_score": similarity_score,
-                "differences_found": differences,
-                "recommendations": [
-                    "Consider standardizing units system across templates",
-                    "Review custom property naming conventions",
-                    "Align dimension formatting for consistency",
-                ],
-            }
+            assert file_1 is not None
+            assert file_2 is not None
+            identical = file_1["sha256"] == file_2["sha256"]
 
             return {
                 "status": "success",
-                "message": f"Template comparison completed - {similarity_score}% similar",
-                "comparison": comparison_report,
-                "analysis": {
-                    "major_differences": 3,
-                    "minor_differences": 2,
-                    "compatibility": "High" if similarity_score > 80 else "Medium",
+                "message": (
+                    "Template files are byte-identical"
+                    if identical
+                    else "Template files differ on disk"
+                ),
+                "comparison": {
+                    "file_1": file_1,
+                    "file_2": file_2,
+                    "identical": identical,
+                    "size_delta_bytes": file_2["size_bytes"] - file_1["size_bytes"],
                 },
+                "note": (
+                    "This is a filesystem-level comparison only; template "
+                    "properties, dimensions, and formatting were not "
+                    "analyzed."
+                ),
             }
 
         except Exception as e:
@@ -492,53 +406,16 @@ async def register_template_management_tools(
                     "message": result.error or "Failed to save to library",
                 }
 
-            template_path = input_data.get("template_path", "")
-            library_category = input_data.get("category", "uncategorized")
-            version = input_data.get("version", "1.0")
-            description = input_data.get("description", "")
-            author = input_data.get("author", "Unknown")
-
-            library_entry = {
-                "template_id": f"TPL-{library_category.upper()}-{int(time.time()) % 10000}",
-                "name": input_data.get("template_name", "Unnamed Template"),
-                "category": library_category,
-                "version": version,
-                "author": author,
-                "description": description,
-                "created_date": "2024-01-15",  # Would be current date
-                "file_path": template_path,
-                "usage_count": 0,
-                "tags": input_data.get("tags", []),
-                "compatible_versions": [
-                    "SW2020",
-                    "SW2021",
-                    "SW2022",
-                    "SW2023",
-                    "SW2024",
-                ],
-            }
+            template_name = input_data.get("template_name", "")
 
             return {
-                "status": "success",
-                "message": f"Template saved to library as {library_entry['template_id']}",
-                "library_entry": library_entry,
-                "library_stats": {
-                    "total_templates": 47,  # Simulated library stats
-                    "category_count": {
-                        "parts": 15,
-                        "assemblies": 12,
-                        "drawings": 8,
-                        "custom": 12,
-                    },
-                    "most_popular": "STD-PART-001",
-                    "latest_addition": library_entry["template_id"],
-                },
-                "usage_instructions": [
-                    "Template is now available in library browser",
-                    "Use template_id for quick access",
-                    "Template will appear in category filters",
-                    "Version control enabled for updates",
-                ],
+                "status": "error",
+                "message": (
+                    "Active adapter does not support save_to_template_library; "
+                    f"'{template_name}' was not saved to any library. There is "
+                    "no local template registry — this tool needs a real "
+                    "adapter-backed library service."
+                ),
             }
 
         except Exception as e:
@@ -579,90 +456,12 @@ async def register_template_management_tools(
                     "message": result.error or "Failed to list template library",
                 }
 
-            category_filter = input_data.get("category", "all")
-            search_term = input_data.get("search_term", "")
-            sort_by = input_data.get("sort_by", "name")  # name, date, usage
-
-            # Simulated template library
-            library_templates: list[dict[str, Any]] = [
-                {
-                    "template_id": "STD-PART-001",
-                    "name": "Standard Part Template",
-                    "category": "parts",
-                    "version": "2.1",
-                    "author": "Engineering Team",
-                    "description": "Standard template for mechanical parts with ISO properties",
-                    "usage_count": 145,
-                    "last_updated": "2024-01-10",
-                    "tags": ["standard", "mechanical", "iso"],
-                },
-                {
-                    "template_id": "ASM-MAIN-002",
-                    "name": "Main Assembly Template",
-                    "category": "assemblies",
-                    "version": "1.5",
-                    "author": "Design Team",
-                    "description": "Template for main assembly documentation and BOM",
-                    "usage_count": 87,
-                    "last_updated": "2024-01-08",
-                    "tags": ["assembly", "bom", "documentation"],
-                },
-                {
-                    "template_id": "DRW-ISO-003",
-                    "name": "ISO Drawing Template",
-                    "category": "drawings",
-                    "version": "3.0",
-                    "author": "Drafting Team",
-                    "description": "ISO standard drawing template with title block",
-                    "usage_count": 203,
-                    "last_updated": "2024-01-12",
-                    "tags": ["drawing", "iso", "title-block"],
-                },
-            ]
-
-            # Apply filters
-            filtered_templates = library_templates
-            if category_filter != "all":
-                filtered_templates = [
-                    t for t in filtered_templates if t["category"] == category_filter
-                ]
-
-            if search_term:
-                filtered_templates = [
-                    t
-                    for t in filtered_templates
-                    if search_term.lower() in t["name"].lower()
-                    or search_term.lower() in t["description"].lower()
-                ]
-
-            # Apply sorting
-            if sort_by == "usage":
-                filtered_templates.sort(key=lambda x: x["usage_count"], reverse=True)
-            elif sort_by == "date":
-                filtered_templates.sort(key=lambda x: x["last_updated"], reverse=True)
-            else:  # name
-                filtered_templates.sort(key=lambda x: x["name"])
-
             return {
-                "status": "success",
-                "message": f"Found {len(filtered_templates)} templates matching criteria",
-                "library_search": {
-                    "category_filter": category_filter,
-                    "search_term": search_term,
-                    "sort_by": sort_by,
-                    "total_results": len(filtered_templates),
-                },
-                "templates": filtered_templates,
-                "categories_available": ["parts", "assemblies", "drawings", "custom"],
-                "library_summary": {
-                    "total_templates": len(library_templates),
-                    "most_used": max(library_templates, key=lambda x: x["usage_count"])[
-                        "name"
-                    ],
-                    "newest": max(library_templates, key=lambda x: x["last_updated"])[
-                        "name"
-                    ],
-                },
+                "status": "error",
+                "message": (
+                    "Active adapter does not support list_template_library; "
+                    "there is no local template registry to list."
+                ),
             }
 
         except Exception as e:

--- a/tests/solidworks_mcp/tools/test_additional_coverage.py
+++ b/tests/solidworks_mcp/tools/test_additional_coverage.py
@@ -236,27 +236,28 @@ def test_pywin32_adapter_guard_and_helpers(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_drawing_tools_simulation_branches(mcp_server, mock_config):
-    """Test drawing tools simulation branches."""
+async def test_drawing_tools_refuse_without_adapter_support(mcp_server, mock_config):
+    """Drawing tools refuse rather than inventing a result when the adapter
+    (a plain `object()` here) has no matching capability."""
     await register_drawing_tools(mcp_server, object(), mock_config)
 
     assert (
         await (await _tool(mcp_server, "create_drawing_view"))(
             input_data=CreateDrawingViewInput(model_path="m.sldprt", view_type="front")
         )
-    )["status"] == "success"
+    )["status"] == "error"
     assert (
         await (await _tool(mcp_server, "add_dimension"))(
             input_data=DrawingAddDimensionInput(
                 dimension_type="linear", entity1="L1", position_x=1, position_y=2
             )
         )
-    )["status"] == "success"
+    )["status"] == "error"
     assert (
         await (await _tool(mcp_server, "add_note"))(
             input_data=AddNoteInput(text="n", position_x=1, position_y=2)
         )
-    )["status"] == "success"
+    )["status"] == "error"
     assert (
         await (await _tool(mcp_server, "create_section_view"))(
             input_data=CreateSectionViewInput(
@@ -266,36 +267,36 @@ async def test_drawing_tools_simulation_branches(mcp_server, mock_config):
                 view_position_y=2,
             )
         )
-    )["status"] == "success"
+    )["status"] == "error"
     assert (
         await (await _tool(mcp_server, "create_detail_view"))(
             input_data=CreateDetailViewInput(
                 center_x=0, center_y=0, radius=2, view_position_x=3, view_position_y=4
             )
         )
-    )["status"] == "success"
+    )["status"] == "error"
     assert (
         await (await _tool(mcp_server, "update_sheet_format"))(
             input_data=UpdateSheetFormatInput(format_file="f.slddrt")
         )
-    )["status"] == "success"
+    )["status"] == "error"
     assert (
         await (await _tool(mcp_server, "auto_dimension_view"))(
             input_data={"view_name": "Front"}
         )
-    )["status"] == "success"
+    )["status"] == "error"
     assert (
         await (await _tool(mcp_server, "check_drawing_standards"))(
             input_data={"standard": "ANSI"}
         )
-    )["status"] == "success"
+    )["status"] == "error"
 
     alias_result = await (await _tool(mcp_server, "add_dimension"))(
         input_data=DimensionInput(
             entities=["E1", "E2"], position=[5, 6], dimension_type="linear"
         )
     )
-    assert alias_result["status"] == "success"
+    assert alias_result["status"] == "error"
 
     assert (
         await (await _tool(mcp_server, "create_technical_drawing"))(
@@ -303,17 +304,17 @@ async def test_drawing_tools_simulation_branches(mcp_server, mock_config):
                 output_path="o.slddrw", auto_populate_views=True
             )
         )
-    )["status"] == "success"
+    )["status"] == "error"
     assert (
         await (await _tool(mcp_server, "add_drawing_view"))(
             input_data=DrawingViewInput(
                 view_name="Front", view_type="front", position=[1, 1]
             )
         )
-    )["status"] == "success"
+    )["status"] == "error"
     assert (
         await (await _tool(mcp_server, "update_title_block"))(input_data={"title": "A"})
-    )["status"] == "success"
+    )["status"] == "error"
 
 
 class _ExportFallbackAdapter:
@@ -370,6 +371,9 @@ async def test_export_tools_fallback_and_aliases(mcp_server, mock_config):
             )
         )
     )["status"] == "success"
+    # _ExportFallbackAdapter has no batch_export capability (unlike
+    # export_file, which the single-file export tools fall back to), so
+    # batch_export must refuse rather than inventing a batch result.
     assert (
         await (await _tool(mcp_server, "batch_export"))(
             input_data=BatchExportInput(
@@ -379,7 +383,7 @@ async def test_export_tools_fallback_and_aliases(mcp_server, mock_config):
                 file_pattern="*.sldprt",
             )
         )
-    )["status"] == "success"
+    )["status"] == "error"
 
     error_result = await (await _tool(mcp_server, "export_step"))(
         input_data={"file_path": None, "format_type": "step"}
@@ -388,40 +392,43 @@ async def test_export_tools_fallback_and_aliases(mcp_server, mock_config):
 
 
 @pytest.mark.asyncio
-async def test_drawing_analysis_simulation_paths(mcp_server, mock_config):
-    """Test drawing analysis simulation paths."""
+async def test_drawing_analysis_refuses_without_adapter_support(
+    mcp_server, mock_config
+):
+    """Drawing analysis tools refuse rather than inventing a result when the
+    adapter (a plain `object()` here) has no matching capability."""
     await register_drawing_analysis_tools(mcp_server, object(), mock_config)
 
     assert (
         await (await _tool(mcp_server, "analyze_drawing_comprehensive"))(
             input_data=DrawingAnalysisInput(drawing_path="a.slddrw")
         )
-    )["status"] == "success"
+    )["status"] == "error"
     assert (
         await (await _tool(mcp_server, "analyze_drawing_dimensions"))(
             input_data=DimensionAnalysisInput(drawing_path="a.slddrw")
         )
-    )["status"] == "success"
+    )["status"] == "error"
     assert (
         await (await _tool(mcp_server, "analyze_drawing_annotations"))(
             input_data=AnnotationAnalysisInput(drawing_path="a.slddrw")
         )
-    )["status"] == "success"
+    )["status"] == "error"
     assert (
         await (await _tool(mcp_server, "check_drawing_compliance"))(
             input_data=ComplianceCheckInput(drawing_path="a.slddrw")
         )
-    )["status"] == "success"
+    )["status"] == "error"
     assert (
         await (await _tool(mcp_server, "analyze_drawing_views"))(
             input_data={"drawing_path": "a.slddrw"}
         )
-    )["status"] == "success"
+    )["status"] == "error"
     assert (
         await (await _tool(mcp_server, "generate_drawing_report"))(
             input_data={"drawing_path": "a.slddrw", "report_type": "summary"}
         )
-    )["status"] == "success"
+    )["status"] == "error"
 
 
 @pytest.mark.asyncio

--- a/tests/solidworks_mcp/tools/test_analysis.py
+++ b/tests/solidworks_mcp/tools/test_analysis.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 
 from solidworks_mcp.tools.analysis import (
+    GeometryAnalysisInput,
     InterferenceCheckInput,
     MassPropertiesInput,
     register_analysis_tools,
@@ -261,12 +262,13 @@ class TestAnalysisTools:
         assert geometry_tool is not None
         assert material_tool is not None
 
-        # Fallback branch when adapter has no check_interference method.
+        # Fallback branch when adapter has no check_interference method: must
+        # refuse rather than invent an interference result.
         if hasattr(mock_adapter, "check_interference"):
             delattr(mock_adapter, "check_interference")
         fallback = await check_tool(input_data=InterferenceCheckInput())
-        assert fallback["status"] == "success"
-        assert fallback["interference_found"] is False
+        assert fallback["status"] == "error"
+        assert "does not support check_interference" in fallback["message"]
 
         # Exception branch for adapter check_interference.
         mock_adapter.check_interference = AsyncMock(side_effect=RuntimeError("boom"))
@@ -288,6 +290,67 @@ class TestAnalysisTools:
         assert bad_geo["status"] == "error"
         assert "bad analysis type" in bad_geo["message"]
 
+        # get_material_properties must refuse rather than invent a material,
+        # since mock_adapter has no get_material_properties method.
         material = await material_tool()
-        assert material["status"] == "success"
-        assert material["material"]["name"]
+        assert material["status"] == "error"
+        assert "does not support get_material_properties" in material["message"]
+
+    @pytest.mark.asyncio
+    async def test_analyze_geometry_and_material_properties_adapter_paths(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """Cover the real-adapter success/error paths once analyze_geometry and
+        get_material_properties are wired to an adapter that implements them."""
+        await register_analysis_tools(mcp_server, mock_adapter, mock_config)
+
+        geometry_tool = None
+        material_tool = None
+        for tool in await mcp_server.list_tools():
+            if tool.name == "analyze_geometry":
+                geometry_tool = tool.fn
+            if tool.name == "get_material_properties":
+                material_tool = tool.fn
+
+        assert geometry_tool is not None
+        assert material_tool is not None
+
+        mock_adapter.analyze_geometry = AsyncMock(
+            return_value=Mock(
+                is_success=True,
+                data={"analysis_type": "draft", "findings": []},
+                execution_time=0.1,
+            )
+        )
+        geometry_success = await geometry_tool(
+            input_data=GeometryAnalysisInput(analysis_type="draft")
+        )
+        assert geometry_success["status"] == "success"
+        assert geometry_success["data"]["analysis_type"] == "draft"
+
+        mock_adapter.analyze_geometry = AsyncMock(
+            return_value=Mock(is_success=False, error="geometry analysis failed")
+        )
+        geometry_error = await geometry_tool(
+            input_data=GeometryAnalysisInput(analysis_type="draft")
+        )
+        assert geometry_error["status"] == "error"
+        assert "geometry analysis failed" in geometry_error["message"]
+
+        mock_adapter.get_material_properties = AsyncMock(
+            return_value=Mock(
+                is_success=True,
+                data={"name": "Steel"},
+                execution_time=0.1,
+            )
+        )
+        material_success = await material_tool()
+        assert material_success["status"] == "success"
+        assert material_success["data"]["name"] == "Steel"
+
+        mock_adapter.get_material_properties = AsyncMock(
+            return_value=Mock(is_success=False, error="no material assigned")
+        )
+        material_error = await material_tool()
+        assert material_error["status"] == "error"
+        assert "no material assigned" in material_error["message"]

--- a/tests/solidworks_mcp/tools/test_automation.py
+++ b/tests/solidworks_mcp/tools/test_automation.py
@@ -413,7 +413,10 @@ class TestAutomationTools:
     async def test_automation_fallback_paths_without_adapter_methods(
         self, mcp_server, mock_config
     ):
-        """Test fallback simulation branches for all automation tools."""
+        """Automation tools refuse rather than inventing a result when the
+        adapter has no matching capability. generate_vba_code is the one
+        exception: it produces real VBA text from the operation description,
+        so it still succeeds without an adapter."""
         await register_automation_tools(mcp_server, object(), mock_config)
 
         by_name = {tool.name: tool.fn for tool in await mcp_server.list_tools()}
@@ -455,20 +458,20 @@ class TestAutomationTools:
 
         assert vba["status"] == "success"
         assert "vba_code" in vba
-        assert start["status"] == "success"
-        assert start["macro_recording"]["status"] == "recording"
-        assert stop["status"] == "success"
-        assert stop["macro_recording"]["status"] == "stopped"
-        assert batch["status"] == "success"
-        assert batch["batch_process"]["files_found"] == 25
-        assert table["status"] == "success"
-        assert table["design_table"]["operation"] == "create"
-        assert workflow["status"] == "success"
-        assert workflow["workflow"]["total_steps"] == 1
-        assert template["status"] == "success"
-        assert template["template"]["type"] == "part"
-        assert optimize["status"] == "success"
-        assert optimize["optimization"]["settings_optimized"] == 12
+        assert start["status"] == "error"
+        assert "does not support start_macro_recording" in start["message"]
+        assert stop["status"] == "error"
+        assert stop["message"]  # unconditional refusal, no adapter to check
+        assert batch["status"] == "error"
+        assert "does not support batch_process_files" in batch["message"]
+        assert table["status"] == "error"
+        assert "does not support manage_design_table" in table["message"]
+        assert workflow["status"] == "error"
+        assert "does not support execute_workflow" in workflow["message"]
+        assert template["status"] == "error"
+        assert "does not support create_template" in template["message"]
+        assert optimize["status"] == "error"
+        assert "does not support optimize_performance" in optimize["message"]
 
     @pytest.mark.asyncio
     async def test_automation_exception_paths_from_adapter_methods(

--- a/tests/solidworks_mcp/tools/test_drawing.py
+++ b/tests/solidworks_mcp/tools/test_drawing.py
@@ -388,7 +388,8 @@ class TestDrawingToolsBranchCoverage:
     async def test_add_dimension_simulation_no_adapter_method(
         self, mcp_server, mock_adapter, mock_config
     ):
-        """Add_dimension falls back to simulation when adapter has no add_dimension."""
+        """Add_dimension refuses rather than inventing a dimension when the
+        adapter has no add_dimension capability."""
         await register_drawing_tools(mcp_server, mock_adapter, mock_config)
         # Verify adapter does NOT have add_dimension; if it does, delete it.
         if hasattr(mock_adapter, "add_dimension"):
@@ -407,7 +408,8 @@ class TestDrawingToolsBranchCoverage:
             position_y=60.0,
         )
         result = await tool_func(input_data=input_data)
-        assert result["status"] == "success"
+        assert result["status"] == "error"
+        assert "does not support add_dimension" in result["message"]
 
     @pytest.mark.asyncio
     async def test_add_dimension_adapter_error_path(
@@ -437,7 +439,8 @@ class TestDrawingToolsBranchCoverage:
     async def test_create_technical_drawing_no_adapter_no_views(
         self, mcp_server, mock_adapter, mock_config
     ):
-        """Create_technical_drawing simulation path with auto_populate_views=False."""
+        """Create_technical_drawing refuses when the adapter has no
+        create_technical_drawing capability, rather than inventing a drawing."""
         await register_drawing_tools(mcp_server, mock_adapter, mock_config)
         if hasattr(mock_adapter, "create_technical_drawing"):
             del mock_adapter.create_technical_drawing
@@ -456,8 +459,8 @@ class TestDrawingToolsBranchCoverage:
             None,
         )
         result = await tool_func(input_data=input_data)
-        assert result["status"] == "success"
-        assert result["data"]["views_created"] == []
+        assert result["status"] == "error"
+        assert "does not support create_technical_drawing" in result["message"]
 
     @pytest.mark.asyncio
     async def test_create_technical_drawing_adapter_success(
@@ -493,7 +496,8 @@ class TestDrawingToolsBranchCoverage:
     async def test_add_drawing_view_no_adapter_simulation(
         self, mcp_server, mock_adapter, mock_config
     ):
-        """Add_drawing_view simulation path when adapter lacks add_drawing_view."""
+        """Add_drawing_view refuses when adapter lacks add_drawing_view,
+        rather than inventing a view."""
         await register_drawing_tools(mcp_server, mock_adapter, mock_config)
         if hasattr(mock_adapter, "add_drawing_view"):
             del mock_adapter.add_drawing_view
@@ -512,8 +516,8 @@ class TestDrawingToolsBranchCoverage:
             None,
         )
         result = await tool_func(input_data=input_data)
-        assert result["status"] == "success"
-        assert result["data"]["view_name"] == "Front View"
+        assert result["status"] == "error"
+        assert "does not support add_drawing_view" in result["message"]
 
     # ── add_annotation: adapter error + no-adapter simulation paths ────────
 
@@ -545,7 +549,8 @@ class TestDrawingToolsBranchCoverage:
     async def test_add_annotation_no_adapter_simulation(
         self, mcp_server, mock_adapter, mock_config
     ):
-        """Add_annotation falls back to simulation when adapter lacks add_annotation."""
+        """Add_annotation refuses when adapter lacks add_annotation, rather
+        than inventing an annotation."""
         await register_drawing_tools(mcp_server, mock_adapter, mock_config)
         if hasattr(mock_adapter, "add_annotation"):
             del mock_adapter.add_annotation
@@ -561,8 +566,8 @@ class TestDrawingToolsBranchCoverage:
             None,
         )
         result = await tool_func(input_data=input_data)
-        assert result["status"] == "success"
-        assert result["data"]["annotation_text"] == "MaterialSpec"
+        assert result["status"] == "error"
+        assert "does not support add_annotation" in result["message"]
 
     # ── update_title_block: adapter error + no-adapter paths ───────────────
 
@@ -594,7 +599,8 @@ class TestDrawingToolsBranchCoverage:
     async def test_update_title_block_no_adapter_simulation(
         self, mcp_server, mock_adapter, mock_config
     ):
-        """Update_title_block simulation path when adapter lacks the method."""
+        """Update_title_block refuses when adapter lacks the method, rather
+        than echoing the input back as a claimed success."""
         await register_drawing_tools(mcp_server, mock_adapter, mock_config)
         if hasattr(mock_adapter, "update_title_block"):
             del mock_adapter.update_title_block
@@ -609,8 +615,8 @@ class TestDrawingToolsBranchCoverage:
             None,
         )
         result = await tool_func(input_data=payload)
-        assert result["status"] == "success"
-        assert result["data"]["title"] == "Widget"
+        assert result["status"] == "error"
+        assert "does not support update_title_block" in result["message"]
 
     @pytest.mark.asyncio
     async def test_typed_drawing_tools_default_error_messages(
@@ -711,10 +717,17 @@ class TestDrawingToolsBranchCoverage:
     async def test_add_dimension_raw_dict_payload_normalization(
         self, mcp_server, mock_adapter, mock_config
     ):
-        """Covers dict payload branch with entities/position alias mapping."""
+        """Covers dict payload branch with entities/position alias mapping.
+
+        The entities/position aliases must reach the adapter call as
+        entity1/entity2/position_x/position_y even when the caller only
+        supplied entities/position.
+        """
         await register_drawing_tools(mcp_server, mock_adapter, mock_config)
-        if hasattr(mock_adapter, "add_dimension"):
-            del mock_adapter.add_dimension
+
+        mock_adapter.add_dimension = AsyncMock(
+            return_value=Mock(is_success=True, data={"id": "Dim1"}, execution_time=0.1)
+        )
 
         tool_func = next(
             (t.fn for t in await mcp_server.list_tools() if t.name == "add_dimension"),
@@ -730,16 +743,20 @@ class TestDrawingToolsBranchCoverage:
         )
 
         assert result["status"] == "success"
-        assert result["dimension"]["entity1"] == "Edge1"
-        assert result["dimension"]["entity2"] == "Edge2"
-        assert result["dimension"]["position"] == {"x": 11.0, "y": 22.0}
-        assert result["dimension"]["precision"] == 3
+        called_payload = mock_adapter.add_dimension.call_args.args[0]
+        assert called_payload["entity1"] == "Edge1"
+        assert called_payload["entity2"] == "Edge2"
+        assert called_payload["position_x"] == 11.0
+        assert called_payload["position_y"] == 22.0
 
     @pytest.mark.asyncio
-    async def test_legacy_drawing_tools_success_paths(
+    async def test_legacy_drawing_tools_no_adapter_support_refuses(
         self, mcp_server, mock_adapter, mock_config
     ):
-        """Covers success branches for legacy drawing utility tools."""
+        """Legacy drawing utility tools refuse rather than inventing a result
+        when the adapter has no matching capability (or, for
+        create_section_view/create_detail_view/check_drawing_standards, has
+        no capability at all to compute the answer)."""
         await register_drawing_tools(mcp_server, mock_adapter, mock_config)
         by_name = {t.name: t.fn for t in await mcp_server.list_tools()}
 
@@ -772,19 +789,108 @@ class TestDrawingToolsBranchCoverage:
         auto_dim = await by_name["auto_dimension_view"]({"view_name": "Front"})
         std = await by_name["check_drawing_standards"]({"standard": "ANSI"})
 
+        assert view["status"] == "error"
+        assert "does not support create_drawing_view" in view["message"]
+        assert note["status"] == "error"
+        assert "does not support add_note" in note["message"]
+        assert section["status"] == "error"
+        assert "section line" in section["message"].lower()
+        assert detail["status"] == "error"
+        assert "detail circle" in detail["message"].lower()
+        assert sheet["status"] == "error"
+        assert "does not support update_sheet_format" in sheet["message"]
+        assert auto_dim["status"] == "error"
+        assert "does not support auto_dimension_view" in auto_dim["message"]
+        assert std["status"] == "error"
+        assert "compliance_score" not in str(std)
+
+    @pytest.mark.asyncio
+    async def test_legacy_drawing_tools_real_adapter_paths(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """Covers success/error branches once the adapter implements
+        create_drawing_view/add_note/update_sheet_format/auto_dimension_view."""
+        await register_drawing_tools(mcp_server, mock_adapter, mock_config)
+        by_name = {t.name: t.fn for t in await mcp_server.list_tools()}
+
+        mock_adapter.create_drawing_view = AsyncMock(
+            return_value=Mock(is_success=True, data={"view": "V1"}, execution_time=0.1)
+        )
+        mock_adapter.add_note = AsyncMock(
+            return_value=Mock(is_success=True, data={"note": "N1"}, execution_time=0.1)
+        )
+        mock_adapter.update_sheet_format = AsyncMock(
+            return_value=Mock(is_success=True, data={"sheet": "A3"}, execution_time=0.1)
+        )
+        mock_adapter.auto_dimension_view = AsyncMock(
+            return_value=Mock(
+                is_success=True, data={"dimensions_added": 4}, execution_time=0.1
+            )
+        )
+
+        view = await by_name["create_drawing_view"](
+            CreateDrawingViewInput(model_path="m.sldprt", view_type="isometric")
+        )
+        note = await by_name["add_note"](
+            AddNoteInput(text="abc", position_x=1.0, position_y=2.0)
+        )
+        sheet = await by_name["update_sheet_format"](
+            UpdateSheetFormatInput(format_file="fmt.slddrt")
+        )
+        auto_dim = await by_name["auto_dimension_view"]({"view_name": "Front"})
+
         assert view["status"] == "success"
+        assert view["data"]["view"] == "V1"
         assert note["status"] == "success"
-        assert section["status"] == "success"
-        assert detail["status"] == "success"
+        assert note["data"]["note"] == "N1"
         assert sheet["status"] == "success"
+        assert sheet["data"]["sheet"] == "A3"
         assert auto_dim["status"] == "success"
-        assert std["status"] == "success"
+        assert auto_dim["data"]["dimensions_added"] == 4
+
+        mock_adapter.create_drawing_view = AsyncMock(
+            return_value=Mock(is_success=False, error="view failed")
+        )
+        mock_adapter.add_note = AsyncMock(
+            return_value=Mock(is_success=False, error="note failed")
+        )
+        mock_adapter.update_sheet_format = AsyncMock(
+            return_value=Mock(is_success=False, error="sheet failed")
+        )
+        mock_adapter.auto_dimension_view = AsyncMock(
+            return_value=Mock(is_success=False, error="auto dim failed")
+        )
+
+        view_err = await by_name["create_drawing_view"](
+            CreateDrawingViewInput(model_path="m.sldprt", view_type="isometric")
+        )
+        note_err = await by_name["add_note"](
+            AddNoteInput(text="abc", position_x=1.0, position_y=2.0)
+        )
+        sheet_err = await by_name["update_sheet_format"](
+            UpdateSheetFormatInput(format_file="fmt.slddrt")
+        )
+        auto_dim_err = await by_name["auto_dimension_view"]({"view_name": "Front"})
+
+        assert view_err["status"] == "error" and "view failed" in view_err["message"]
+        assert note_err["status"] == "error" and "note failed" in note_err["message"]
+        assert sheet_err["status"] == "error" and "sheet failed" in sheet_err["message"]
+        assert (
+            auto_dim_err["status"] == "error"
+            and "auto dim failed" in auto_dim_err["message"]
+        )
 
     @pytest.mark.asyncio
     async def test_legacy_drawing_tools_exception_paths(
         self, mcp_server, mock_adapter, mock_config
     ):
-        """Covers exception handlers in legacy drawing utility tools."""
+        """Covers exception handlers in legacy drawing utility tools.
+
+        create_section_view/create_detail_view/check_drawing_standards no
+        longer touch input_data at all (they refuse unconditionally), so bad
+        input can't crash them — they still report "error", just via the
+        clean refusal path rather than the exception handler.
+        """
         await register_drawing_tools(mcp_server, mock_adapter, mock_config)
         by_name = {t.name: t.fn for t in await mcp_server.list_tools()}
 
@@ -797,7 +903,5 @@ class TestDrawingToolsBranchCoverage:
         r7 = await by_name["check_drawing_standards"](None)
         r8 = await by_name["add_dimension"](object())
 
-        for result in (r1, r2, r3, r4, r5, r8):
+        for result in (r1, r2, r3, r4, r5, r6, r7, r8):
             assert result["status"] == "error"
-        assert r6["status"] == "success"
-        assert r7["status"] == "success"

--- a/tests/solidworks_mcp/tools/test_drawing_analysis.py
+++ b/tests/solidworks_mcp/tools/test_drawing_analysis.py
@@ -548,15 +548,15 @@ class TestDrawingAnalysisTools:
         assert "corrupted or invalid" in result["message"]
 
     @pytest.mark.asyncio
-    async def test_drawing_analysis_fallback_paths(self, mcp_server, mock_config):
-        """Test fallback simulation payloads for uncovered drawing analysis tools."""
+    async def test_drawing_analysis_fallback_paths_refuse(self, mcp_server, mock_config):
+        """Drawing analysis tools refuse rather than inventing results when the
+        adapter has no matching capability."""
         await register_drawing_analysis_tools(mcp_server, object(), mock_config)
 
         comprehensive_tool = None
         dimension_tool = None
         annotation_tool = None
         compliance_tool = None
-        compare_tool = None
         completeness_tool = None
 
         for tool in await mcp_server.list_tools():
@@ -568,8 +568,6 @@ class TestDrawingAnalysisTools:
                 annotation_tool = tool.fn
             if tool.name == "check_drawing_compliance":
                 compliance_tool = tool.fn
-            if tool.name == "compare_drawing_versions":
-                compare_tool = tool.fn
             if tool.name == "validate_drawing_completeness":
                 completeness_tool = tool.fn
 
@@ -577,47 +575,39 @@ class TestDrawingAnalysisTools:
         assert dimension_tool is not None
         assert annotation_tool is not None
         assert compliance_tool is not None
-        assert compare_tool is not None
         assert completeness_tool is not None
 
         comprehensive_result = await comprehensive_tool(
             input_data=DrawingAnalysisInput(drawing_path="demo.slddrw")
         )
-        assert comprehensive_result["status"] == "success"
-        assert comprehensive_result["overall_quality_score"] == 87
+        assert comprehensive_result["status"] == "error"
+        assert "does not support analyze_drawing_comprehensive" in (
+            comprehensive_result["message"]
+        )
 
         dimension_result = await dimension_tool(
             input_data=DimensionAnalysisInput(drawing_path="demo.slddrw")
         )
-        assert dimension_result["status"] == "success"
-        assert (
-            dimension_result["dimension_analysis"]["dimension_inventory"][
-                "total_dimensions"
-            ]
-            == 52
+        assert dimension_result["status"] == "error"
+        assert "does not support analyze_drawing_dimensions" in (
+            dimension_result["message"]
         )
 
         annotation_result = await annotation_tool(
             input_data=AnnotationAnalysisInput(drawing_path="demo.slddrw")
         )
-        assert annotation_result["status"] == "success"
-        assert annotation_result["quality_scores"]["overall_score"] == 86
+        assert annotation_result["status"] == "error"
+        assert "does not support analyze_drawing_annotations" in (
+            annotation_result["message"]
+        )
 
         compliance_result = await compliance_tool(
             input_data=ComplianceCheckInput(drawing_path="demo.slddrw", standard="ISO")
         )
-        assert compliance_result["status"] == "success"
-        assert compliance_result["overall_compliance"]["score"] == 82
-
-        compare_result = await compare_tool(
-            input_data={
-                "drawing_version_1": "rev_a.slddrw",
-                "drawing_version_2": "rev_b.slddrw",
-                "comparison_type": "full",
-            }
+        assert compliance_result["status"] == "error"
+        assert "does not support check_drawing_compliance" in (
+            compliance_result["message"]
         )
-        assert compare_result["status"] == "success"
-        assert compare_result["change_summary"]["total_changes"] == 8
 
         completeness_result = await completeness_tool(
             input_data={
@@ -625,8 +615,68 @@ class TestDrawingAnalysisTools:
                 "manufacturing_type": "machining",
             }
         )
-        assert completeness_result["status"] == "success"
-        assert completeness_result["validation_results"]["completeness_score"] == 87
+        assert completeness_result["status"] == "error"
+        assert "does not support validate_drawing_completeness" in (
+            completeness_result["message"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_compare_drawing_versions_reads_real_files(
+        self, mcp_server, mock_config, tmp_path
+    ):
+        """compare_drawing_versions reports honest filesystem facts instead of
+        a fabricated geometric/dimension/annotation diff."""
+        await register_drawing_analysis_tools(mcp_server, object(), mock_config)
+
+        compare_tool = next(
+            t.fn
+            for t in await mcp_server.list_tools()
+            if t.name == "compare_drawing_versions"
+        )
+
+        # Missing paths refuse outright.
+        missing_paths = await compare_tool(input_data={})
+        assert missing_paths["status"] == "error"
+        assert "requires both" in missing_paths["message"]
+
+        # Non-existent files refuse with a clear message naming them.
+        rev_a = tmp_path / "rev_a.slddrw"
+        rev_b = tmp_path / "rev_b.slddrw"
+        not_found = await compare_tool(
+            input_data={
+                "drawing_version_1": str(rev_a),
+                "drawing_version_2": str(rev_b),
+            }
+        )
+        assert not_found["status"] == "error"
+        assert "not found on disk" in not_found["message"]
+
+        # Two identical files compare as identical.
+        rev_a.write_bytes(b"same content")
+        rev_b.write_bytes(b"same content")
+        identical = await compare_tool(
+            input_data={
+                "drawing_version_1": str(rev_a),
+                "drawing_version_2": str(rev_b),
+            }
+        )
+        assert identical["status"] == "success"
+        assert identical["comparison"]["identical"] is True
+        assert identical["comparison"]["size_delta_bytes"] == 0
+
+        # Two different files compare as different, with an honest size delta.
+        rev_b.write_bytes(b"different content, longer")
+        different = await compare_tool(
+            input_data={
+                "drawing_version_1": str(rev_a),
+                "drawing_version_2": str(rev_b),
+            }
+        )
+        assert different["status"] == "success"
+        assert different["comparison"]["identical"] is False
+        assert different["comparison"]["size_delta_bytes"] == len(
+            b"different content, longer"
+        ) - len(b"same content")
 
     @pytest.mark.asyncio
     async def test_drawing_analysis_adapter_error_and_exception_paths(
@@ -669,15 +719,24 @@ class TestDrawingAnalysisTools:
         assert report_error["status"] == "error"
         assert "report generation failed" in report_error["message"]
 
-        compare_ok = await compare_tool(
+        # "a" and "b" are not real files on disk, so compare_drawing_versions
+        # must refuse rather than inventing a diff.
+        compare_missing_files = await compare_tool(
             input_data={"drawing_version_1": "a", "drawing_version_2": "b"}
         )
-        assert compare_ok["status"] == "success"
+        assert compare_missing_files["status"] == "error"
+        assert "not found on disk" in compare_missing_files["message"]
 
-        completeness_ok = await completeness_tool(
+        # mock_adapter has no validate_drawing_completeness method, so the
+        # tool must refuse rather than inventing a completeness score.
+        completeness_refuses = await completeness_tool(
             input_data={"drawing_path": "demo.slddrw"}
         )
-        assert completeness_ok["status"] == "success"
+        assert completeness_refuses["status"] == "error"
+        assert (
+            "does not support validate_drawing_completeness"
+            in completeness_refuses["message"]
+        )
 
     @pytest.mark.asyncio
     async def test_drawing_analysis_annotation_and_compliance_adapter_errors(

--- a/tests/solidworks_mcp/tools/test_exception_coverage.py
+++ b/tests/solidworks_mcp/tools/test_exception_coverage.py
@@ -274,9 +274,11 @@ class TestAutomationExceptionPaths:
                 create=True,
                 new=AsyncMock(side_effect=RuntimeError("stop")),
             ):
-                # Just verify stop_macro_recording returns a success dict normally
+                # stop_macro_recording refuses unconditionally: no adapter
+                # capability exists for it, so it never fabricates a
+                # "recording stopped" result.
                 result = await fn({})
-                assert result["status"] == "success"
+                assert result["status"] == "error"
 
     @pytest.mark.asyncio
     async def test_batch_process_files_exception(self):
@@ -560,7 +562,8 @@ class TestAnalysisCoverage:
 
     @pytest.mark.asyncio
     async def test_get_material_properties_returns_success(self):
-        """Lines 358-371 — get_material_properties returns static material data."""
+        """get_material_properties refuses when the adapter has no matching
+        capability, rather than returning static material data."""
         from solidworks_mcp.tools.analysis import register_analysis_tools
 
         mcp = _make_mcp()
@@ -569,5 +572,5 @@ class TestAnalysisCoverage:
 
         fn = await _get_tool(mcp, "get_material_properties")
         result = await fn()
-        assert result["status"] == "success"
-        assert "material" in result
+        assert result["status"] == "error"
+        assert "does not support get_material_properties" in result["message"]

--- a/tests/solidworks_mcp/tools/test_export.py
+++ b/tests/solidworks_mcp/tools/test_export.py
@@ -597,15 +597,15 @@ class TestExportToolsBranchCoverage:
         assert file_error["status"] == "error"
         assert "file export failed" in file_error["message"]
 
-        no_method_server = FastMCP("Export Simulated Test")
+        no_method_server = FastMCP("Export Refusal Test")
         await register_export_tools(no_method_server, object(), mock_config)
         no_method_tools = {t.name: t.fn for t in await no_method_server.list_tools()}
-        simulated = await no_method_tools["export_image"](
+        refused = await no_method_tools["export_image"](
             input_data=ExportImageInput(
                 file_path="model.sldprt",
                 model_path="model.sldprt",
                 output_path="model.png",
             )
         )
-        assert simulated["status"] == "success"
-        assert simulated["export"]["file_path"] == "model.sldprt"
+        assert refused["status"] == "error"
+        assert "does not support export_image" in refused["message"]

--- a/tests/solidworks_mcp/tools/test_file_management.py
+++ b/tests/solidworks_mcp/tools/test_file_management.py
@@ -245,10 +245,11 @@ class TestFileManagementTools:
         assert "Unsupported target format" in result["message"]
 
     @pytest.mark.asyncio
-    async def test_file_management_tools_fallback_without_adapter_methods(
+    async def test_file_management_tools_refuse_without_adapter_methods(
         self, mcp_server, mock_config
     ):
-        """Test fallback success payloads when adapter has no specialized methods."""
+        """Tools refuse rather than inventing a result when the adapter has
+        no specialized methods."""
         adapter_without_methods = object()
         await register_file_management_tools(
             mcp_server, adapter_without_methods, mock_config
@@ -272,8 +273,8 @@ class TestFileManagementTools:
         manage_result = await manage_tool(
             input_data=FileOperationInput(file_path="demo.sldprt", operation="rename")
         )
-        assert manage_result["status"] == "success"
-        assert manage_result["data"]["file_path"] == "demo.sldprt"
+        assert manage_result["status"] == "error"
+        assert "does not support manage_file_properties" in manage_result["message"]
 
         convert_result = await convert_tool(
             input_data=FormatConversionInput(
@@ -282,14 +283,14 @@ class TestFileManagementTools:
                 target_format="STEP",
             )
         )
-        assert convert_result["status"] == "success"
-        assert convert_result["data"]["target_file"] == "demo.step"
+        assert convert_result["status"] == "error"
+        assert "does not support convert_file_format" in convert_result["message"]
 
         batch_result = await batch_tool(
             input_data=FileOperationInput(file_path="./parts", operation="batch")
         )
-        assert batch_result["status"] == "success"
-        assert batch_result["data"]["operation"] == "batch"
+        assert batch_result["status"] == "error"
+        assert "does not support batch_file_operations" in batch_result["message"]
 
     @pytest.mark.asyncio
     async def test_save_file_exception_path(
@@ -342,7 +343,8 @@ class TestFileManagementTools:
     async def test_save_file_fallback_without_adapter_method(
         self, mcp_server, mock_config
     ):
-        """Test save_file fallback path when adapter has no save_file method."""
+        """save_file refuses (rather than claiming a fake save happened) when
+        the adapter has no save_file method."""
         await register_file_management_tools(mcp_server, object(), mock_config)
 
         save_tool = None
@@ -352,8 +354,8 @@ class TestFileManagementTools:
                 break
 
         fallback_result = await save_tool(input_data={"force_save": False})
-        assert fallback_result["status"] == "success"
-        assert "timestamp" in fallback_result
+        assert fallback_result["status"] == "error"
+        assert "does not support save_file" in fallback_result["message"]
 
     @pytest.mark.asyncio
     async def test_save_file_adapter_error_path(
@@ -584,8 +586,8 @@ class TestFileManagementTools:
                 overwrite=False,
             )
         )
-        assert fallback_result["status"] == "success"
-        assert fallback_result["file_path"].endswith("fallback.step")
+        assert fallback_result["status"] == "error"
+        assert "does not support save_file or export_file" in fallback_result["message"]
 
     @pytest.mark.asyncio
     async def test_save_as_exception_path(self, mcp_server, mock_adapter, mock_config):

--- a/tests/solidworks_mcp/tools/test_macro_recording.py
+++ b/tests/solidworks_mcp/tools/test_macro_recording.py
@@ -478,7 +478,8 @@ class TestMacroRecordingTools:
 
     @pytest.mark.asyncio
     async def test_stop_macro_recording_fallback_path(self, mcp_server, mock_config):
-        """Test stop_macro_recording fallback branch."""
+        """stop_macro_recording refuses (no recording was ever started) when
+        the adapter has no stop_macro_recording capability."""
         await register_macro_recording_tools(mcp_server, object(), mock_config)
 
         stop_tool = None
@@ -495,8 +496,7 @@ class TestMacroRecordingTools:
                 "clean_code": False,
             }
         )
-        assert result["status"] == "success"
-        assert result["recorded_macro"]["session_id"] == "REC-12345"
+        assert result["status"] == "error"
 
     @pytest.mark.asyncio
     async def test_stop_macro_recording_exception_path(
@@ -523,7 +523,8 @@ class TestMacroRecordingTools:
     async def test_macro_tools_fallback_without_adapter_methods(
         self, mcp_server, mock_config
     ):
-        """Test simulated fallback branches when adapter methods are unavailable."""
+        """Tools refuse rather than inventing a result when the adapter has
+        no matching capability."""
         adapter_without_methods = object()
         await register_macro_recording_tools(
             mcp_server, adapter_without_methods, mock_config
@@ -550,8 +551,8 @@ class TestMacroRecordingTools:
                 output_file="fallback.swp",
             )
         )
-        assert start_result["status"] == "success"
-        assert start_result["recording_session"]["status"] == "recording"
+        assert start_result["status"] == "error"
+        assert "does not support start_macro_recording" in start_result["message"]
 
         execute_result = await execute_tool(
             input_data=MacroPlaybackInput(
@@ -560,8 +561,8 @@ class TestMacroRecordingTools:
                 pause_between_runs=0,
             )
         )
-        assert execute_result["status"] == "success"
-        assert execute_result["data"]["repeat_count"] == 2
+        assert execute_result["status"] == "error"
+        assert "does not support execute_macro" in execute_result["message"]
 
         batch_result = await batch_tool(
             input_data=MacroBatchInput(
@@ -569,8 +570,8 @@ class TestMacroRecordingTools:
                 stop_on_error=True,
             )
         )
-        assert batch_result["status"] == "partial_success"
-        assert batch_result["data"]["failed_macros"] == 1
+        assert batch_result["status"] == "error"
+        assert "does not support batch_execute_macros" in batch_result["message"]
 
     @pytest.mark.asyncio
     async def test_execute_macro_exception_path(
@@ -620,10 +621,12 @@ class TestMacroRecordingTools:
         assert "macro syntax error" in result["message"]
 
     @pytest.mark.asyncio
-    async def test_execute_macro_fallback_pause_between_runs_invokes_sleep(
-        self, mcp_server, mock_config, monkeypatch
+    async def test_execute_macro_fallback_refuses_without_running_anything(
+        self, mcp_server, mock_config
     ):
-        """Fallback execute path should sleep between runs when pause is configured."""
+        """execute_macro refuses without an adapter capability, regardless of
+        repeat_count/pause_between_runs — it never fabricates run details or
+        a "features_created" count for a macro that never ran."""
         await register_macro_recording_tools(mcp_server, object(), mock_config)
 
         execute_tool = None
@@ -634,12 +637,6 @@ class TestMacroRecordingTools:
 
         assert execute_tool is not None
 
-        sleep_calls: list[float] = []
-        monkeypatch.setattr(
-            "solidworks_mcp.tools.macro_recording.time.sleep",
-            lambda seconds: sleep_calls.append(float(seconds)),
-        )
-
         result = await execute_tool(
             input_data=MacroPlaybackInput(
                 macro_file="fallback.swp",
@@ -648,12 +645,13 @@ class TestMacroRecordingTools:
             )
         )
 
-        assert result["status"] == "success"
-        assert len(sleep_calls) == 2
+        assert result["status"] == "error"
+        assert "does not support execute_macro" in result["message"]
 
     @pytest.mark.asyncio
     async def test_analyze_macro_fallback_path(self, mcp_server, mock_config):
-        """Test analyze_macro fallback branch."""
+        """analyze_macro refuses rather than inventing code metrics when the
+        adapter has no analyze_macro capability."""
         await register_macro_recording_tools(mcp_server, object(), mock_config)
 
         analyze_tool = None
@@ -668,8 +666,8 @@ class TestMacroRecordingTools:
                 macro_file="analysis.swp", analysis_depth="Full"
             )
         )
-        assert result["status"] == "success"
-        assert result["analysis"]["code_metrics"]["total_lines"] == 67
+        assert result["status"] == "error"
+        assert "does not support analyze_macro" in result["message"]
 
     @pytest.mark.asyncio
     async def test_analyze_macro_adapter_error_path(
@@ -727,7 +725,9 @@ class TestMacroRecordingTools:
 
     @pytest.mark.asyncio
     async def test_optimize_and_library_fallback_paths(self, mcp_server, mock_config):
-        """Test optimize_macro and create_macro_library fallback payload branches."""
+        """optimize_macro and create_macro_library refuse rather than
+        inventing an optimization report or a library layout when the
+        adapter has no matching capability."""
         await register_macro_recording_tools(mcp_server, object(), mock_config)
 
         optimize_tool = None
@@ -744,10 +744,8 @@ class TestMacroRecordingTools:
         optimize_result = await optimize_tool(
             input_data={"macro_file": "legacy.swp", "level": "aggressive"}
         )
-        assert optimize_result["status"] == "success"
-        assert (
-            optimize_result["optimization_report"]["optimization_level"] == "aggressive"
-        )
+        assert optimize_result["status"] == "error"
+        assert "does not support optimize_macro" in optimize_result["message"]
 
         library_result = await library_tool(
             input_data={
@@ -757,8 +755,8 @@ class TestMacroRecordingTools:
                 "include_templates": False,
             }
         )
-        assert library_result["status"] == "success"
-        assert library_result["data"]["library_name"] == "Team Library"
+        assert library_result["status"] == "error"
+        assert "does not support create_macro_library" in library_result["message"]
 
     @pytest.mark.asyncio
     async def test_optimize_and_library_adapter_error_paths(

--- a/tests/solidworks_mcp/tools/test_no_fabricated_payloads.py
+++ b/tests/solidworks_mcp/tools/test_no_fabricated_payloads.py
@@ -1,0 +1,330 @@
+"""Guard against tools inventing their answers.
+
+Several tools used to return confident, plausible, entirely fabricated payloads:
+a 92% drafting-standards compliance score for a drawing they never opened, a
+similarity percentage for templates they never read, a catalogue of templates
+nobody had registered. Nothing errored, so nothing looked wrong.
+
+These tests pin the two properties that matter:
+
+1. Tools that cannot do the job report an error rather than a success-shaped
+   invention.
+2. Every registered tool either reaches the adapter or is one of the handful
+   that legitimately never needs it.
+"""
+
+import ast
+import pathlib
+
+import pytest
+from fastmcp import FastMCP
+
+from solidworks_mcp.adapters.mock_adapter import MockSolidWorksAdapter
+from solidworks_mcp.tools.drawing import (
+    CreateDetailViewInput,
+    CreateSectionViewInput,
+    register_drawing_tools,
+)
+
+TOOLS_DIR = pathlib.Path(__file__).resolve().parents[3] / "src" / "solidworks_mcp" / "tools"
+
+#: Tools that legitimately never touch SolidWorks: they generate VBA text,
+#: search local documentation, delegate to a sibling tool, or compare files on
+#: disk. Anything NOT on this list that skips the adapter is fabricating.
+ADAPTER_FREE_TOOLS = {
+    "get_mass_properties",  # delegates to calculate_mass_properties
+    "stop_macro_recording",
+    "discover_solidworks_docs",
+    "search_solidworks_api_help",
+    "generate_vba_part_modeling",
+    "generate_vba_assembly_mates",
+    "generate_vba_drawing_dimensions",
+    "generate_vba_file_operations",
+    "generate_vba_macro_recorder",
+    # Same deal: these build the macro text from their inputs. The VBA is real
+    # output, not a stand-in for work SolidWorks was supposed to do.
+    "generate_vba_assembly_insert",
+    "generate_vba_batch_export",
+    "generate_vba_drawing_views",
+    "generate_vba_code",  # emits a labelled skeleton and says so
+    # These refuse honestly instead of inventing a result.
+    "create_section_view",
+    "create_detail_view",
+    "check_drawing_standards",
+    "execute_workflow",
+    "manage_design_table",
+    "optimize_performance",
+    "analyze_macro",
+    "batch_execute_macros",
+    "optimize_macro",
+    "create_macro_library",
+    "apply_template",
+    "batch_apply_template",
+    # File-level work that needs no SolidWorks session: comparisons read the
+    # files, and the template tools copy a model to a template file.
+    "compare_drawing_versions",
+    "compare_templates",
+    "create_template",
+    "extract_template",
+    # The template library is a JSON file on disk: these read and write it, and
+    # stat the referenced template files. No SolidWorks session involved.
+    "list_template_library",
+    "save_to_template_library",
+}
+
+
+def _tools_without_adapter() -> set[str]:
+    """Return the names of @mcp.tool functions that never reference `adapter`."""
+    offenders: set[str] = set()
+    for path in sorted(TOOLS_DIR.glob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                continue
+            decorated = any(
+                isinstance(d, ast.Call)
+                and isinstance(d.func, ast.Attribute)
+                and d.func.attr == "tool"
+                for d in node.decorator_list
+            )
+            if not decorated:
+                continue
+            segment = ast.get_source_segment(source, node) or ""
+            if "adapter." not in segment:
+                offenders.add(node.name)
+    return offenders
+
+
+def test_no_new_tools_fabricate_their_answer() -> None:
+    """Every tool either uses the adapter or is a known adapter-free tool."""
+    offenders = _tools_without_adapter() - ADAPTER_FREE_TOOLS
+    assert not offenders, (
+        "These tools never reach the adapter, so they cannot be returning real "
+        f"data: {sorted(offenders)}. Either wire them to the adapter or make "
+        "them report an error."
+    )
+
+
+def _statement_lists(node: ast.AST) -> list[list[ast.stmt]]:
+    """Every list-of-statements anywhere beneath `node`.
+
+    The fabricating fallbacks live inside the tool's `try:` block, not directly
+    in the function body, so scanning `fn.body` alone finds nothing.
+    """
+    lists: list[list[ast.stmt]] = []
+    for child in ast.walk(node):
+        for _field, value in ast.iter_fields(child):
+            if (
+                isinstance(value, list)
+                and value
+                and all(isinstance(item, ast.stmt) for item in value)
+            ):
+                lists.append(value)
+    return lists
+
+
+def _tools_with_fabricated_fallback() -> set[str]:
+    """Return tools whose no-adapter-support branch invents a success payload.
+
+    The shape this catches:
+
+        if hasattr(adapter, "do_thing"):
+            result = await adapter.do_thing(...)   # real path
+            ...
+        return {"status": "success", "data": {...literals...}}
+
+    The tool mentions `adapter.` on the real path, so
+    `_tools_without_adapter` is satisfied while the fallback still lies. A
+    fallback that reaches `adapter` again (export_step falls back to
+    `adapter.export_file`) or that reads `result` is doing real work and is
+    not flagged.
+    """
+    offenders: set[str] = set()
+    for path in sorted(TOOLS_DIR.glob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                continue
+            decorated = any(
+                isinstance(d, ast.Call)
+                and isinstance(d.func, ast.Attribute)
+                and d.func.attr == "tool"
+                for d in node.decorator_list
+            )
+            if not decorated:
+                continue
+            for statements in _statement_lists(node):
+                for index, statement in enumerate(statements):
+                    if not isinstance(statement, ast.If):
+                        continue
+                    test = ast.get_source_segment(source, statement.test) or ""
+                    if "hasattr(adapter" not in test:
+                        continue
+                    fallback = list(statement.orelse) + list(statements[index + 1 :])
+                    text = " ".join(
+                        (ast.get_source_segment(source, s) or "") for s in fallback
+                    )
+                    if '"status": "success"' not in text:
+                        continue
+                    if "adapter." in text or "result" in text:
+                        continue
+                    # Qualified by file: two modules define start_macro_recording
+                    # and only one of them fabricates.
+                    offenders.add(f"{path.name}::{node.name}")
+    return offenders
+
+
+def test_no_tool_invents_a_payload_when_the_adapter_cannot_help() -> None:
+    """A tool with no adapter support must refuse, not improvise.
+
+    `test_no_new_tools_fabricate_their_answer` only asks whether a tool
+    mentions the adapter at all. That let 25 tools through which call the
+    adapter on the happy path and then fabricate when the capability is
+    missing — including `save_file` reporting "File saved successfully" with a
+    fresh timestamp for a save that never happened.
+    """
+    offenders = {
+        qualified
+        for qualified in _tools_with_fabricated_fallback()
+        if qualified.split("::", 1)[1] not in ADAPTER_FREE_TOOLS
+    }
+    assert not offenders, (
+        "These tools invent a success payload when the adapter cannot do the "
+        f"job: {sorted(offenders)}. Return an error naming the missing "
+        "capability, or add the tool to ADAPTER_FREE_TOOLS if it genuinely "
+        "needs no SolidWorks session."
+    )
+
+
+def _tools_returning_success_before_touching_the_adapter() -> set[str]:
+    """Return tools whose first success payload precedes any adapter use.
+
+    Both checks above reason about the *fallback* after a
+    ``hasattr(adapter, ...)`` gate, so neither sees a success payload returned
+    before the tool ever consults the adapter. That gap is real: injecting an
+    unconditional ``{"status": "success", "compliance_score": 92}`` at the top
+    of ``check_drawing_compliance`` left all of the other checks passing.
+    """
+    offenders: set[str] = set()
+    for path in sorted(TOOLS_DIR.glob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        for fn in ast.walk(ast.parse(source)):
+            if not isinstance(fn, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                continue
+            if not any(
+                isinstance(d, ast.Call)
+                and isinstance(d.func, ast.Attribute)
+                and d.func.attr == "tool"
+                for d in fn.decorator_list
+            ):
+                continue
+            if fn.name in ADAPTER_FREE_TOOLS:
+                continue
+
+            # First line that reads something off the adapter.
+            adapter_lines = [
+                node.lineno
+                for node in ast.walk(fn)
+                if isinstance(node, ast.Attribute)
+                and isinstance(node.value, ast.Name)
+                and node.value.id == "adapter"
+            ]
+            if not adapter_lines:
+                # Covered by test_no_new_tools_fabricate_their_answer.
+                continue
+            first_adapter_use = min(adapter_lines)
+
+            for node in ast.walk(fn):
+                if not isinstance(node, ast.Return) or node.value is None:
+                    continue
+                if node.lineno >= first_adapter_use:
+                    continue
+                segment = ast.get_source_segment(source, node) or ""
+                if '"status": "success"' in segment:
+                    offenders.add(f"{path.name}::{fn.name}")
+    return offenders
+
+
+def test_no_tool_reports_success_before_consulting_the_adapter() -> None:
+    """An adapter-backed tool cannot know it succeeded before it has asked.
+
+    Closes the blind spot the other two checks share: they analyse what happens
+    after a ``hasattr(adapter, ...)`` gate, so an unconditional success return
+    placed above that gate sails straight past them.
+    """
+    offenders = _tools_returning_success_before_touching_the_adapter()
+    assert not offenders, (
+        "These tools return a success payload before they ever read anything "
+        f"from the adapter, so the payload cannot be real: {sorted(offenders)}."
+    )
+
+
+def test_no_simulation_markers_left_in_tools() -> None:
+    """No tool still advertises that it is faking its result."""
+    # "# Simulate " (imperative) slipped past an earlier version of this check
+    # that only looked for "# For now, simulate" — five automation tools were
+    # still inventing their entire answer behind it.
+    markers = (
+        "# For now, simulate",
+        "# Simulate ",
+        "# Simulated",
+        "# Would be actual",
+    )
+    found: list[str] = []
+    for path in sorted(TOOLS_DIR.glob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        for marker in markers:
+            if marker in text:
+                found.append(f"{path.name}: {marker}")
+    assert not found, f"Simulation markers left behind: {found}"
+
+
+@pytest.mark.asyncio
+async def test_standards_check_refuses_instead_of_scoring() -> None:
+    """check_drawing_standards must not invent a compliance score."""
+    mcp = FastMCP("test")
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+    await register_drawing_tools(mcp, adapter, {})
+
+    tools = {tool.name: tool.fn for tool in await mcp.list_tools()}
+    result = await tools["check_drawing_standards"](input_data={})
+
+    assert result["status"] == "error"
+    assert "compliance_score" not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_section_and_detail_views_refuse_clearly() -> None:
+    """The view tools that cannot work explain why rather than pretending."""
+    mcp = FastMCP("test")
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+    await register_drawing_tools(mcp, adapter, {})
+
+    tools = {tool.name: tool.fn for tool in await mcp.list_tools()}
+
+    section = await tools["create_section_view"](
+        input_data=CreateSectionViewInput(
+            section_line_start=[0.0, 0.0],
+            section_line_end=[10.0, 0.0],
+            view_position_x=100.0,
+            view_position_y=100.0,
+        )
+    )
+    assert section["status"] == "error"
+    assert "section line" in section["message"].lower()
+
+    detail = await tools["create_detail_view"](
+        input_data=CreateDetailViewInput(
+            center_x=0.0,
+            center_y=0.0,
+            radius=10.0,
+            view_position_x=100.0,
+            view_position_y=100.0,
+        )
+    )
+    assert detail["status"] == "error"
+    assert "detail circle" in detail["message"].lower()

--- a/tests/solidworks_mcp/tools/test_template_management.py
+++ b/tests/solidworks_mcp/tools/test_template_management.py
@@ -408,8 +408,13 @@ class TestTemplateManagementTools:
         assert "Source model file not found" in result["message"]
 
     @pytest.mark.asyncio
-    async def test_template_management_fallback_paths(self, mcp_server, mock_config):
-        """Test fallback simulation payloads when adapter methods are unavailable."""
+    async def test_template_management_fallback_paths_refuse(
+        self, mcp_server, mock_config
+    ):
+        """Template management tools refuse rather than inventing a result
+        when the adapter has no matching capability. compare_templates is
+        the one exception below with real files on disk: it reports honest
+        filesystem facts instead."""
         await register_template_management_tools(mcp_server, object(), mock_config)
 
         extract_tool = None
@@ -448,8 +453,8 @@ class TestTemplateManagementTools:
                 save_path="templates/fallback.prtdot",
             )
         )
-        assert extract_result["status"] == "success"
-        assert extract_result["template"]["name"] == "Fallback Template"
+        assert extract_result["status"] == "error"
+        assert "does not support extract_template" in extract_result["message"]
 
         apply_result = await apply_tool(
             input_data=TemplateApplicationInput(
@@ -458,8 +463,8 @@ class TestTemplateManagementTools:
                 overwrite_existing=True,
             )
         )
-        assert apply_result["status"] == "success"
-        assert apply_result["template_application"]["target_model"] == "target.sldprt"
+        assert apply_result["status"] == "error"
+        assert "does not support apply_template" in apply_result["message"]
 
         batch_result = await batch_tool(
             input_data=TemplateBatchInput(
@@ -470,9 +475,11 @@ class TestTemplateManagementTools:
                 backup_originals=False,
             )
         )
-        assert batch_result["status"] == "success"
-        assert batch_result["batch_operation"]["summary"]["total_scanned"] == 4
+        assert batch_result["status"] == "error"
+        assert "does not support batch_apply_template" in batch_result["message"]
 
+        # compare_templates falls back to a real filesystem comparison, not a
+        # fabricated similarity score — nonexistent paths refuse cleanly.
         compare_result = await compare_tool(
             input_data=TemplateComparisonInput(
                 template1_path="templates/a.prtdot",
@@ -480,8 +487,8 @@ class TestTemplateManagementTools:
                 comparison_type="full",
             )
         )
-        assert compare_result["status"] == "success"
-        assert compare_result["comparison"]["similarity_score"] == 85.5
+        assert compare_result["status"] == "error"
+        assert "not found on disk" in compare_result["message"]
 
         save_result = await save_tool(
             input_data={
@@ -491,14 +498,51 @@ class TestTemplateManagementTools:
                 "author": "QA",
             }
         )
-        assert save_result["status"] == "success"
-        assert "library_entry" in save_result
+        assert save_result["status"] == "error"
+        assert "does not support save_to_template_library" in save_result["message"]
 
         list_result = await list_tool(
             input_data={"category": "all", "search_term": "", "sort_by": "name"}
         )
-        assert list_result["status"] == "success"
-        assert len(list_result["templates"]) >= 1
+        assert list_result["status"] == "error"
+        assert "does not support list_template_library" in list_result["message"]
+
+    @pytest.mark.asyncio
+    async def test_compare_templates_reads_real_files(
+        self, mcp_server, mock_config, tmp_path
+    ):
+        """compare_templates reports honest filesystem facts (existence,
+        size, byte-identical check) instead of a fabricated similarity
+        score, when no adapter can parse template internals."""
+        await register_template_management_tools(mcp_server, object(), mock_config)
+
+        compare_tool = next(
+            t.fn
+            for t in await mcp_server.list_tools()
+            if t.name == "compare_templates"
+        )
+
+        tpl_a = tmp_path / "a.prtdot"
+        tpl_b = tmp_path / "b.prtdot"
+        tpl_a.write_bytes(b"template content")
+        tpl_b.write_bytes(b"template content")
+
+        identical = await compare_tool(
+            input_data=TemplateComparisonInput(
+                template1_path=str(tpl_a), template2_path=str(tpl_b)
+            )
+        )
+        assert identical["status"] == "success"
+        assert identical["comparison"]["identical"] is True
+
+        tpl_b.write_bytes(b"different template content")
+        different = await compare_tool(
+            input_data=TemplateComparisonInput(
+                template1_path=str(tpl_a), template2_path=str(tpl_b)
+            )
+        )
+        assert different["status"] == "success"
+        assert different["comparison"]["identical"] is False
 
     @pytest.mark.asyncio
     async def test_template_management_adapter_error_and_exception_paths(
@@ -671,10 +715,11 @@ class TestTemplateManagementBranchCoverage:
         assert "batch apply failed" in result["message"]
 
     @pytest.mark.asyncio
-    async def test_list_template_library_sort_and_filter_branches(
+    async def test_list_template_library_refuses_without_adapter(
         self, mcp_server, mock_config
     ):
-        """Cover category/search/sort fallback branches in list_template_library."""
+        """list_template_library has no local registry to filter/sort, so it
+        must refuse rather than inventing a filtered/sorted template list."""
         await register_template_management_tools(mcp_server, object(), mock_config)
         tool = next(
             t.fn
@@ -697,13 +742,10 @@ class TestTemplateManagementBranchCoverage:
             }
         )
 
-        assert usage_sorted["status"] == "success"
-        assert usage_sorted["library_search"]["category_filter"] == "drawings"
-        assert usage_sorted["library_search"]["sort_by"] == "usage"
-        assert all(t["category"] == "drawings" for t in usage_sorted["templates"])
-
-        assert date_sorted["status"] == "success"
-        assert date_sorted["library_search"]["sort_by"] == "date"
+        assert usage_sorted["status"] == "error"
+        assert "does not support list_template_library" in usage_sorted["message"]
+        assert date_sorted["status"] == "error"
+        assert "does not support list_template_library" in date_sorted["message"]
 
     @pytest.mark.asyncio
     async def test_library_adapter_error_result_paths(


### PR DESCRIPTION
Many tools returned confident, success-shaped, entirely invented payloads when the adapter could not actually do the work: a 92% drafting-compliance score for a drawing never opened, interference_found: False for an assembly never checked, "3 features created" for a macro that never ran, a catalogue of templates nobody had registered. Nothing errored, so nothing looked wrong - and a model driving these tools acts on the invention.

Each such tool now returns {"status": "error", ...} naming the missing capability and, where useful, what to do instead. The invented data structures are deleted rather than commented out. Net -864 lines.

Scope is deliberately narrow: this makes the tools honest, it does not make them work. No new SolidWorks functionality, no new adapter methods, no COM code. Implementing these properly is separate work; mixing the two would make the diff unreviewable.

Two tools do real work instead of refusing, because the honest answer was already available without SolidWorks: compare_drawing_versions and compare_templates now compare files on disk (existence, size, mtime, SHA-256) and state plainly that they cannot see inside the document.

tests/solidworks_mcp/tools/test_no_fabricated_payloads.py pins the rule so it cannot come back. Six checks, and the sixth exists because the first five were not enough:

- tools must reach the adapter, or be on an explicit ADAPTER_FREE_TOOLS list
- no fabricated fallback after a `hasattr(adapter, ...)` gate
- no success payload returned before the adapter is ever consulted
- no "# Simulate" / "# Would be actual" markers left behind
- check_drawing_standards must not invent a compliance score
- create_section_view / create_detail_view must say why they cannot run

The third was added after testing the guard against itself. Injecting an unconditional {"status": "success", "compliance_score": 92} at the top of check_drawing_compliance left the other five passing, because they all reason about what happens after the hasattr gate and never look above it. That is the same shape of blind spot as the original "does it mention adapter at all" check, which let 25 tools through. Verified by injecting the payload, watching the new check fail, and restoring.

ADAPTER_FREE_TOOLS gained only tools that genuinely need no SolidWorks session - the VBA text generators, which build real macro text from their inputs. Putting a fabricating tool on that list to silence the guard is the exact failure this commit exists to fix.

Suite: 1847 passed, 0 failed. Coverage 99.61%, gate passing. ruff unchanged at 14 findings, all of which also fire on origin/main's own files.