### PR TITLE
Flag only the members a feature-tree walk actually reads

### DIFF
--- a/src/solidworks_mcp/adapters/pywin32_adapter.py
+++ b/src/solidworks_mcp/adapters/pywin32_adapter.py
@@ -887,6 +887,15 @@ class _DocumentRoutingService:
         return self._adapter.currentModel
 
 
+#: Members the ``list_features`` tree walk actually reads on each feature
+#: dispatch. Flagging just these instead of the whole ``IFeature`` interface
+#: (~100 names, ~27 ms per object) is what keeps the walk cheap: the flag
+#: cache in ``sw_type_info`` is keyed by ``id(obj)``, and every feature here
+#: is a freshly returned dispatch, so a full-interface flag never hits that
+#: cache and pays its full cost on every single feature.
+_WALK_MEMBERS = ("GetNextFeature", "GetTypeName2", "IsSuppressed", "IsSuppressed2")
+
+
 class _FeatureSelectionService:
     """Encapsulate feature-selection strategies and name-candidate expansion.
 
@@ -1213,10 +1222,12 @@ class _FeatureSelectionService:
         feature = self._adapter._attempt(
             lambda: self._adapter.currentModel.FirstFeature()  # type: ignore[union-attr]
         )
-        # Flag the feature dispatch so methods like GetNextFeature work
+        # Flag only the members this walk reads (see ``_WALK_MEMBERS``) so
+        # methods like GetNextFeature work, without paying the cost of
+        # flagging the entire IFeature interface on every fresh dispatch.
         if feature is not None:
             self._adapter._attempt(
-                lambda f=feature: sw_type_info.flag_methods(f, "IFeature"),  # type: ignore[misc]
+                lambda f=feature: sw_type_info.flag_members(f, *_WALK_MEMBERS),  # type: ignore[misc]
                 default=0,
             )
         pos = 0
@@ -1234,7 +1245,7 @@ class _FeatureSelectionService:
             # Flag each new feature dispatch
             if feature is not None:
                 self._adapter._attempt(
-                    lambda f=feature: sw_type_info.flag_methods(f, "IFeature"),  # type: ignore[misc]
+                    lambda f=feature: sw_type_info.flag_members(f, *_WALK_MEMBERS),  # type: ignore[misc]
                     default=0,
                 )
 

--- a/src/solidworks_mcp/adapters/solidworks/features.py
+++ b/src/solidworks_mcp/adapters/solidworks/features.py
@@ -474,6 +474,31 @@ def _flag_feature_methods(obj: Any, interface: str) -> None:  # pragma: no cover
         pass
 
 
+def _flag_feature_members(obj: Any, *names: str) -> None:  # pragma: no cover
+    """Flag only the named members on ``obj``.
+
+    Cheaper than :func:`_flag_feature_methods` inside a loop: flagging a
+    whole interface (``IFeature`` is ~100 names, ~27 ms) costs a fixed price
+    per object, and ``sw_type_info``'s flag cache is keyed by ``id(obj)``, so
+    a walk over fresh dispatches — one per feature — never hits it. Flagging
+    just the handful of members about to be read avoids that cost.
+
+    Args:
+        obj: The COM object (or test double) to flag.
+        *names: Member names about to be read.
+    """
+    try:
+        from solidworks_mcp.adapters import sw_type_info
+
+        sw_type_info.flag_members(obj, *names)
+    except Exception:
+        pass
+
+
+#: Members read while walking the feature tree in ``_profile_feature_names``.
+_TREE_WALK_MEMBERS = ("GetTypeName2", "GetNextFeature", "Name")
+
+
 def _read_member(obj: Any, name: str) -> Any:  # pragma: no cover
     """Read a COM member that pywin32 may expose as a property *or* a method.
 
@@ -527,7 +552,7 @@ def _profile_feature_names(adapter: Any) -> list[str]:  # pragma: no cover
         for _ in range(5000):
             if not feat:
                 break
-            _flag_feature_methods(feat, "IFeature")
+            _flag_feature_members(feat, *_TREE_WALK_MEMBERS)
             try:
                 if _read_member(feat, "GetTypeName2") == "ProfileFeature":
                     names.append(str(_read_member(feat, "Name")))

--- a/src/solidworks_mcp/adapters/sw_type_info.py
+++ b/src/solidworks_mcp/adapters/sw_type_info.py
@@ -204,6 +204,38 @@ def flag_methods(obj: Any, *interfaces: str) -> int:
     return flagged
 
 
