### PR TITLE
feat(assembly): insert, list and mate components

### DIFF
--- a/src/solidworks_mcp/adapters/base.py
+++ b/src/solidworks_mcp/adapters/base.py
@@ -965,6 +965,73 @@ class SolidWorksAdapter(ABC):
             error="add_fillet is not implemented by this adapter",
         )
 
+    # Assembly Operations
+    async def insert_component(
+        self, file_path: str, x: float = 0.0, y: float = 0.0, z: float = 0.0
+    ) -> AdapterResult[dict[str, Any]]:
+        """Insert a part or sub-assembly into the active assembly.
+
+        Args:
+            file_path (str): Absolute path to the ``.sldprt`` or ``.sldasm``.
+            x (float): X position in millimetres. Defaults to 0.0.
+            y (float): Y position in millimetres. Defaults to 0.0.
+            z (float): Z position in millimetres. Defaults to 0.0.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: Component name and counts, or error.
+        """
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="insert_component is not implemented by this adapter",
+        )
+
+    async def list_components(self) -> AdapterResult[list[str]]:
+        """List the top-level components of the active assembly.
+
+        Returns:
+            AdapterResult[list[str]]: Component instance names, or error.
+        """
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="list_components is not implemented by this adapter",
+        )
+
+    async def add_mate(
+        self,
+        component_a: str,
+        component_b: str,
+        entity_a: str = "Front Plane",
+        entity_b: str = "Front Plane",
+        mate_type: str = "coincident",
+        alignment: str = "aligned",
+        distance: float = 0.0,
+        angle: float = 0.0,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Mate two components together in the active assembly.
+
+        Args:
+            component_a (str): First component instance name.
+            component_b (str): Second component instance name.
+            entity_a (str): Named feature on the first component. Defaults to
+                "Front Plane".
+            entity_b (str): Named feature on the second component. Defaults to
+                "Front Plane".
+            mate_type (str): Mate type, e.g. ``coincident``. Defaults to
+                "coincident".
+            alignment (str): ``aligned``, ``anti_aligned`` or ``closest``.
+                Defaults to "aligned".
+            distance (float): Distance in millimetres, for a distance mate.
+                Defaults to 0.0.
+            angle (float): Angle in degrees, for an angle mate. Defaults to 0.0.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: Mate details, or error.
+        """
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="add_mate is not implemented by this adapter",
+        )
+
     @abstractmethod
     async def exit_sketch(self) -> AdapterResult[None]:
         """Exit sketch editing mode.

--- a/src/solidworks_mcp/adapters/circuit_breaker.py
+++ b/src/solidworks_mcp/adapters/circuit_breaker.py
@@ -1027,6 +1027,92 @@ class CircuitBreakerAdapter(SolidWorksAdapter):
             input_dict={"name": name, "value": value},
         )
 
+    # Assembly operations
+
+    async def insert_component(
+        self, file_path: str, x: float = 0.0, y: float = 0.0, z: float = 0.0
+    ) -> AdapterResult[dict[str, Any]]:
+        """Insert component through circuit breaker.
+
+        Args:
+            file_path (str): Path to the target file.
+            x (float): X position in millimetres. Defaults to 0.0.
+            y (float): Y position in millimetres. Defaults to 0.0.
+            z (float): Z position in millimetres. Defaults to 0.0.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_circuit_breaker(
+            "insert_component",
+            lambda: self.adapter.insert_component(file_path, x, y, z),
+            input_dict={"file_path": file_path, "x": x, "y": y, "z": z},
+        )
+
+    async def list_components(self) -> AdapterResult[list[str]]:
+        """List components through circuit breaker.
+
+        Returns:
+            AdapterResult[list[str]]: The result produced by the operation.
+        """
+        return await self._execute_with_circuit_breaker(
+            "list_components",
+            lambda: self.adapter.list_components(),
+            input_dict={},
+        )
+
+    async def add_mate(
+        self,
+        component_a: str,
+        component_b: str,
+        entity_a: str = "Front Plane",
+        entity_b: str = "Front Plane",
+        mate_type: str = "coincident",
+        alignment: str = "aligned",
+        distance: float = 0.0,
+        angle: float = 0.0,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Add mate through circuit breaker.
+
+        Args:
+            component_a (str): First component instance name.
+            component_b (str): Second component instance name.
+            entity_a (str): Named feature on the first component. Defaults to
+                "Front Plane".
+            entity_b (str): Named feature on the second component. Defaults to
+                "Front Plane".
+            mate_type (str): Mate type. Defaults to "coincident".
+            alignment (str): Mate alignment. Defaults to "aligned".
+            distance (float): Distance in millimetres. Defaults to 0.0.
+            angle (float): Angle in degrees. Defaults to 0.0.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_circuit_breaker(
+            "add_mate",
+            lambda: self.adapter.add_mate(
+                component_a,
+                component_b,
+                entity_a,
+                entity_b,
+                mate_type,
+                alignment,
+                distance,
+                angle,
+            ),
+            input_dict={
+                "component_a": component_a,
+                "component_b": component_b,
+                "entity_a": entity_a,
+                "entity_b": entity_b,
+                "mate_type": mate_type,
+                "alignment": alignment,
+                "distance": distance,
+                "angle": angle,
+            },
+        )
+
     # SolidWorks-as-Code checkpoint
 
     async def soc_create_checkpoint(

--- a/src/solidworks_mcp/adapters/connection_pool.py
+++ b/src/solidworks_mcp/adapters/connection_pool.py
@@ -967,6 +967,79 @@ class ConnectionPoolAdapter(SolidWorksAdapter):
             "set_dimension", lambda adapter: adapter.set_dimension(name, value)
         )
 
+    # Assembly operations
+
+    async def insert_component(
+        self, file_path: str, x: float = 0.0, y: float = 0.0, z: float = 0.0
+    ) -> AdapterResult[dict[str, Any]]:
+        """Insert component using pool.
+
+        Args:
+            file_path (str): Path to the target file.
+            x (float): X position in millimetres. Defaults to 0.0.
+            y (float): Y position in millimetres. Defaults to 0.0.
+            z (float): Z position in millimetres. Defaults to 0.0.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_pool(
+            "insert_component",
+            lambda adapter: adapter.insert_component(file_path, x, y, z),
+        )
+
+    async def list_components(self) -> AdapterResult[list[str]]:
+        """List components using pool.
+
+        Returns:
+            AdapterResult[list[str]]: The result produced by the operation.
+        """
+        return await self._execute_with_pool(
+            "list_components", lambda adapter: adapter.list_components()
+        )
+
+    async def add_mate(
+        self,
+        component_a: str,
+        component_b: str,
+        entity_a: str = "Front Plane",
+        entity_b: str = "Front Plane",
+        mate_type: str = "coincident",
+        alignment: str = "aligned",
+        distance: float = 0.0,
+        angle: float = 0.0,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Add mate using pool.
+
+        Args:
+            component_a (str): First component instance name.
+            component_b (str): Second component instance name.
+            entity_a (str): Named feature on the first component. Defaults to
+                "Front Plane".
+            entity_b (str): Named feature on the second component. Defaults to
+                "Front Plane".
+            mate_type (str): Mate type. Defaults to "coincident".
+            alignment (str): Mate alignment. Defaults to "aligned".
+            distance (float): Distance in millimetres. Defaults to 0.0.
+            angle (float): Angle in degrees. Defaults to 0.0.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_pool(
+            "add_mate",
+            lambda adapter: adapter.add_mate(
+                component_a,
+                component_b,
+                entity_a,
+                entity_b,
+                mate_type,
+                alignment,
+                distance,
+                angle,
+            ),
+        )
+
 
 class ConnectionPool:
     """Legacy alias class expected by tests.

--- a/src/solidworks_mcp/adapters/mock_adapter.py
+++ b/src/solidworks_mcp/adapters/mock_adapter.py
@@ -148,6 +148,9 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         # its sketch-entity registry.
         self._sketch_entity_ids: set[str] = set()
         self._dimensions: dict[str, float] = {}
+        # Assembly components inserted via insert_component, keyed by
+        # insertion order. See insert_component/list_components/add_mate.
+        self._components: list[str] = []
         self._operation_count = 0
 
         # Configurable simulation delays (in seconds)
@@ -1913,4 +1916,125 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
 
         return AdapterResult(
             status=AdapterResultStatus.SUCCESS, data=None, execution_time=0.1
+        )
+
+    async def insert_component(
+        self, file_path: str, x: float = 0.0, y: float = 0.0, z: float = 0.0
+    ) -> AdapterResult[dict[str, Any]]:
+        """Mock inserting a component into the active assembly.
+
+        Records the component in ``self._components`` so repeated inserts
+        accumulate and ``list_components`` reflects them.
+
+        Args:
+            file_path (str): Path to the part or sub-assembly to insert.
+            x (float): X position in millimetres. Defaults to 0.0.
+            y (float): Y position in millimetres. Defaults to 0.0.
+            z (float): Z position in millimetres. Defaults to 0.0.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        await asyncio.sleep(self._delays["model_operation"])
+        self._operation_count += 1
+
+        self._components.append(f"component-{len(self._components) + 1}")
+
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data={
+                "component": self._components[-1],
+                "file_path": file_path,
+                "position": {"x": x, "y": y, "z": z},
+                "components_before": len(self._components) - 1,
+                "components_after": len(self._components),
+            },
+            execution_time=self._delays["model_operation"],
+        )
+
+    async def list_components(self) -> AdapterResult[list[str]]:
+        """Mock listing the top-level components of the active assembly.
+
+        Returns:
+            AdapterResult[list[str]]: The result produced by the operation.
+        """
+        await asyncio.sleep(self._delays["model_operation"] / 2)
+        self._operation_count += 1
+
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data=list(self._components),
+            execution_time=self._delays["model_operation"] / 2,
+        )
+
+    async def add_mate(
+        self,
+        component_a: str,
+        component_b: str,
+        entity_a: str = "Front Plane",
+        entity_b: str = "Front Plane",
+        mate_type: str = "coincident",
+        alignment: str = "aligned",
+        distance: float = 0.0,
+        angle: float = 0.0,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Mock mating two components in the active assembly.
+
+        Args:
+            component_a (str): First component instance name.
+            component_b (str): Second component instance name.
+            entity_a (str): Named feature on the first component. Defaults to
+                "Front Plane".
+            entity_b (str): Named feature on the second component. Defaults to
+                "Front Plane".
+            mate_type (str): Mate type. Defaults to "coincident".
+            alignment (str): Mate alignment. Defaults to "aligned".
+            distance (float): Distance in millimetres, for a distance mate.
+                Defaults to 0.0.
+            angle (float): Angle in degrees, for an angle mate. Defaults to 0.0.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        known_mate_types = {
+            "coincident",
+            "concentric",
+            "perpendicular",
+            "parallel",
+            "tangent",
+            "distance",
+            "angle",
+        }
+        if mate_type not in known_mate_types:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    f"Unknown mate type '{mate_type}'. "
+                    f"Use one of: {', '.join(sorted(known_mate_types))}."
+                ),
+            )
+
+        await asyncio.sleep(self._delays["model_operation"])
+        self._operation_count += 1
+
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data={
+                "mate_type": mate_type,
+                "alignment": alignment,
+                "components": [component_a, component_b],
+                "entities": [entity_a, entity_b],
+                "distance": distance or None,
+                "angle": angle or None,
+                # The real adapter fills these by comparing every component's
+                # Transform2 before and after the mate. The mock has no
+                # geometry to move, so it reports "not determinable" rather
+                # than True: this field exists precisely so a caller can tell
+                # a mate that positioned something from one SolidWorks
+                # accepted and ignored, and a mock that always answers True
+                # would make that check useless wherever mock mode is used.
+                "moved_components": [],
+                "geometry_moved": None,
+            },
+            execution_time=self._delays["model_operation"],
         )

