### PR TITLE
Stop the all-tools guards from swallowing a raising tool

### DIFF
--- a/tests/solidworks_mcp/test_all_endpoints_harness.py
+++ b/tests/solidworks_mcp/test_all_endpoints_harness.py
@@ -617,8 +617,8 @@ class TestLevelBSmokeExecution:
                 )
                 if not isinstance(result, dict):
                     non_dict.append(f"{name}: returned {type(result).__name__}")
-            except Exception:
-                pass  # Exceptions are caught in test_smoke_all_tools
+            except Exception as exc:
+                non_dict.append(f"{name}: raised {type(exc).__name__}: {exc}")
 
         assert not non_dict, (
             f"{len(non_dict)} tools did not return a dict:\n" + "\n".join(non_dict)
@@ -641,8 +641,8 @@ class TestLevelBSmokeExecution:
                 )
                 if isinstance(result, dict) and "status" not in result:
                     missing_status.append(name)
-            except Exception:
-                pass
+            except Exception as exc:
+                missing_status.append(f"{name}: raised {type(exc).__name__}: {exc}")
 
         assert not missing_status, (
             f"{len(missing_status)} tools returned dicts without 'status':\n"


### PR DESCRIPTION
test_all_tools_return_dict and test_all_tools_have_status_field iterate every registered tool and are the broad safety net across all ~109 of them. Both wrapped the call in:

    except Exception:
        pass

so a tool that raises was recorded as neither a non-dict nor a missing status. The loudest possible failure was the one thing these two tests could not see. Each handler now records the exception into the same list its assert reads.

Demonstrated rather than assumed. Injecting a RuntimeError as the first statement of close_model, both tests now fail with:

    close_model: raised RuntimeError: DELIBERATE_BREAK tool raises

Against the handlers they replace, the same injection passed silently.

Running the fixed tests over the current tool set exposed nothing: no tool raises on its smoke payload today. The value here is that the next one will be visible.

The two other handlers in this file already recorded their exceptions and are unchanged.

Suite: 1836 passed, 0 failed, serial and under `-n auto --dist=worksteal` (twice). Coverage 99.87%, gate passing. ruff unchanged at 14 findings.