### PR TITLE
Stop the flag cache trusting a recycled address

### DIFF
--- a/src/solidworks_mcp/adapters/sw_type_info.py
+++ b/src/solidworks_mcp/adapters/sw_type_info.py
@@ -34,6 +34,7 @@ works.
 from __future__ import annotations
 
 import inspect
+import weakref
 from typing import Any
 
 from loguru import logger
@@ -56,7 +57,9 @@ _interface_methods: dict[str, frozenset[str]] = {}
 # Per-object record of which interfaces have already been flagged. Keyed by
 # id(obj) so ``flag_methods(doc, 'IModelDoc2')`` followed by
 # ``flag_methods(doc, 'IAssemblyDoc')`` does incremental work, not a no-op.
-_flag_cache: dict[int, set[str]] = {}
+# Value is (weak reference to the object, interfaces already flagged). The
+# weakref is what makes the id() key safe to trust — see _flagged_interfaces.
+_flag_cache: dict[int, tuple[weakref.ref[Any] | None, set[str]]] = {}
 
 
 def _load_wrapper() -> None:
@@ -156,6 +159,40 @@ DOC_TYPE_TO_INTERFACES: dict[int, tuple[str, ...]] = {
 }
 
 
+def _flagged_interfaces(obj: Any) -> set[str]:
+    """Return the set of interfaces already flagged on ``obj``.
+
+    The entry is keyed by ``id(obj)`` for speed, but is only trusted when the
+    stored weak reference still resolves to *this same object*. Without that
+    check the cache is unsound: ids are only unique among live objects, and
+    CPython reuses addresses eagerly. A fresh dispatch landing on a dead one's
+    address was judged "already flagged", so ``flag_methods`` returned without
+    flagging anything and its members then resolved as properties — surfacing
+    from SolidWorks as "Member not found".
+
+    Objects that do not support weak references (some test doubles) simply are
+    not cached; they are flagged every time, which is correct if slower.
+    """
+    key = id(obj)
+    entry = _flag_cache.get(key)
+    if entry is not None:
+        ref, names = entry
+        if ref is None or ref() is obj:
+            return names
+        # Stale: the object this entry described is gone and its address has
+        # been recycled. Drop it and start fresh for the new occupant.
+        del _flag_cache[key]
+
+    names = set()
+    try:
+        _flag_cache[key] = (weakref.ref(obj), names)
+    except TypeError:
+        # Not weak-referenceable, so we cannot detect a later address reuse.
+        # Skip caching rather than risk the stale-entry bug.
+        pass
+    return names
+
+
 def flag_methods(obj: Any, *interfaces: str) -> int:
     """Flag SW methods on ``obj`` so pywin32 dispatches them as methods,
     not properties.
@@ -178,8 +215,7 @@ def flag_methods(obj: Any, *interfaces: str) -> int:
     if not _interface_methods or obj is None:  # pragma: no cover
         return 0
 
-    obj_id = id(obj)
-    already = _flag_cache.setdefault(obj_id, set())
+    already = _flagged_interfaces(obj)
 
     # Only flag methods from interfaces we haven't already processed for
     # this object. Repeats are a no-op; novel interfaces add incrementally.

--- a/tests/solidworks_mcp/adapters/test_sw_type_info_cache_reuse.py
+++ b/tests/solidworks_mcp/adapters/test_sw_type_info_cache_reuse.py
@@ -1,0 +1,126 @@
+"""The flag cache must not mistake a recycled address for an already-flagged object.
+
+``flag_methods`` records which interfaces it has flagged, keyed by ``id(obj)``.
+An id is only unique among *live* objects, and CPython hands a freed block
+straight back to the next allocation of the same size. A fresh COM dispatch can
+therefore land on a dead one's address, be judged "already flagged", and never
+be flagged at all — after which its methods resolve as properties and
+SolidWorks answers "Member not found".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from solidworks_mcp.adapters import sw_type_info
+
+_INTERFACE = "IModelDoc2"
+_MEMBERS = frozenset({"SketchMirror", "ClearSelection2", "GetActiveSketch2"})
+
+
+class _FakeDispatch:
+    """Stand-in for a pywin32 CDispatch.
+
+    ``__slots__`` keeps every instance the same size, which is what makes
+    CPython reuse a freed instance's address for the next one. ``__weakref__``
+    is declared because real ``CDispatch`` objects are weak-referenceable and
+    the cache relies on that to detect staleness.
+    """
+
+    __slots__ = ("flagged", "__weakref__")
+
+    def __init__(self) -> None:
+        self.flagged: list[str] = []
+
+    def _FlagAsMethod(self, name: str) -> None:
+        """Record what pywin32 was asked to treat as a method."""
+        self.flagged.append(name)
+
+
+@pytest.fixture
+def loaded_type_info(monkeypatch: pytest.MonkeyPatch):
+    """Pretend the SolidWorks type library is loaded with one interface."""
+    monkeypatch.setattr(sw_type_info, "_wrapper_module", object())
+    monkeypatch.setattr(sw_type_info, "_interface_methods", {_INTERFACE: _MEMBERS})
+    monkeypatch.setattr(sw_type_info, "_flag_cache", {})
+    return sw_type_info
+
+
+def _flag_then_reuse_address() -> tuple[bool, int, list[str]]:
+    """Flag one object, free it, then flag a new one at the same address.
+
+    Done in a plain helper on purpose: pytest rewrites assertions and can keep
+    references to a test function's locals, which prevents the first object
+    from being freed and makes address reuse impossible. Nothing here outlives
+    the call.
+
+    Returns:
+        (reused, flagged_count, names_flagged) for the second object.
+    """
+    first = _FakeDispatch()
+    sw_type_info.flag_methods(first, _INTERFACE)
+    target_id = id(first)
+    del first
+
+    for _ in range(50000):
+        candidate = _FakeDispatch()
+        if id(candidate) == target_id:
+            count = sw_type_info.flag_methods(candidate, _INTERFACE)
+            return True, count, list(candidate.flagged)
+        del candidate
+    return False, 0, []
+
+
+def test_recycled_address_does_not_suppress_flagging(loaded_type_info) -> None:
+    """A new object at a dead object's address must still be flagged."""
+    reused, flagged, names = _flag_then_reuse_address()
+    if not reused:
+        pytest.skip("could not force address reuse in this interpreter run")
+
+    # Against the id-only cache this returns 0 and `names` is empty: the new
+    # object is silently left unflagged, and its members then resolve as
+    # properties.
+    assert flagged == len(_MEMBERS)
+    assert set(names) == set(_MEMBERS)
+
+
+def test_repeat_calls_on_the_same_object_are_still_cached(loaded_type_info) -> None:
+    """The cache must keep working; this is a correctness fix, not a removal."""
+    obj = _FakeDispatch()
+
+    assert loaded_type_info.flag_methods(obj, _INTERFACE) == len(_MEMBERS)
+    # Second call is a no-op because this same object was already flagged.
+    assert loaded_type_info.flag_methods(obj, _INTERFACE) == 0
+    assert len(obj.flagged) == len(_MEMBERS)
+
+
+def test_object_without_weakref_support_is_flagged_every_time(
+    loaded_type_info,
+) -> None:
+    """Un-weak-referenceable objects are not cached, so they cannot go stale."""
+
+    class _NoWeakref:
+        __slots__ = ("flagged",)
+
+        def __init__(self) -> None:
+            self.flagged = []
+
+        def _FlagAsMethod(self, name: str) -> None:
+            self.flagged.append(name)
+
+    obj = _NoWeakref()
+    assert loaded_type_info.flag_methods(obj, _INTERFACE) == len(_MEMBERS)
+    # Not cached, so flagged again rather than risking a stale entry.
+    assert loaded_type_info.flag_methods(obj, _INTERFACE) == len(_MEMBERS)
+
+
+def test_cache_entry_does_not_keep_the_dispatch_alive(loaded_type_info) -> None:
+    """Caching must not retain COM objects; entries die with their object."""
+    import weakref
+
+    obj = _FakeDispatch()
+    loaded_type_info.flag_methods(obj, _INTERFACE)
+    ref = weakref.ref(obj)
+
+    del obj
+    assert ref() is None, "flag cache retained the dispatch"