--- a/src/solidworks_mcp/adapters/solidworks/io.py
+++ b/src/solidworks_mcp/adapters/solidworks/io.py
@@ -18,9 +18,11 @@ from ..base import AdapterResult, AdapterResultStatus, MassProperties, SolidWork
 try:
     import pythoncom
     import win32com.client
+    import win32com.client.dynamic as _dynamic
 except ImportError:  # pragma: no cover
     pythoncom = SimpleNamespace()
     win32com = SimpleNamespace(client=SimpleNamespace())
+    _dynamic = SimpleNamespace(Dispatch=lambda *_a, **_kw: None)
 
 try:
     import comtypes  # type: ignore[import-untyped]
@@ -73,6 +75,202 @@ def _bridge_com_to_comtypes(pywin32_obj: Any, iface: Any) -> Any:  # pragma: no 
     ct_unk = ctypes.cast(ptr_int, ctypes.POINTER(comtypes.IUnknown))
     ct_unk.AddRef()
     return ct_unk.QueryInterface(iface)
+
+
+_MATE_TYPES: dict[str, int] = {
+    "coincident": 0,
+    "concentric": 1,
+    "perpendicular": 2,
+    "parallel": 3,
+    "tangent": 4,
+    "distance": 5,
+    "angle": 6,
+}
+
+
+_MATE_ALIGNMENTS: dict[str, int] = {
+    "aligned": 0,
+    "anti_aligned": 1,
+    "closest": 2,
+}
+
+
+def _component_transforms(adapter: Any, assembly: Any) -> dict[str, tuple[float, ...]]:
+    """Snapshot every component's placement, for before/after comparison.
+
+    ``IComponent2.Transform2`` is the component's position relative to the
+    assembly root, as a ``MathTransform`` whose ``ArrayData`` is 16 doubles
+    (a 3x3 rotation, a translation, and a scale). Comparing the snapshot
+    before and after a mate is what distinguishes a mate that actually
+    positioned geometry from one that SolidWorks accepted and ignored.
+
+    Args:
+        adapter: A connected ``PyWin32Adapter``.
+        assembly: The ``IAssemblyDoc`` dispatch to snapshot.
+
+    Returns:
+        dict[str, tuple[float, ...]]: Component name to transform matrix.
+        Components whose transform cannot be read are omitted rather than
+        recorded as unchanged — an unreadable transform is not evidence of
+        anything, and treating it as "same" would fake a passing comparison.
+    """
+    snapshot: dict[str, tuple[float, ...]] = {}
+    for name, component in _component_pairs(adapter, assembly):
+        if component is None:
+            continue
+        transform = adapter._attempt(lambda c=component: c.Transform2, default=None)
+        if transform is None:
+            continue
+        data = adapter._attempt(lambda t=transform: t.ArrayData, default=None)
+        if not isinstance(data, (list, tuple)):
+            continue
+        try:
+            snapshot[name] = tuple(round(float(value), 9) for value in data)
+        except (TypeError, ValueError):
+            continue
+    return snapshot
+
+
+class _ByrefFallback:
+    """Stand-in for a byref VARIANT when pywin32 is unavailable.
+
+    The callers' contract for a byref holder is "an object whose ``.value``
+    the COM call fills in". Returning a bare ``0`` or ``""`` broke that: on any
+    machine without pywin32 (Linux CI, mock runs) ``_read_material_name`` could
+    never read its database out-parameter back, so it silently reported
+    ``None``. This keeps the contract on both platforms.
+    """
+
+    __slots__ = ("value",)
+
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+    def __eq__(self, other: Any) -> bool:
+        """Compare equal to the seeded value, so callers can treat it as one."""
+        if isinstance(other, _ByrefFallback):
+            return bool(self.value == other.value)
+        return bool(self.value == other)
+
+    def __hash__(self) -> int:
+        """Hash as the seeded value."""
+        return hash(self.value)
+
+    def __bool__(self) -> bool:
+        """Truthiness follows the seeded value."""
+        return bool(self.value)
+
+    def __repr__(self) -> str:
+        """Show the seeded value for readable assertion output."""
+        return f"_ByrefFallback({self.value!r})"
+
+
+def _byref_int() -> Any:
+    """Return a byref long VARIANT for a SolidWorks out-parameter.
+
+    See :func:`_byref_bstr` for why ``pythoncom.Missing`` does not work.
+
+    Returns:
+        Any: A ``VARIANT(VT_BYREF | VT_I4, 0)``, or ``0`` when pywin32 is
+        unavailable (test/mock environments).
+    """
+    variant_ctor = getattr(getattr(win32com, "client", None), "VARIANT", None)
+    if not callable(variant_ctor):
+        return _ByrefFallback(0)
+    return variant_ctor(
+        int(getattr(pythoncom, "VT_BYREF", 0)) | int(getattr(pythoncom, "VT_I4", 0)), 0
+    )
+
+
+def _doc_type(adapter: Any) -> int | None:
+    """Return the active document's type: 1 part, 2 assembly, 3 drawing.
+
+    ``GetType`` is one of the members pywin32 late binding may expose as either
+    a bound method or a plain value, so calling it directly returns ``None`` on
+    some documents.  ``_get_attr_or_call`` handles both shapes.
+
+    Args:
+        adapter: A connected ``PyWin32Adapter``.
+
+    Returns:
+        int | None: The document type, or ``None`` when it cannot be read.
+    """
+    value = adapter._attempt(
+        lambda: adapter._get_attr_or_call(adapter.currentModel, "GetType"),
+        default=None,
+    )
+    return int(value) if isinstance(value, (int, float)) else None
+
+
+def _component_pairs(adapter: Any, assembly: Any) -> list[tuple[str, Any]]:
+    """Return an assembly's top-level components as ``(name, dispatch)``.
+
+    Args:
+        adapter: A connected ``PyWin32Adapter``.
+        assembly: The assembly document, flagged for ``IAssemblyDoc``.
+
+    Returns:
+        list[tuple[str, Any]]: Component name and its ``IComponent2``
+        dispatch. A component whose dispatch cannot be wrapped is reported
+        as ``("<unnamed>", None)`` so callers still see the correct count.
+    """
+    components = adapter._attempt(lambda: assembly.GetComponents(True), default=None)
+    if not isinstance(components, (list, tuple)):
+        return []
+
+    pairs: list[tuple[str, Any]] = []
+    for component in components:
+        wrapped = _as_com(adapter, component, "IComponent2")
+        if wrapped is None:
+            pairs.append(("<unnamed>", None))
+            continue
+        name = adapter._attempt(lambda c=wrapped: c.Name2, default=None)
+        if not name:
+            name = adapter._attempt(lambda c=wrapped: c.GetPathName(), default=None)
+        pairs.append((str(name) if name else "<unnamed>", wrapped))
+    return pairs
+
+
+def _component_names(adapter: Any, assembly: Any) -> list[str]:
+    """Return the names of an assembly's top-level components.
+
+    ``AddComponent*`` can return an object having added nothing, so the
+    component list is the ground truth for whether an insert worked.
+
+    Args:
+        adapter: A connected ``PyWin32Adapter``.
+        assembly: The assembly document, flagged for ``IAssemblyDoc``.
+
+    Returns:
+        list[str]: Component names, empty when the assembly holds none.
+    """
+    return [name for name, _ in _component_pairs(adapter, assembly)]
+
+
+def _as_com(adapter: Any, obj: Any, interface: str) -> Any:
+    """Wrap a raw dispatch and flag its methods for an interface.
+
+    Objects handed back inside arrays (``GetViews`` and friends) arrive as raw
+    ``PyIDispatch``.  Method flagging is a no-op on those, so every call
+    against them raises until they are wrapped through ``dynamic.Dispatch``.
+
+    Args:
+        adapter: A connected ``PyWin32Adapter``.
+        obj: The raw dispatch.
+        interface: Interface name, e.g. ``"IView"``.
+
+    Returns:
+        Any: The wrapped, flagged object, or ``None``.
+    """
+    wrapped = adapter._attempt(lambda: _dynamic.Dispatch(obj), default=None)
+    if wrapped is None:
+        return None
+    adapter._attempt(
+        lambda: _sw_type_info.flag_methods(wrapped, interface), default=None
+    )
+    return wrapped
+
+
 
 
 class SolidWorksIOMixin:
@@ -949,3 +1147,365 @@ class SolidWorksIOMixin:
             data=result.data,
             execution_time=result.execution_time,
         )
+
+    async def insert_component(
+            self, file_path: str, x: float = 0.0, y: float = 0.0, z: float = 0.0
+        ) -> AdapterResult[dict[str, Any]]:
+            """Insert a part or sub-assembly into the active assembly.
+
+            Wraps ``IAssemblyDoc::AddComponent4(CompName, ConfigName, X, Y, Z)``,
+            falling back to ``AddComponent5``.  Position is in **millimetres**.
+
+            **The component file must contain solid geometry.**  SolidWorks
+            silently refuses to insert an empty part — every overload returns
+            ``None`` and the component count stays put.  That behaviour is what
+            made this look unimplementable until the ``save_file`` bug that was
+            writing empty parts got fixed.
+
+            Success is confirmed by the assembly's component count going up, since
+            ``AddComponent*`` gives no usable failure signal.
+
+            Args:
+                file_path (str): Absolute path to the ``.sldprt`` or ``.sldasm``.
+                x (float): X position in millimetres.
+                y (float): Y position in millimetres.
+                z (float): Z position in millimetres.
+
+            Returns:
+                AdapterResult[dict[str, Any]]: Component name and before/after
+                counts.  ``ERROR`` when the active document is not an assembly, the
+                file is missing, or nothing was inserted.
+
+            Raises:
+                Exception: Propagated through ``_handle_com_operation``.
+
+            Example::
+
+                await adapter.insert_component(r"C:\\parts\\bracket.sldprt", 0, 0, 0)
+            """
+            adapter = self._adapter(self)
+            if not adapter.currentModel:
+                return AdapterResult(
+                    status=AdapterResultStatus.ERROR, error="No active model"
+                )
+
+            path = os.path.abspath(file_path)
+            if not os.path.exists(path):
+                return AdapterResult(
+                    status=AdapterResultStatus.ERROR,
+                    error=f"Component file not found: {file_path}",
+                )
+
+            doc_type = _doc_type(adapter)
+            if doc_type != 2:
+                return AdapterResult(
+                    status=AdapterResultStatus.ERROR,
+                    error=(
+                        "insert_component requires an assembly document "
+                        f"(active document type is {doc_type!r}, expected 2). "
+                        "Call create_assembly first."
+                    ),
+                )
+
+            def _insert() -> dict[str, Any]:
+                assembly = _sw_type_info.flagged(adapter.currentModel, "IAssemblyDoc")
+                before = _component_names(adapter, assembly)
+
+                # The document has to be loaded before it can be inserted, and the
+                # errors/warnings out-parameters must be byref VARIANTs: with
+                # pythoncom.Missing OpenDoc6 returns None and the part stays
+                # unloaded, after which every AddComponent overload does nothing.
+                app = adapter.swApp
+                opened = adapter._attempt(
+                    lambda: app.OpenDoc6(
+                        path,
+                        2 if path.lower().endswith(".sldasm") else 1,
+                        1,
+                        "",
+                        _byref_int(),
+                        _byref_int(),
+                    ),
+                    default=None,
+                )
+                if not opened:
+                    raise Exception(
+                        f"Could not load '{file_path}' - OpenDoc6 returned nothing."
+                    )
+
+                title = adapter._attempt(
+                    lambda: _sw_type_info.flagged(
+                        adapter.currentModel, "IModelDoc2"
+                    ).GetTitle(),
+                    default=None,
+                )
+                if title:
+                    adapter._attempt(
+                        lambda: app.ActivateDoc3(title, False, 0, _byref_int()),
+                        default=None,
+                    )
+
+                component = adapter._attempt(
+                    lambda: assembly.AddComponent4(
+                        path, "", x / 1000.0, y / 1000.0, z / 1000.0
+                    ),
+                    default=None,
+                )
+                if component is None:
+                    component = adapter._attempt(
+                        lambda: assembly.AddComponent5(
+                            path, 0, "", False, "",
+                            x / 1000.0, y / 1000.0, z / 1000.0,
+                        ),
+                        default=None,
+                    )
+
+                adapter._attempt(lambda: assembly.EditRebuild3(), default=None)
+
+                after = _component_names(adapter, assembly)
+                if len(after) <= len(before):
+                    raise Exception(
+                        f"Component was not inserted - the assembly still has "
+                        f"{len(after)} component(s). The most common cause is a "
+                        f"part with no solid geometry: SolidWorks refuses those "
+                        f"silently. Check '{file_path}' opens with a body."
+                    )
+
+                added = [n for n in after if n not in before]
+                return {
+                    "component": added[-1] if added else after[-1],
+                    "file_path": path,
+                    "position": {"x": x, "y": y, "z": z},
+                    "components_before": len(before),
+                    "components_after": len(after),
+                }
+
+            return cast(
+                AdapterResult[dict[str, Any]],
+                adapter._handle_com_operation("insert_component", _insert),
+            )
+
+    async def add_mate(
+            self,
+            component_a: str,
+            component_b: str,
+            entity_a: str = "Front Plane",
+            entity_b: str = "Front Plane",
+            mate_type: str = "coincident",
+            alignment: str = "aligned",
+            distance: float = 0.0,
+            angle: float = 0.0,
+        ) -> AdapterResult[dict[str, Any]]:
+            """Mate two components together.
+
+            Wraps ``IAssemblyDoc::AddMate5``.  The two entities are selected via
+            ``IComponent2::FeatureByName`` + ``IFeature::Select2`` rather than
+            ``SelectByID2``, which raises ``Type mismatch`` on this build.
+
+            That restricts the entities to *named tree features* — the reference
+            planes and axes of each component.  Plane-to-plane mating covers
+            alignment and stacking, which is the common case; mating to a specific
+            face or edge needs entity names this adapter cannot enumerate.
+
+            Args:
+                component_a (str): First component instance name, as reported by
+                    :meth:`list_components`.
+                component_b (str): Second component instance name.
+                entity_a (str): Named feature on the first component.
+                entity_b (str): Named feature on the second component.
+                mate_type (str): ``coincident``, ``concentric``, ``perpendicular``,
+                    ``parallel``, ``tangent``, ``distance`` or ``angle``.
+                alignment (str): ``aligned``, ``anti_aligned`` or ``closest``.
+                distance (float): Distance in millimetres, for a distance mate.
+                angle (float): Angle in degrees, for an angle mate.
+
+            Returns:
+                AdapterResult[dict[str, Any]]: The mate created, plus the bounding
+                box before and after so the caller can see what moved.  ``ERROR``
+                when the entities cannot be selected or SolidWorks rejects the
+                mate.
+
+            Raises:
+                Exception: Propagated through ``_handle_com_operation``.
+
+            Example::
+
+                await adapter.add_mate("plate-1", "plate-2")
+            """
+            adapter = self._adapter(self)
+            if _doc_type(adapter) != 2:
+                return AdapterResult(
+                    status=AdapterResultStatus.ERROR,
+                    error="add_mate requires an assembly document",
+                )
+
+            mate_key = str(mate_type).strip().lower()
+            if mate_key not in _MATE_TYPES:
+                return AdapterResult(
+                    status=AdapterResultStatus.ERROR,
+                    error=(
+                        f"Unknown mate type '{mate_type}'. "
+                        f"Use one of: {', '.join(sorted(_MATE_TYPES))}."
+                    ),
+                )
+            align_key = str(alignment).strip().lower()
+            if align_key not in _MATE_ALIGNMENTS:
+                return AdapterResult(
+                    status=AdapterResultStatus.ERROR,
+                    error=(
+                        f"Unknown alignment '{alignment}'. "
+                        f"Use one of: {', '.join(sorted(_MATE_ALIGNMENTS))}."
+                    ),
+                )
+
+            def _mate() -> dict[str, Any]:
+                import math
+
+                model = adapter.currentModel
+                assembly = _sw_type_info.flagged(model, "IAssemblyDoc")
+
+                components = adapter._attempt(
+                    lambda: assembly.GetComponents(True), default=None
+                )
+                if not isinstance(components, (list, tuple)):
+                    raise Exception("Could not read the assembly's components")
+
+                wanted = {component_a: entity_a, component_b: entity_b}
+                found: dict[str, Any] = {}
+                for component in components:
+                    wrapped = _as_com(adapter, component, "IComponent2")
+                    if wrapped is None:
+                        continue
+                    name = adapter._attempt(lambda w=wrapped: w.Name2, default=None)
+                    if name and str(name) in wanted:
+                        found[str(name)] = wrapped
+
+                missing = [n for n in (component_a, component_b) if n not in found]
+                if missing:
+                    available = [
+                        str(adapter._attempt(lambda c=c: _as_com(adapter, c, "IComponent2").Name2, default="?"))
+                        for c in components
+                    ]
+                    raise Exception(
+                        f"Component(s) not found: {', '.join(missing)}. "
+                        f"The assembly holds: {', '.join(available)}."
+                    )
+
+                adapter._attempt(lambda: model.ClearSelection2(True), default=None)
+                for index, component_name in enumerate((component_a, component_b)):
+                    wrapped = found[component_name]
+                    entity_name = wanted[component_name]
+                    feature = adapter._attempt(
+                        lambda w=wrapped, e=entity_name: w.FeatureByName(e), default=None
+                    )
+                    if feature is None:
+                        raise Exception(
+                            f"'{entity_name}' not found on {component_name}. "
+                            "Only named tree features (reference planes and axes) "
+                            "can be selected here."
+                        )
+                    flagged = _as_com(adapter, feature, "IFeature")
+                    if flagged is None or not adapter._attempt(
+                        lambda f=flagged, a=index > 0: f.Select2(a, 0), default=False
+                    ):
+                        raise Exception(
+                            f"Failed to select '{entity_name}' on {component_name}"
+                        )
+
+                selected = adapter._attempt(
+                    lambda: model.SelectionManager.GetSelectedObjectCount2(-1), default=0
+                )
+                if selected != 2:
+                    raise Exception(
+                        f"Expected 2 selected entities for the mate, got {selected}"
+                    )
+
+                transforms_before = _component_transforms(adapter, assembly)
+                status = _byref_int()
+                mate = adapter._attempt(
+                    lambda: assembly.AddMate5(
+                        _MATE_TYPES[mate_key],
+                        _MATE_ALIGNMENTS[align_key],
+                        False,  # Flip
+                        distance / 1000.0,  # Distance (m)
+                        distance / 1000.0,  # upper limit
+                        distance / 1000.0,  # lower limit
+                        0.0,  # gear ratio numerator
+                        0.0,  # gear ratio denominator
+                        math.radians(float(angle)),
+                        math.radians(float(angle)),
+                        math.radians(float(angle)),
+                        False,  # ForPositioningOnly
+                        False,  # LockRotation
+                        0,  # WidthMateOption
+                        status,
+                    ),
+                    default=None,
+                )
+                adapter._attempt(lambda: model.EditRebuild3(), default=None)
+
+                error_status = getattr(status, "value", None)
+                # swAddMateError_e reports 1 for success on this build (measured:
+                # a mate that demonstrably moved a component returned 1).
+                if mate is None or (error_status not in (None, 1)):
+                    raise Exception(
+                        f"SolidWorks rejected the {mate_key} mate "
+                        f"(error status {error_status!r}). Check the two entities "
+                        "can actually satisfy this mate type."
+                    )
+
+                transforms_after = _component_transforms(adapter, assembly)
+                moved = sorted(
+                    name
+                    for name, matrix in transforms_after.items()
+                    if name in transforms_before and transforms_before[name] != matrix
+                )
+                # An empty snapshot means no transform could be read, which is
+                # not the same as "nothing moved" - report it as unknown rather
+                # than as a negative result the caller would read as fact.
+                comparable = bool(transforms_before and transforms_after)
+                return {
+                    "mate_type": mate_key,
+                    "alignment": align_key,
+                    "components": [component_a, component_b],
+                    "entities": [entity_a, entity_b],
+                    "distance": distance or None,
+                    "angle": angle or None,
+                    "moved_components": moved,
+                    "geometry_moved": bool(moved) if comparable else None,
+                }
+
+            return cast(
+                AdapterResult[dict[str, Any]],
+                adapter._handle_com_operation("add_mate", _mate),
+            )
+
+    async def list_components(self) -> AdapterResult[list[str]]:
+            """List the top-level components of the active assembly.
+
+            Returns:
+                AdapterResult[list[str]]: Component names, or an error when the
+                active document is not an assembly.
+            """
+            adapter = self._adapter(self)
+            if not adapter.currentModel:
+                return AdapterResult(
+                    status=AdapterResultStatus.ERROR, error="No active model"
+                )
+            doc_type = _doc_type(adapter)
+            if doc_type != 2:
+                return AdapterResult(
+                    status=AdapterResultStatus.ERROR,
+                    error=(
+                        "list_components requires an assembly document "
+                        f"(active document type is {doc_type!r}, expected 2)"
+                    ),
+                )
+
+            def _list() -> list[str]:
+                assembly = _sw_type_info.flagged(adapter.currentModel, "IAssemblyDoc")
+                return _component_names(adapter, assembly)
+
+            return cast(
+                AdapterResult[list[str]],
+                adapter._handle_com_operation("list_components", _list),
+            )