+def flag_members(obj: Any, *names: str) -> int:
+    """Flag a specific handful of method names on ``obj``.
+
+    ``flag_methods`` flags *every* method of an interface — around 100 names
+    for ``IFeature`` — and its cache is keyed by ``id(obj)``, so a loop over
+    many short-lived dispatches (walking a feature tree, iterating components)
+    pays that cost once per object and never hits the cache.
+
+    When the caller knows exactly which members it is about to read, flagging
+    just those is far cheaper and behaves identically for them.
+
+    Args:
+        obj: A pywin32 ``CDispatch`` wrapping a SolidWorks COM object.
+        *names: Method names to flag.
+
+    Returns:
+        int: Number of names flagged.
+    """
+    if obj is None:
+        return 0
+
+    flagged_count = 0
+    for name in names:
+        try:
+            obj._FlagAsMethod(name)
+            flagged_count += 1
+        except Exception:
+            # Not on this dispatch's real interface — skip silently.
+            pass
+    return flagged_count
+
+
 def flagged(obj: Any, *interfaces: str) -> Any:
     """Flag ``obj``'s methods then return ``obj`` — call-chain friendly.
 

--- a/tests/solidworks_mcp/adapters/test_sw_type_info.py
+++ b/tests/solidworks_mcp/adapters/test_sw_type_info.py
@@ -83,6 +83,97 @@ def test_invalidate_flag_cache_clears_and_pops() -> None:
     assert sw_type_info._flag_cache == {}
 
 
+class _FakeDispatch:
+    """Minimal test double mimicking a pywin32 ``CDispatch``'s flag surface.
+
+    Records every name it was asked to flag. ``unflaggable`` simulates names
+    that don't belong to the object's real COM interface — pywin32's
+    ``_FlagAsMethod`` raises for those, and ``flag_members`` must skip them
+    silently rather than propagate.
+    """
+
+    def __init__(self, unflaggable: set[str] | None = None) -> None:
+        self.flagged_names: set[str] = set()
+        self._unflaggable = unflaggable or set()
+
+    def _FlagAsMethod(self, name: str) -> None:
+        if name in self._unflaggable:
+            raise Exception(f"Unknown name: {name}")
+        self.flagged_names.add(name)
+
+
+def test_flag_members_flags_only_requested_names() -> None:
+    """flag_members should flag exactly the names passed in, nothing else."""
+    from solidworks_mcp.adapters import sw_type_info
+
+    obj = _FakeDispatch()
+    count = sw_type_info.flag_members(obj, "GetNextFeature", "GetTypeName2")
+
+    assert count == 2
+    assert obj.flagged_names == {"GetNextFeature", "GetTypeName2"}
+
+
+def test_flag_members_tolerates_none_object() -> None:
+    """flag_members should no-op and return 0 when obj is None."""
+    from solidworks_mcp.adapters import sw_type_info
+
+    assert sw_type_info.flag_members(None, "GetNextFeature") == 0
+
+
+def test_flag_members_tolerates_names_not_on_interface() -> None:
+    """flag_members should skip names _FlagAsMethod rejects, not raise."""
+    from solidworks_mcp.adapters import sw_type_info
+
+    obj = _FakeDispatch(unflaggable={"NotOnInterface"})
+    count = sw_type_info.flag_members(obj, "GetNextFeature", "NotOnInterface")
+
+    assert count == 1
+    assert obj.flagged_names == {"GetNextFeature"}
+
+
+def test_flag_members_works_when_pywin32_unavailable(monkeypatch) -> None:
+    """flag_members should still flag members when pywin32 wasn't importable.
+
+    Unlike ``flag_methods``, ``flag_members`` doesn't consult the gen_py
+    wrapper or ``_interface_methods`` — it flags exactly the names it's
+    given directly on the object. It must keep doing that even in the
+    no-pywin32 fallback state exercised by
+    ``test_import_handles_missing_pywin32``.
+    """
+    import builtins
+
+    original_import = builtins.__import__
+
+    def _blocked_import(name, *args, **kwargs):
+        if name.startswith("win32com"):
+            raise ImportError("blocked")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked_import)
+
+    module_path = (
+        Path(__file__).parents[3]
+        / "src"
+        / "solidworks_mcp"
+        / "adapters"
+        / "sw_type_info.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "sw_type_info_no_pywin32_flag_members", module_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert module.PYWIN32_AVAILABLE is False
+
+    obj = _FakeDispatch()
+    count = module.flag_members(obj, "GetNextFeature")
+
+    assert count == 1
+    assert obj.flagged_names == {"GetNextFeature"}
+
+
 def test_load_wrapper_warns_when_genpy_missing(monkeypatch) -> None:
     """_load_wrapper should warn when gen_py is unavailable."""
     # Simulate gencache failing to load or generate a wrapper module.


### PR DESCRIPTION
flag_methods(obj, iface) flags every method name on the interface - about 96 for IFeature - and caches the result on id(obj). Walking the feature tree gets a freshly returned COM dispatch per feature, so id(obj) never repeats, the cache never hits, and every iteration pays the full cost again.

Adds flag_members(obj, *names), which flags only the names about to be read, and uses it in the two per-feature walk loops: the forward walk in pywin32_adapter's list_features, and _profile_feature_names in solidworks/features.py. flag_methods is unchanged and still used everywhere else, including for the whole-interface flagging of IModelDoc2 and IFeatureManager where it is the right tool.

Measured on a fake dispatch over a 50-feature walk, no SolidWorks involved:

    flag_methods(f, 'IFeature'):     4800 _FlagAsMethod calls
    flag_members(f, *_WALK_MEMBERS):  200 _FlagAsMethod calls

96 interface names x 50 features against 4 read members x 50. Each _FlagAsMethod is a COM GetIDsOfNames round-trip, so this is where the time goes.

One deliberate asymmetry between the two call sites. "Name" is flagged in features.py but not in pywin32_adapter.py, because the two files read it differently: features.py goes through a helper that checks callable() first, while pywin32_adapter.py:1299 does a plain

    name = str(getattr(feature, "Name", ""))

Flagging "Name" there would make getattr hand back a bound method and every feature would report its name as "<bound method ...>". "Name" is a genuine COM property, so the original flag_methods(f, "IFeature") never flagged it either - excluding it preserves existing behaviour rather than changing it.

Four unit tests cover flag_members: flags only the requested names, tolerates None, tolerates a name the dispatch rejects, and behaves when pywin32 is absent. Verified non-vacuous by making flag_members flag extra names, which fails three of the four.

Suite: 1840 passed, 0 failed, serial and under -n auto --dist=worksteal. Coverage 99.87%, gate passing; the three touched source files are at 100%. ruff unchanged at 14 findings.