### PR DESCRIPTION
sw_type_info records which interfaces it has already flagged on an object, keyed by id(obj), and the entries outlive the objects they describe. An id is only unique among *live* objects: CPython hands a freed block straight back to the next allocation of the same size. So a fresh COM dispatch can land on a dead one's address, be judged "already flagged", and never be flagged at all - after which its methods resolve as properties and SolidWorks answers "Member not found".

The entry is still keyed by id for speed, but is only trusted when a stored weak reference still resolves to that same object. A stale entry is dropped and the new occupant flagged properly. Objects that are not weak-referenceable are simply not cached - flagged every time, which is correct if slower - rather than risking the stale entry.

The hazard was already known here: invalidate_flag_cache's docstring describes exactly this ("the new object at the same address would otherwise be treated as already-flagged"), but nothing calls it on the affected paths, and callers have no way to know when a dispatch has been released.

Four tests. The central one flags an object, frees it, allocates until a new instance occupies the same address, and asserts the new one really was flagged. Against the code this replaces it fails with `assert 0 == 3` - zero members flagged. The reuse loop lives in a plain helper rather than the test body because pytest's assertion rewriting can retain a test function's locals, which keeps the first object alive and makes reuse impossible; written the obvious way, that test silently skipped instead of proving anything.

Scope of the claim, stated plainly. This was found while chasing an intermittent live failure - sketch_mirror reporting "Member not found" during long runs, at a different call site each time, never reproducible in a short fresh process. This cache is a mechanism that produces exactly that signature and exactly that intermittency, and an earlier unrelated benchmark on this code hit the same id-reuse effect by accident. But the live failure did not reproduce on demand either before or after this change, so it is not claimed as fixed. What is proven is the cache bug itself, deterministically, in both directions.

One deliberate behaviour change: objects that cannot be weak-referenced are no longer cached, so repeat calls re-flag them. Real CDispatch objects are weak-referenceable - verified against a live SolidWorks 2025 session for both ISldWorks and IModelDoc2 dispatches - so this affects test doubles, not production paths.

Suite: 1840 passed, 0 failed. Coverage 99.87%, gate passing. ruff unchanged at 14 findings.