--- a/src/solidworks_mcp/tools/modeling.py
+++ b/src/solidworks_mcp/tools/modeling.py
@@ -383,6 +383,76 @@ class CreateAssemblyInput(CompatInput):
     components: list[str] = Field(default_factory=list, description="Component list")
 
 
+class InsertComponentInput(CompatInput):
+    """Input schema for inserting a component into an assembly.
+
+    Attributes:
+        file_path (str): Path to the part or sub-assembly.
+        x (float): X position in millimetres.
+        y (float): Y position in millimetres.
+        z (float): Z position in millimetres.
+    """
+
+    file_path: str = Field(
+        description="Absolute path to the .sldprt or .sldasm to insert"
+    )
+    x: float = Field(default=0.0, description="X position in millimetres")
+    y: float = Field(default=0.0, description="Y position in millimetres")
+    z: float = Field(default=0.0, description="Z position in millimetres")
+
+    def model_post_init(self, __context: Any) -> None:
+        if not self.file_path.strip():
+            raise ValueError("file_path is required")
+
+
+class AddMateInput(CompatInput):
+    """Input schema for mating two assembly components.
+
+    Attributes:
+        component_a (str): First component instance name.
+        component_b (str): Second component instance name.
+        entity_a (str): Named feature on the first component.
+        entity_b (str): Named feature on the second component.
+        mate_type (str): Mate type.
+        alignment (str): Mate alignment.
+        distance (float): Distance in millimetres for a distance mate.
+        angle (float): Angle in degrees for an angle mate.
+    """
+
+    component_a: str = Field(
+        description="First component instance name, as reported by list_components"
+    )
+    component_b: str = Field(description="Second component instance name")
+    entity_a: str = Field(
+        default="Front Plane",
+        description=(
+            "Named feature on the first component. Only tree features "
+            "(reference planes and axes) can be selected"
+        ),
+    )
+    entity_b: str = Field(
+        default="Front Plane", description="Named feature on the second component"
+    )
+    mate_type: str = Field(
+        default="coincident",
+        description=(
+            "coincident, concentric, perpendicular, parallel, tangent, "
+            "distance or angle"
+        ),
+    )
+    alignment: str = Field(
+        default="aligned", description="aligned, anti_aligned or closest"
+    )
+    distance: float = Field(
+        default=0.0, description="Distance in millimetres, for a distance mate"
+    )
+    angle: float = Field(default=0.0, description="Angle in degrees, for an angle mate")
+
+    def model_post_init(self, __context: Any) -> None:
+        if not self.component_a.strip() or not self.component_b.strip():
+            raise ValueError("component_a and component_b are required")
+
+
 class CreateDrawingInput(CompatInput):
     """Input schema for creating a new drawing.
 
@@ -1224,5 +1294,143 @@ async def register_modeling_tools(
             logger.error(f"Error in create_loft tool: {e}")
             return {"status": "error", "message": f"Unexpected error: {str(e)}"}
 
-    tool_count = 12  # Number of tools registered
+    @mcp.tool()
+    async def insert_component(input_data: InsertComponentInput) -> dict[str, Any]:
+        """Insert a part or sub-assembly into the active assembly.
+
+        Call ``create_assembly`` first. Position is in millimetres from the
+        assembly origin.
+
+        **The component file must contain solid geometry** — SolidWorks
+        silently refuses to insert an empty part, so a missing or empty
+        component surfaces as an error rather than a fabricated success.
+
+        Args:
+            input_data (InsertComponentInput): File path and position.
+
+        Returns:
+            dict[str, Any]: Status, the component's instance name and counts.
+
+        Example:
+            ```python
+            await create_assembly({"name": "bracket_asm"})
+            await insert_component({"file_path": "C:/parts/plate.sldprt"})
+            await insert_component({"file_path": "C:/parts/plate.sldprt", "x": 100.0})
+            ```
+        """
+        try:
+            input_data = _normalize_input(input_data, InsertComponentInput)
+            result = await adapter.insert_component(
+                input_data.file_path, input_data.x, input_data.y, input_data.z
+            )
+            if result.is_success:
+                data = result.data if isinstance(result.data, dict) else {}
+                return {
+                    "status": "success",
+                    "message": f"Inserted {data.get('component', 'component')}",
+                    "component": data,
+                    "execution_time": result.execution_time,
+                }
+            return {
+                "status": "error",
+                "message": f"Failed to insert component: {result.error}",
+            }
+        except Exception as e:
+            logger.error(f"Error in insert_component tool: {e}")
+            return {"status": "error", "message": f"Unexpected error: {str(e)}"}
+
+    @mcp.tool()
+    async def add_mate(input_data: AddMateInput) -> dict[str, Any]:
+        """Mate two components in the active assembly.
+
+        Positions components relative to one another — coincident planes to
+        stack or align them, concentric to line up axes, distance to hold a
+        gap.
+
+        Entities are selected by feature name, so only each component's
+        reference planes and axes can be mated. Mating to a specific face or
+        edge needs entity names this adapter cannot enumerate.
+
+        Args:
+            input_data (AddMateInput): Components, entities and mate type.
+
+        Returns:
+            dict[str, Any]: Status and mate details.
+
+        Example:
+            ```python
+            components = await list_components()
+            await add_mate({
+                "component_a": components["components"][0],
+                "component_b": components["components"][1],
+                "mate_type": "coincident",
+            })
+            ```
+        """
+        try:
+            input_data = _normalize_input(input_data, AddMateInput)
+            result = await adapter.add_mate(
+                input_data.component_a,
+                input_data.component_b,
+                input_data.entity_a,
+                input_data.entity_b,
+                input_data.mate_type,
+                input_data.alignment,
+                input_data.distance,
+                input_data.angle,
+            )
+            if result.is_success:
+                data = result.data if isinstance(result.data, dict) else {}
+                message = (
+                    f"Added {input_data.mate_type} mate between "
+                    f"{input_data.component_a} and {input_data.component_b}"
+                )
+                # SolidWorks accepts a mate whose constraint is already
+                # satisfied and moves nothing. That is a real success, but
+                # saying so plainly beats leaving the caller to infer it.
+                if data.get("geometry_moved") is False:
+                    message += (
+                        " (no component moved - the constraint was already "
+                        "satisfied)"
+                    )
+                return {
+                    "status": "success",
+                    "message": message,
+                    "mate": data,
+                    "execution_time": result.execution_time,
+                }
+            return {
+                "status": "error",
+                "message": f"Failed to add mate: {result.error}",
+            }
+        except Exception as e:
+            logger.error(f"Error in add_mate tool: {e}")
+            return {"status": "error", "message": f"Unexpected error: {str(e)}"}
+
+    @mcp.tool()
+    async def list_components() -> dict[str, Any]:
+        """List the top-level components of the active assembly.
+
+        Returns:
+            dict[str, Any]: Status and the component instance names.
+        """
+        try:
+            result = await adapter.list_components()
+            if result.is_success:
+                components = result.data if isinstance(result.data, list) else []
+                return {
+                    "status": "success",
+                    "message": f"{len(components)} component(s) in the assembly",
+                    "components": components,
+                    "execution_time": result.execution_time,
+                }
+            return {
+                "status": "error",
+                "message": f"Failed to list components: {result.error}",
+            }
+        except Exception as e:
+            logger.error(f"Error in list_components tool: {e}")
+            return {"status": "error", "message": f"Unexpected error: {str(e)}"}
+
+    tool_count = 15  # Number of tools registered
     return tool_count

--- a/tests/solidworks_mcp/adapters/test_new_capabilities.py
+++ b/tests/solidworks_mcp/adapters/test_new_capabilities.py
@@ -1,0 +1,264 @@
+"""Contract tests for the assembly capabilities added to the adapter surface.
+
+``insert_component``, ``list_components`` and ``add_mate`` each exist on the
+base adapter, the mock, the circuit breaker and the connection pool. A method
+missing from either wrapper silently degrades to the base "not implemented"
+default at runtime, and mock mode cannot catch it — the mock is not wrapped —
+so the wiring is asserted directly here.
+
+Modeled on ``test_new_capabilities.py`` from the
+``feat/feature-editing-and-breaker-isolation`` branch, scoped to just the
+three capabilities introduced on this branch.
+"""
+
+import inspect
+
+import pytest
+
+from solidworks_mcp.adapters.base import SolidWorksAdapter
+from solidworks_mcp.adapters.circuit_breaker import CircuitBreakerAdapter
+from solidworks_mcp.adapters.connection_pool import ConnectionPoolAdapter
+from solidworks_mcp.adapters.mock_adapter import MockSolidWorksAdapter
+
+#: Capabilities added on this branch.
+CAPABILITIES = [
+    "insert_component",
+    "list_components",
+    "add_mate",
+]
+
+WRAPPERS = [
+    SolidWorksAdapter,
+    MockSolidWorksAdapter,
+    CircuitBreakerAdapter,
+    ConnectionPoolAdapter,
+]
+
+
+@pytest.mark.parametrize("capability", CAPABILITIES)
+@pytest.mark.parametrize("cls", WRAPPERS, ids=lambda c: c.__name__)
+def test_capability_exists_on_every_layer(capability: str, cls: type) -> None:
+    """A capability missing from a wrapper degrades silently at runtime."""
+    method = getattr(cls, capability, None)
+    assert method is not None, f"{cls.__name__} is missing {capability}"
+    assert inspect.iscoroutinefunction(method), (
+        f"{cls.__name__}.{capability} must be async"
+    )
+
+
+@pytest.mark.parametrize("capability", CAPABILITIES)
+def test_real_adapter_resolves_to_the_com_mixin(capability: str) -> None:
+    """PyWin32Adapter must reach the COM implementation, not the base stub.
+
+    The mixin methods are only reachable if they are defined *inside*
+    ``SolidWorksIOMixin``. Written at module scope in ``io.py`` they still
+    import cleanly, still pass every mock test, and still satisfy the
+    layer checks above — but ``PyWin32Adapter`` then resolves the name to
+    ``SolidWorksAdapter``'s "not implemented" default and the real COM code
+    is never called. That happened while building this branch, and only
+    showed up under runtime MRO inspection.
+    """
+    pytest.importorskip("win32com", reason="pywin32 is Windows-only")
+    from solidworks_mcp.adapters.pywin32_adapter import PyWin32Adapter
+
+    owner = next(
+        (klass.__name__ for klass in PyWin32Adapter.__mro__ if capability in vars(klass)),
+        None,
+    )
+    assert owner == "SolidWorksIOMixin", (
+        f"PyWin32Adapter.{capability} resolves to {owner}, not the COM mixin. "
+        "The implementation is unreachable and every call silently returns the "
+        "base adapter's 'not implemented' error."
+    )
+
+
+@pytest.mark.parametrize("capability", CAPABILITIES)
+def test_wrappers_do_not_silently_fall_through_to_base(capability: str) -> None:
+    """The breaker and pool must define their own pass-through, not inherit."""
+    for cls in (CircuitBreakerAdapter, ConnectionPoolAdapter):
+        assert capability in vars(cls), (
+            f"{cls.__name__} inherits {capability} from the base adapter, so "
+            "calls to it return 'not implemented' instead of reaching the real "
+            "adapter"
+        )
+
+
+@pytest.mark.asyncio
+async def test_mock_insert_component_records_and_lists() -> None:
+    """insert_component records state that list_components reflects back."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    first = await adapter.insert_component("C:/parts/a.sldprt")
+    assert first.is_success
+    assert first.data["component"] == "component-1"
+    assert first.data["components_before"] == 0
+    assert first.data["components_after"] == 1
+
+    second = await adapter.insert_component("C:/parts/b.sldprt", x=10.0)
+    assert second.is_success
+    assert second.data["component"] == "component-2"
+    assert second.data["components_before"] == 1
+    assert second.data["components_after"] == 2
+
+    listed = await adapter.list_components()
+    assert listed.is_success
+    assert listed.data == ["component-1", "component-2"]
+
+
+@pytest.mark.asyncio
+async def test_mock_add_mate_reports_the_mate() -> None:
+    """add_mate on the mock reports the components and mate type back."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.add_mate("part-1", "part-2", mate_type="concentric")
+    assert result.is_success
+    assert result.data["components"] == ["part-1", "part-2"]
+    assert result.data["mate_type"] == "concentric"
+
+
+@pytest.mark.asyncio
+async def test_mock_does_not_claim_geometry_moved() -> None:
+    """The mock must not answer the "did it really work" question with True.
+
+    ``geometry_moved`` is the field that separates a mate which positioned
+    a component from one SolidWorks accepted and ignored. The mock has no
+    geometry, so the only honest answer is "not determinable".
+    """
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.add_mate("part-1", "part-2")
+    assert result.is_success
+    assert result.data["geometry_moved"] is None, (
+        "the mock reported a geometry check it cannot perform"
+    )
+    assert result.data["moved_components"] == []
+
+
+def test_mock_mate_types_match_the_com_layer() -> None:
+    """The mock's accepted mate types must match the COM implementation.
+
+    The two lists are maintained separately, so a mate type added to the COM
+    layer alone would be rejected in mock mode and accepted live -- and the
+    whole test suite runs against the mock.
+    """
+    from solidworks_mcp.adapters.solidworks.io import _MATE_TYPES
+
+    source = inspect.getsource(MockSolidWorksAdapter.add_mate)
+    for mate_type in _MATE_TYPES:
+        assert f'"{mate_type}"' in source, (
+            f"the COM layer supports the {mate_type!r} mate but the mock "
+            "rejects it, so no test can cover it"
+        )
+
+
+@pytest.mark.asyncio
+async def test_mock_add_mate_rejects_unknown_mate_type() -> None:
+    """An unknown mate type is a validation error, not a fabricated success."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.add_mate("part-1", "part-2", mate_type="bogus")
+    assert not result.is_success
+
+
+@pytest.mark.asyncio
+async def test_base_defaults_report_missing_capability() -> None:
+    """The base adapter's defaults name the missing capability, not a fabrication."""
+
+    class _BareAdapter(SolidWorksAdapter):
+        """Minimal concrete adapter that leaves the new capabilities unimplemented."""
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            return None
+
+        def is_connected(self) -> bool:
+            return False
+
+        async def health_check(self):
+            return None
+
+        async def open_model(self, file_path):
+            return None
+
+        async def close_model(self, save=False):
+            return None
+
+        async def get_model_info(self):
+            return None
+
+        async def list_features(self, include_suppressed=False, max_assembly_depth=2):
+            return None
+
+        async def list_configurations(self):
+            return None
+
+        async def create_part(self, name=None, units=None):
+            return None
+
+        async def create_assembly(self, name=None):
+            return None
+
+        async def create_drawing(self, name=None):
+            return None
+
+        async def create_extrusion(self, params):
+            return None
+
+        async def create_revolve(self, params):
+            return None
+
+        async def create_sweep(self, params):
+            return None
+
+        async def create_loft(self, params):
+            return None
+
+        async def create_sketch(self, plane):
+            return None
+
+        async def add_line(self, x1, y1, x2, y2):
+            return None
+
+        async def add_circle(self, center_x, center_y, radius):
+            return None
+
+        async def add_rectangle(self, x1, y1, x2, y2):
+            return None
+
+        async def exit_sketch(self):
+            return None
+
+        async def get_mass_properties(self):
+            return None
+
+        async def export_image(self, payload):
+            return None
+
+        async def export_file(self, file_path, format_type):
+            return None
+
+        async def get_dimension(self, name):
+            return None
+
+        async def set_dimension(self, name, value):
+            return None
+
+    adapter = _BareAdapter()
+
+    insert_result = await adapter.insert_component("C:/parts/a.sldprt")
+    assert not insert_result.is_success
+    assert "insert_component" in (insert_result.error or "")
+
+    list_result = await adapter.list_components()
+    assert not list_result.is_success
+    assert "list_components" in (list_result.error or "")
+
+    mate_result = await adapter.add_mate("a", "b")
+    assert not mate_result.is_success
+    assert "add_mate" in (mate_result.error or "")

--- a/tests/solidworks_mcp/tools/test_modeling.py
+++ b/tests/solidworks_mcp/tools/test_modeling.py
@@ -6,6 +6,7 @@ import pytest
 
 from solidworks_mcp.tools.modeling import (
     AddFilletInput,
+    AddMateInput,
     CloseModelInput,
     CreateAssemblyInput,
     CreateCutExtrudeInput,
@@ -16,6 +17,7 @@ from solidworks_mcp.tools.modeling import (
     CreateRevolveInput,
     CreateSweepInput,
     GetDimensionInput,
+    InsertComponentInput,
     OpenModelInput,
     SetDimensionInput,
     _result_value,
@@ -32,10 +34,12 @@ class TestModelingTools:
         tool_count = await register_modeling_tools(
             mcp_server, mock_adapter, mock_config
         )
-        assert tool_count == 12
+        assert tool_count == 15
         # The Phase 1 sweep/loft tools must be registered alongside the rest.
         names = {tool.name for tool in await mcp_server.list_tools()}
         assert {"create_sweep", "create_loft"} <= names
+        # Assembly component/mate tools must be registered too.
+        assert {"insert_component", "add_mate", "list_components"} <= names
 
     @pytest.mark.asyncio
     async def test_open_model_success(self, mcp_server, mock_adapter, mock_config):
@@ -429,6 +433,16 @@ class TestModelingTools:
                 depth=-5.0,  # Negative depth should be invalid
             )
 
+        # InsertComponentInput requires a non-empty file_path
+        with pytest.raises(ValueError):
+            InsertComponentInput(file_path="")
+
+        # AddMateInput requires non-empty component names
+        with pytest.raises(ValueError):
+            AddMateInput(component_a="", component_b="part-2")
+        with pytest.raises(ValueError):
+            AddMateInput(component_a="part-1", component_b="")
+
     @pytest.mark.asyncio
     async def test_performance_monitoring(
         self, mcp_server, mock_adapter, mock_config, perf_monitor
@@ -666,3 +680,159 @@ class TestModelingTools:
         )
         assert fillet_result["status"] == "error"
         assert "fillet radius too large" in fillet_result["message"]
+
+
+class TestAssemblyTools:
+    """Test suite for insert_component / list_components / add_mate tools."""
+
+    @pytest.mark.asyncio
+    async def test_insert_component_success(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """insert_component returns success with the expected payload shape."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        await mock_adapter.create_assembly()
+
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "insert_component"
+        )
+        result = await tool_func(InsertComponentInput(file_path="C:/parts/a.sldprt"))
+
+        assert result["status"] == "success"
+        assert result["component"]["component"] == "component-1"
+        assert result["component"]["components_before"] == 0
+        assert result["component"]["components_after"] == 1
+        assert "execution_time" in result
+
+    @pytest.mark.asyncio
+    async def test_add_mate_success(self, mcp_server, mock_adapter, mock_config):
+        """add_mate returns success with mate details in the payload."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        await mock_adapter.create_assembly()
+
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "add_mate"
+        )
+        result = await tool_func(
+            AddMateInput(
+                component_a="part-1", component_b="part-2", mate_type="coincident"
+            )
+        )
+
+        assert result["status"] == "success"
+        assert result["mate"]["components"] == ["part-1", "part-2"]
+        assert result["mate"]["mate_type"] == "coincident"
+
+    @pytest.mark.asyncio
+    async def test_list_components_success_and_reflects_inserts(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """list_components returns exactly what insert_component actually inserted."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        await mock_adapter.create_assembly()
+
+        tool = {
+            registered.name: registered.fn
+            for registered in await mcp_server.list_tools()
+        }
+
+        await tool["insert_component"](InsertComponentInput(file_path="C:/parts/a.sldprt"))
+        await tool["insert_component"](InsertComponentInput(file_path="C:/parts/b.sldprt"))
+
+        result = await tool["list_components"]()
+
+        assert result["status"] == "success"
+        assert result["components"] == ["component-1", "component-2"]
+        assert result["message"] == "2 component(s) in the assembly"
+
+    @pytest.mark.asyncio
+    async def test_insert_component_error_when_adapter_lacks_capability(
+        self, mcp_server, mock_config
+    ):
+        """A bare object() adapter has no insert_component - report error, not a fabrication."""
+        await register_modeling_tools(mcp_server, object(), mock_config)
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "insert_component"
+        )
+        result = await tool_func(InsertComponentInput(file_path="C:/parts/a.sldprt"))
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_add_mate_error_when_adapter_lacks_capability(
+        self, mcp_server, mock_config
+    ):
+        """A bare object() adapter has no add_mate - report error, not a fabrication."""
+        await register_modeling_tools(mcp_server, object(), mock_config)
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "add_mate"
+        )
+        result = await tool_func(AddMateInput(component_a="a-1", component_b="b-1"))
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_list_components_error_when_adapter_lacks_capability(
+        self, mcp_server, mock_config
+    ):
+        """A bare object() adapter has no list_components - report error, not a fabrication."""
+        await register_modeling_tools(mcp_server, object(), mock_config)
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "list_components"
+        )
+        result = await tool_func()
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_insert_component_surfaces_adapter_error(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """A failed adapter result surfaces the adapter's own error message."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        mock_adapter.insert_component = AsyncMock(
+            return_value=Mock(is_success=False, error="no solid geometry")
+        )
+
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "insert_component"
+        )
+        result = await tool_func(InsertComponentInput(file_path="C:/parts/empty.sldprt"))
+
+        assert result["status"] == "error"
+        assert "no solid geometry" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_add_mate_surfaces_adapter_error(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """A failed add_mate adapter result surfaces the adapter's own error."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        mock_adapter.add_mate = AsyncMock(
+            return_value=Mock(is_success=False, error="mate rejected by SolidWorks")
+        )
+
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "add_mate"
+        )
+        result = await tool_func(
+            AddMateInput(component_a="part-1", component_b="part-2")
+        )
+
+        assert result["status"] == "error"
+        assert "mate rejected by SolidWorks" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_list_components_surfaces_adapter_error(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """A failed list_components adapter result surfaces the adapter's own error."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        mock_adapter.list_components = AsyncMock(
+            return_value=Mock(is_success=False, error="not an assembly document")
+        )
+
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "list_components"
+        )
+        result = await tool_func()
+
+        assert result["status"] == "error"
+        assert "not an assembly document" in result["message"]

--- a/tests/test_live_sw_regression.py
+++ b/tests/test_live_sw_regression.py
@@ -2241,3 +2241,81 @@ async def test_list_features_assembly_resolves_real_components_and_subassembly(
         )
     finally:
         adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))
+
+
+@pytest.mark.asyncio
+async def test_assembly_insert_list_and_mate_change_real_geometry(connected_adapter):
+    """Insert two components, list them, and mate them - verified by geometry.
+
+    A tool returning ``status: "success"`` proves nothing here: AddComponent5
+    returns a component object even when it placed nothing, and AddMate5
+    reports success for a mate SolidWorks then ignores. So this asserts on
+    measurements instead:
+
+    - the assembly's volume is exactly twice the part's, which is what a
+      "successful" insert that placed nothing fails
+    - ``list_components`` reports exactly the two that were inserted
+    - the mate changes a component's ``Transform2`` matrix, which is what an
+      accepted-but-ignored mate fails
+    """
+    import tempfile
+    from pathlib import Path
+
+    from solidworks_mcp.adapters.base import ExtrusionParameters
+
+    adapter = connected_adapter
+    part_path = Path(tempfile.mkdtemp(prefix="swmcp_asm_")) / "block.SLDPRT"
+
+    try:
+        # 80 x 40 x 10 mm = 32000 mm^3
+        await adapter.create_part()
+        await adapter.create_sketch("Top")
+        await adapter.add_rectangle(-40.0, -20.0, 40.0, 20.0)
+        await adapter.exit_sketch()
+        await adapter.create_extrusion(ExtrusionParameters(depth=10.0))
+
+        part_props = await adapter.get_mass_properties()
+        assert part_props.is_success, part_props.error
+        part_volume = part_props.data.volume
+        assert part_volume == pytest.approx(32000.0, rel=1e-6), part_volume
+
+        saved = await adapter.save_file(str(part_path))
+        assert saved.is_success, saved.error
+        assert part_path.exists()
+
+        created = await adapter.create_assembly()
+        assert created.is_success, created.error
+
+        first = await adapter.insert_component(str(part_path), 0.0, 0.0, 0.0)
+        assert first.is_success, first.error
+        second = await adapter.insert_component(str(part_path), 0.1, 0.0, 0.06)
+        assert second.is_success, second.error
+
+        listed = await adapter.list_components()
+        assert listed.is_success, listed.error
+        assert len(listed.data) == 2, listed.data
+
+        asm_props = await adapter.get_mass_properties()
+        assert asm_props.is_success, asm_props.error
+        assert asm_props.data.volume == pytest.approx(2 * part_volume, rel=1e-6), (
+            f"assembly volume {asm_props.data.volume} is not twice the part "
+            f"volume {part_volume} - an insert reported success but placed "
+            f"nothing"
+        )
+
+        mated = await adapter.add_mate(listed.data[0], listed.data[1])
+        assert mated.is_success, mated.error
+        assert mated.data["geometry_moved"] is True, (
+            f"add_mate reported success but no component transform changed: "
+            f"{mated.data}"
+        )
+        assert mated.data["moved_components"], mated.data
+
+        after = await adapter.get_mass_properties()
+        assert after.is_success, after.error
+        assert after.data.volume == pytest.approx(2 * part_volume, rel=1e-6), (
+            "the mate changed the assembly's volume, so it moved more than "
+            "position"
+        )
+    finally:
+        adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))


### PR DESCRIPTION
## What

The server can create an assembly but cannot put anything in one. This adds
the three capabilities that make assemblies usable:

| Tool | What it does |
|------|--------------|
| `insert_component(file_path, x, y, z)` | Add a part or sub-assembly at a position |
| `list_components()` | The top-level component instance names |
| `add_mate(component_a, component_b, ...)` | Mate two components — 7 mate types, 3 alignments |

This complements #50 rather than overlapping it. That PR added assembly
traversal to `list_features`, which walks the component tree of an assembly
someone already built by hand; nothing in the server could build one.

## Verified against real SolidWorks, by geometry

Both COM calls report success when they have done nothing, so neither return
value is trusted:

- **`AddComponent5` returns a component object even when it placed nothing.**
  A part with no solid body is refused silently. `insert_component` therefore
  compares the component count before and after and raises if it did not grow.
- **`AddMate5` reports success for a mate SolidWorks then ignores.** `add_mate`
  snapshots every component's `IComponent2::Transform2` before and after and
  reports which components actually moved.

Live proof — build an 80×40×10 mm block (32000 mm³), save it, insert it twice
into a new assembly:

```
part volume:            32000.0
list_components:        count=2
assembly volume:        64000.0
volume ratio:           2.0000      <- an insert that placed nothing fails here
add_mate:               success
    geometry_moved:     True
    moved_components:   ['block-2']  <- an ignored mate fails here
volume after mate:      64000.0
```

That run is committed as a `solidworks_only` regression test in
`tests/test_live_sw_regression.py`.

## Notes for review

- **`OpenDoc6` must load the component before `AddComponent5` can place it**,
  and its `errors`/`warnings` out-parameters have to be byref VARIANTs. With
  `pythoncom.Missing` it returns `None`, the part stays unloaded, and every
  `AddComponent` overload then does nothing while still reporting success.
- **`geometry_moved` is `None`, not `True`, when no transform could be read** —
  and the mock returns `None` for the same reason. That field exists so a
  caller can tell a mate that positioned something from one that was accepted
  and ignored; a mock that always answered `True` would make the check
  worthless everywhere mock mode runs.
- Wired through all five layers plus tool registration (12 → 15 tools in
  `modeling.py`).
- `test_new_capabilities.py` asserts the wiring, including that
  `PyWin32Adapter` resolves each name to `SolidWorksIOMixin`. Written at module
  scope in `io.py` these methods still import cleanly, still pass every mock
  test, and still satisfy the per-layer checks — but the adapter then resolves
  them to the base "not implemented" stub and the COM code never runs. That
  happened while building this branch, which is why the guard is there.

## Test results

- 1888 passed serially, 1888 under `-n auto --dist=worksteal`
- Coverage 98.04%
- `ruff check src tests` unchanged at the 14 findings already on `main`
- Live regression test passes against SolidWorks 2025