### PR TITLE
feat(drawing): place views and notes on a drawing

### DIFF
--- a/src/solidworks_mcp/adapters/base.py
+++ b/src/solidworks_mcp/adapters/base.py
@@ -1032,6 +1032,84 @@ class SolidWorksAdapter(ABC):
             error="add_mate is not implemented by this adapter",
         )
 
+    # Drawing Operations
+    async def create_drawing_view(
+        self, payload: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Place a view of a model on the active drawing sheet.
+
+        Args:
+            payload (Any): Tool payload carrying the model path, orientation,
+                position in millimetres and optional view scale.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The new view's details, or error.
+        """
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="create_drawing_view is not implemented by this adapter",
+        )
+
+    async def add_drawing_view(
+        self, payload: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Add a view of a model to the active drawing sheet.
+
+        Args:
+            payload (Any): Tool payload carrying the model path, orientation,
+                position in millimetres and optional view scale.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The new view's details, or error.
+        """
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="add_drawing_view is not implemented by this adapter",
+        )
+
+    async def create_technical_drawing(
+        self, payload: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Lay out the standard views of a model on the active sheet.
+
+        Args:
+            payload (Any): Tool payload carrying the model path and the
+                projection angle.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The view names created, or error.
+        """
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="create_technical_drawing is not implemented by this adapter",
+        )
+
+    async def add_note(self, payload: Any = None) -> AdapterResult[dict[str, Any]]:
+        """Place a text note on the active drawing sheet.
+
+        Args:
+            payload (Any): Tool payload carrying the note text, its position in
+                millimetres and an optional font size in points.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The note's details, or error.
+        """
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="add_note is not implemented by this adapter",
+        )
+
+    async def list_drawing_views(self) -> AdapterResult[list[str]]:
+        """List the views on the active drawing.
+
+        Returns:
+            AdapterResult[list[str]]: View names, or error.
+        """
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="list_drawing_views is not implemented by this adapter",
+        )
+
     @abstractmethod
     async def exit_sketch(self) -> AdapterResult[None]:
         """Exit sketch editing mode.

--- a/src/solidworks_mcp/adapters/circuit_breaker.py
+++ b/src/solidworks_mcp/adapters/circuit_breaker.py
@@ -1061,6 +1061,84 @@ class CircuitBreakerAdapter(SolidWorksAdapter):
             input_dict={},
         )
 
+    async def create_drawing_view(
+        self, payload: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Create a drawing view through circuit breaker.
+
+        Args:
+            payload (Any): Tool payload for the drawing view.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_circuit_breaker(
+            "create_drawing_view",
+            lambda: self.adapter.create_drawing_view(payload),
+            input_dict=payload if isinstance(payload, dict) else {},
+        )
+
+    async def add_drawing_view(
+        self, payload: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Add a drawing view through circuit breaker.
+
+        Args:
+            payload (Any): Tool payload for the drawing view.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_circuit_breaker(
+            "add_drawing_view",
+            lambda: self.adapter.add_drawing_view(payload),
+            input_dict=payload if isinstance(payload, dict) else {},
+        )
+
+    async def create_technical_drawing(
+        self, payload: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Create standard views through circuit breaker.
+
+        Args:
+            payload (Any): Tool payload for the technical drawing.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_circuit_breaker(
+            "create_technical_drawing",
+            lambda: self.adapter.create_technical_drawing(payload),
+            input_dict=payload if isinstance(payload, dict) else {},
+        )
+
+    async def add_note(self, payload: Any = None) -> AdapterResult[dict[str, Any]]:
+        """Add a drawing note through circuit breaker.
+
+        Args:
+            payload (Any): Tool payload for the note.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_circuit_breaker(
+            "add_note",
+            lambda: self.adapter.add_note(payload),
+            input_dict=payload if isinstance(payload, dict) else {},
+        )
+
+    async def list_drawing_views(self) -> AdapterResult[list[str]]:
+        """List drawing views through circuit breaker.
+
+        Returns:
+            AdapterResult[list[str]]: The result produced by the operation.
+        """
+        return await self._execute_with_circuit_breaker(
+            "list_drawing_views",
+            lambda: self.adapter.list_drawing_views(),
+            input_dict={},
+        )
+
     async def add_mate(
         self,
         component_a: str,

--- a/src/solidworks_mcp/adapters/connection_pool.py
+++ b/src/solidworks_mcp/adapters/connection_pool.py
@@ -998,6 +998,75 @@ class ConnectionPoolAdapter(SolidWorksAdapter):
             "list_components", lambda adapter: adapter.list_components()
         )
 
+    async def create_drawing_view(
+        self, payload: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Create a drawing view using pool.
+
+        Args:
+            payload (Any): Tool payload for the drawing view.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_pool(
+            "create_drawing_view", lambda adapter: adapter.create_drawing_view(payload)
+        )
+
+    async def add_drawing_view(
+        self, payload: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Add a drawing view using pool.
+
+        Args:
+            payload (Any): Tool payload for the drawing view.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_pool(
+            "add_drawing_view", lambda adapter: adapter.add_drawing_view(payload)
+        )
+
+    async def create_technical_drawing(
+        self, payload: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Create standard views using pool.
+
+        Args:
+            payload (Any): Tool payload for the technical drawing.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_pool(
+            "create_technical_drawing",
+            lambda adapter: adapter.create_technical_drawing(payload),
+        )
+
+    async def add_note(self, payload: Any = None) -> AdapterResult[dict[str, Any]]:
+        """Add a drawing note using pool.
+
+        Args:
+            payload (Any): Tool payload for the note.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_pool(
+            "add_note", lambda adapter: adapter.add_note(payload)
+        )
+
+    async def list_drawing_views(self) -> AdapterResult[list[str]]:
+        """List drawing views using pool.
+
+        Returns:
+            AdapterResult[list[str]]: The result produced by the operation.
+        """
+        return await self._execute_with_pool(
+            "list_drawing_views", lambda adapter: adapter.list_drawing_views()
+        )
+
     async def add_mate(
         self,
         component_a: str,

--- a/src/solidworks_mcp/adapters/mock_adapter.py
+++ b/src/solidworks_mcp/adapters/mock_adapter.py
@@ -30,6 +30,27 @@ from .base import (
 )
 from .solidworks.sketch import RELATION_NAME_MAP
 
+#: Orientations the mock accepts for a drawing view. Kept in step with
+#: ``_NAMED_VIEWS`` in ``adapters/solidworks/io.py`` by a test — the two lists
+#: are maintained separately, and an orientation accepted live but rejected
+#: here could never be covered, since the suite runs against the mock.
+_MOCK_NAMED_VIEWS: frozenset[str] = frozenset(
+    {
+        "front",
+        "back",
+        "left",
+        "right",
+        "top",
+        "bottom",
+        "isometric",
+        "iso",
+        "trimetric",
+        "dimetric",
+        "current",
+    }
+)
+
+
 #: Canned assembly component tree used by ``list_features`` when a mock
 #: Assembly's ``_assembly_components`` hasn't been configured by a test.
 #: Two top-level Part components plus one nested sub-assembly one level
@@ -151,6 +172,9 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         # Assembly components inserted via insert_component, keyed by
         # insertion order. See insert_component/list_components/add_mate.
         self._components: list[str] = []
+        # Drawing views placed via create_drawing_view / add_drawing_view /
+        # create_technical_drawing, in sheet order. See list_drawing_views.
+        self._drawing_views: list[str] = []
         self._operation_count = 0
 
         # Configurable simulation delays (in seconds)
@@ -1964,6 +1988,175 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         return AdapterResult(
             status=AdapterResultStatus.SUCCESS,
             data=list(self._components),
+            execution_time=self._delays["model_operation"] / 2,
+        )
+
+    # Drawing Operations
+    def _mock_place_view(self, payload: Any) -> AdapterResult[dict[str, Any]]:
+        """Record a drawing view so ``list_drawing_views`` reflects it.
+
+        Args:
+            payload (Any): Tool payload, as the real adapter receives it.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        data = payload if isinstance(payload, dict) else {}
+        model_path = data.get("model_path") or data.get("model_file")
+        if not model_path:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error="A model path is required (model_path or model_file)",
+            )
+
+        orientation = str(data.get("orientation") or data.get("view_type") or "front")
+        if orientation.strip().lower() not in _MOCK_NAMED_VIEWS:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    f"Unknown orientation '{orientation}'. Use one of: "
+                    f"{', '.join(sorted(_MOCK_NAMED_VIEWS))}."
+                ),
+            )
+
+        before = len(self._drawing_views)
+        self._drawing_views.append(f"Drawing View{before + 1}")
+        self._operation_count += 1
+
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data={
+                "name": self._drawing_views[-1],
+                "model_path": model_path,
+                "orientation": orientation,
+                "position": {
+                    "x": float(data.get("position_x", 100.0)),
+                    "y": float(data.get("position_y", 150.0)),
+                },
+                "views_before": before,
+                "views_after": len(self._drawing_views),
+            },
+            execution_time=self._delays["model_operation"],
+        )
+
+    async def create_drawing_view(
+        self, payload: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Mock placing a view of a model on the active drawing sheet.
+
+        Args:
+            payload (Any): Tool payload carrying the model path and orientation.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        await asyncio.sleep(self._delays["model_operation"])
+        return self._mock_place_view(payload)
+
+    async def add_drawing_view(
+        self, payload: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Mock adding a view of a model to the active drawing sheet.
+
+        Args:
+            payload (Any): Tool payload carrying the model path and orientation.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        await asyncio.sleep(self._delays["model_operation"])
+        return self._mock_place_view(payload)
+
+    async def create_technical_drawing(
+        self, payload: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Mock laying out the three standard views of a model.
+
+        Args:
+            payload (Any): Tool payload carrying the model path and projection.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        await asyncio.sleep(self._delays["model_operation"])
+        data = payload if isinstance(payload, dict) else {}
+        model_path = data.get("model_path") or data.get("model_file")
+        if not model_path:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error="A model path is required (model_path or model_file)",
+            )
+
+        third_angle = bool(data.get("third_angle", True))
+        if str(data.get("projection", "")).lower() in {"first", "first_angle"}:
+            third_angle = False
+
+        before = len(self._drawing_views)
+        added = [f"Drawing View{before + offset}" for offset in (1, 2, 3)]
+        self._drawing_views.extend(added)
+        self._operation_count += 1
+
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data={
+                "views": added,
+                "model_path": model_path,
+                "projection": "third_angle" if third_angle else "first_angle",
+                "views_before": before,
+                "views_after": len(self._drawing_views),
+            },
+            execution_time=self._delays["model_operation"],
+        )
+
+    async def add_note(self, payload: Any = None) -> AdapterResult[dict[str, Any]]:
+        """Mock placing a text note on the active drawing sheet.
+
+        Args:
+            payload (Any): Tool payload carrying the text and position.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        await asyncio.sleep(self._delays["model_operation"])
+        data = payload if isinstance(payload, dict) else {}
+        text = data.get("text")
+        if not text:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR, error="add_note requires text"
+            )
+
+        self._operation_count += 1
+        font_points = float(data.get("font_size") or 0.0)
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data={
+                "text": text,
+                "position": {
+                    "x": float(data.get("position_x", 100.0)),
+                    "y": float(data.get("position_y", 50.0)),
+                },
+                # The real adapter sets this from IAnnotation::SetPosition's
+                # return. Mock mode has no sheet to place anything on, so it
+                # reports "not determinable" rather than claiming success at a
+                # check it never performed.
+                "positioned": None,
+                "font_size_points": font_points or None,
+            },
+            execution_time=self._delays["model_operation"],
+        )
+
+    async def list_drawing_views(self) -> AdapterResult[list[str]]:
+        """Mock listing the views on the active drawing.
+
+        Returns:
+            AdapterResult[list[str]]: The result produced by the operation.
+        """
+        await asyncio.sleep(self._delays["model_operation"] / 2)
+        self._operation_count += 1
+
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data=list(self._drawing_views),
             execution_time=self._delays["model_operation"] / 2,
         )
 

--- a/src/solidworks_mcp/adapters/solidworks/io.py
+++ b/src/solidworks_mcp/adapters/solidworks/io.py
@@ -95,6 +95,109 @@ _MATE_ALIGNMENTS: dict[str, int] = {
 }
 
 
+#: SolidWorks named views. The leading asterisk is part of the name and
+#: ``CreateDrawViewFromModelView3`` rejects the name without it.
+_NAMED_VIEWS: dict[str, str] = {
+    "front": "*Front",
+    "back": "*Back",
+    "left": "*Left",
+    "right": "*Right",
+    "top": "*Top",
+    "bottom": "*Bottom",
+    "isometric": "*Isometric",
+    "iso": "*Isometric",
+    "trimetric": "*Trimetric",
+    "dimetric": "*Dimetric",
+    "current": "*Current",
+}
+
+
+#: Points to millimetres. Note schemas express text height in points.
+_POINTS_TO_MM = 25.4 / 72.0
+
+
+def _payload(data: Any) -> dict[str, Any]:
+    """Coerce a tool payload into a plain dict.
+
+    The drawing tools hand the adapter either a ``model_dump()`` result or a
+    raw dict, depending on the tool. Accept a Pydantic model too, so a direct
+    adapter call from a test or script behaves the same as one through a tool.
+
+    Args:
+        data: A dict, a Pydantic model, or an object with attributes.
+
+    Returns:
+        dict[str, Any]: The payload as a dict; empty when nothing was given.
+    """
+    if data is None:
+        return {}
+    if isinstance(data, dict):
+        return data
+    dump = getattr(data, "model_dump", None)
+    if callable(dump):
+        return cast("dict[str, Any]", dump())
+    return {
+        key: value for key, value in vars(data).items() if not key.startswith("_")
+    }
+
+
+def _first(payload: dict[str, Any], *keys: str, default: Any = None) -> Any:
+    """Return the first key present and not None.
+
+    The drawing tools disagree on field names for the same thing — a model is
+    ``model_path`` on one schema and ``model_file`` on another — so each
+    adapter method accepts every spelling its callers use.
+
+    Args:
+        payload: The tool payload.
+        *keys: Candidate key names, in priority order.
+        default: Returned when no key is present.
+
+    Returns:
+        Any: The first value found, otherwise ``default``.
+    """
+    for key in keys:
+        value = payload.get(key)
+        if value is not None:
+            return value
+    return default
+
+
+def _view_names(adapter: Any, drawing: Any) -> list[str]:
+    """Return the drawing's view names, excluding sheet formats.
+
+    ``CreateDrawViewFromModelView3`` returns ``None`` for a model SolidWorks
+    could not resolve, and ``Create3rdAngleViews2`` returns a bare boolean, so
+    the view list is the ground truth for whether views were really added.
+
+    Args:
+        adapter: A connected ``PyWin32Adapter``.
+        drawing: The drawing document, flagged for ``IDrawingDoc``.
+
+    Returns:
+        list[str]: View names in sheet order.
+    """
+    sheets = adapter._attempt(lambda: drawing.GetViews(), default=None)
+    if not isinstance(sheets, (list, tuple)):
+        return []
+
+    names: list[str] = []
+    for sheet in sheets:
+        views = sheet if isinstance(sheet, (list, tuple)) else [sheet]
+        for index, view in enumerate(views):
+            # GetViews returns (sheet, view, view, ...) per sheet; entry 0 is
+            # the sheet itself, not a drawing view.
+            if index == 0 and isinstance(sheet, (list, tuple)):
+                continue
+            wrapped = _as_com(adapter, view, "IView")
+            if wrapped is None:
+                continue
+            name = adapter._attempt(lambda w=wrapped: w.GetName2(), default=None)
+            if name:
+                names.append(str(name))
+    return names
+
+
 def _component_transforms(adapter: Any, assembly: Any) -> dict[str, tuple[float, ...]]:
     """Snapshot every component's placement, for before/after comparison.
 
@@ -600,15 +703,23 @@ class SolidWorksIOMixin:
             if app is None:
                 raise Exception("SolidWorks application is not connected")
 
-            drw_template = app.GetUserPreferenceStringValue(1)
+            # Slot 10 is swDefaultTemplateDrawing. Slot 1 was read here
+            # before and comes back empty on SW 2025, after which the
+            # fallback did GetUserPreferenceStringValue(0).replace("Part",
+            # "Drawing") on another empty string - so NewDocument got "" and
+            # every drawing operation was unreachable. Measured live on
+            # SW 2025: 8=Part.prtdot, 9=Assembly.asmdot, 10=Drawing.drwdot,
+            # 0-3 all empty.
+            drw_template = self._resolve_template_path([10, 1, 0, 2, 3], ".drwdot")
             if not drw_template:
-                drw_template = app.GetUserPreferenceStringValue(0).replace(
-                    "Part", "Drawing"
-                )
+                raise Exception("No drawing template configured in SolidWorks")
 
             model = app.NewDocument(drw_template, 12, 0.2794, 0.2159)
             if not model:
-                raise Exception("Failed to create new drawing")
+                raise Exception(
+                    f"Failed to create new drawing from template "
+                    f"'{drw_template}'"
+                )
 
             adapter._attempt(lambda: _sw_type_info.flag_doc(model, 3), default=0)
             adapter.currentModel = model
@@ -1509,3 +1620,412 @@ class SolidWorksIOMixin:
                 AdapterResult[list[str]],
                 adapter._handle_com_operation("list_components", _list),
             )
+
+    # ---- Drawings ----------------------------------------------------
+
+    def _require_drawing(self) -> AdapterResult[Any] | None:
+        """Return an error result unless the active document is a drawing.
+
+        Returns:
+            AdapterResult[Any] | None: ``None`` when the active document is a
+            drawing, otherwise the error to hand back.
+        """
+        adapter = self._adapter(self)
+        if not adapter.currentModel:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR, error="No active model"
+            )
+        doc_type = _doc_type(adapter)
+        if doc_type != 3:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    "This operation requires a drawing document "
+                    f"(active document type is {doc_type!r}, expected 3). "
+                    "Call create_drawing first."
+                ),
+            )
+        return None
+
+    def _place_view(self, payload: Any) -> AdapterResult[dict[str, Any]]:
+        """Place one named view of a model on the active drawing sheet.
+
+        Shared by ``create_drawing_view`` and ``add_drawing_view``, which are
+        two registered tools reaching the same operation through different
+        input schemas.
+
+        Wraps ``IDrawingDoc::CreateDrawViewFromModelView3(ModelName, ViewName,
+        LocX, LocY, LocZ)``. Position is accepted in millimetres and converted
+        to metres. Success is confirmed by the sheet's view count going up:
+        the call returns ``None`` for a model SolidWorks could not resolve, so
+        its return value proves nothing on its own.
+
+        Args:
+            payload: Tool payload. Reads ``model_path``/``model_file``,
+                ``orientation``/``view_type``, ``position_x``/``position_y``
+                (or a two-element ``position``), and ``scale``.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The new view's name and position.
+        """
+        adapter = self._adapter(self)
+        guard = self._require_drawing()
+        if guard is not None:
+            return cast("AdapterResult[dict[str, Any]]", guard)
+
+        data = _payload(payload)
+        model_path = _first(data, "model_path", "model_file", "path")
+        if not model_path:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error="A model path is required (model_path or model_file)",
+            )
+
+        path = os.path.abspath(str(model_path))
+        if not os.path.exists(path):
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=f"Model file not found: {model_path}",
+            )
+
+        position = data.get("position")
+        if isinstance(position, (list, tuple)) and len(position) >= 2:
+            x, y = float(position[0]), float(position[1])
+        else:
+            x = float(_first(data, "position_x", "x", default=100.0))
+            y = float(_first(data, "position_y", "y", default=150.0))
+
+        requested = str(_first(data, "orientation", "view_type", default="front"))
+        view_name = _NAMED_VIEWS.get(requested.strip().lower())
+        if view_name is None and requested.startswith("*"):
+            view_name = requested
+        if view_name is None:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    f"Unknown orientation '{requested}'. Use one of: "
+                    f"{', '.join(sorted(_NAMED_VIEWS))}, or a raw '*Name'."
+                ),
+            )
+
+        try:
+            scale = float(_first(data, "scale", default=0.0) or 0.0)
+        except (TypeError, ValueError):
+            # The DrawingCreationInput schema types scale as a string ratio
+            # ("1:1"), which is not a view scale factor. Ignore it rather than
+            # failing the whole call over a display preference.
+            scale = 0.0
+
+        def _add() -> dict[str, Any]:
+            drawing = _sw_type_info.flagged(adapter.currentModel, "IDrawingDoc")
+            before = _view_names(adapter, drawing)
+
+            # The model has to be loaded before a view of it can be placed,
+            # and OpenDoc6's errors/warnings out-params must be byref VARIANTs
+            # - with pythoncom.Missing it returns None, the model stays
+            # unloaded, and CreateDrawViewFromModelView3 then silently makes
+            # no view.
+            app = adapter.swApp
+            doc_type = 2 if path.lower().endswith(".sldasm") else 1
+            opened = adapter._attempt(
+                lambda: app.OpenDoc6(
+                    path, doc_type, 1, "", _byref_int(), _byref_int()
+                ),
+                default=None,
+            )
+            if not opened:
+                raise Exception(
+                    f"Could not load '{model_path}' - OpenDoc6 returned nothing."
+                )
+
+            # Opening the model made it active; the drawing has to be active
+            # again before a view can be added to it.
+            drawing_title = adapter._attempt(
+                lambda: _sw_type_info.flagged(
+                    adapter.currentModel, "IModelDoc2"
+                ).GetTitle(),
+                default=None,
+            )
+            if drawing_title:
+                adapter._attempt(
+                    lambda: app.ActivateDoc3(drawing_title, False, 0, _byref_int()),
+                    default=None,
+                )
+
+            view = adapter._attempt(
+                lambda: drawing.CreateDrawViewFromModelView3(
+                    path, view_name, x / 1000.0, y / 1000.0, 0.0
+                ),
+                default=None,
+            )
+
+            after = _view_names(adapter, drawing)
+            if len(after) <= len(before):
+                raise Exception(
+                    f"View was not created - the sheet still has {len(after)} "
+                    f"view(s). Check that '{model_path}' opens on its own and "
+                    f"that '{view_name}' is a valid named view for it."
+                )
+
+            added = [n for n in after if n not in before]
+            new_view = added[-1] if added else after[-1]
+
+            scale_applied = False
+            if scale and view is not None:
+                wrapped = _as_com(adapter, view, "IView")
+                if wrapped is not None:
+                    scale_applied = (
+                        adapter._attempt(
+                            lambda: setattr(wrapped, "ScaleRatio", [scale, 1.0]),
+                            default=None,
+                        )
+                        is not None
+                    )
+
+            return {
+                "name": new_view,
+                "model_path": path,
+                "orientation": view_name,
+                "position": {"x": x, "y": y},
+                "scale": scale or None,
+                "scale_applied": scale_applied if scale else None,
+                "views_before": len(before),
+                "views_after": len(after),
+            }
+
+        return cast(
+            AdapterResult[dict[str, Any]],
+            adapter._handle_com_operation("create_drawing_view", _add),
+        )
+
+    async def create_drawing_view(
+        self, payload: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Place a view of a model on the active drawing sheet.
+
+        Args:
+            payload: Tool payload; see ``_place_view``.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The new view's name and position.
+
+        Example::
+
+            await adapter.create_drawing_view(
+                {"model_path": r"C:\\parts\\bracket.sldprt", "orientation": "front"}
+            )
+        """
+        return self._place_view(payload)
+
+    async def add_drawing_view(
+        self, payload: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Add a view of a model to the active drawing sheet.
+
+        The same operation as ``create_drawing_view``; both tool entry points
+        exist upstream and reach this one implementation.
+
+        Args:
+            payload: Tool payload; see ``_place_view``.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The new view's name and position.
+        """
+        return self._place_view(payload)
+
+    async def create_technical_drawing(
+        self, payload: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Lay out the three standard views of a model on the active sheet.
+
+        Wraps ``IDrawingDoc::Create3rdAngleViews2`` (or
+        ``Create1stAngleViews2``), which places front, top and side in one
+        call. Both return a bare boolean, so the view list before and after is
+        what actually confirms the views exist.
+
+        Args:
+            payload: Tool payload. Reads ``model_path``/``model_file`` and
+                ``third_angle`` (default ``True``; ``projection`` set to
+                ``"first_angle"`` selects the other).
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The view names that appeared.
+
+        Example::
+
+            await adapter.create_technical_drawing(
+                {"model_file": r"C:\\parts\\bracket.sldprt"}
+            )
+        """
+        adapter = self._adapter(self)
+        guard = self._require_drawing()
+        if guard is not None:
+            return cast("AdapterResult[dict[str, Any]]", guard)
+
+        data = _payload(payload)
+        model_path = _first(data, "model_path", "model_file", "path")
+        if not model_path:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error="A model path is required (model_path or model_file)",
+            )
+
+        path = os.path.abspath(str(model_path))
+        if not os.path.exists(path):
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=f"Model file not found: {model_path}",
+            )
+
+        third_angle = bool(data.get("third_angle", True))
+        if str(data.get("projection", "")).lower() in {"first", "first_angle"}:
+            third_angle = False
+
+        def _standard() -> dict[str, Any]:
+            drawing = _sw_type_info.flagged(adapter.currentModel, "IDrawingDoc")
+            before = _view_names(adapter, drawing)
+
+            created = adapter._attempt(
+                lambda: (
+                    drawing.Create3rdAngleViews2(path)
+                    if third_angle
+                    else drawing.Create1stAngleViews2(path)
+                ),
+                default=False,
+            )
+
+            after = _view_names(adapter, drawing)
+            added = [n for n in after if n not in before]
+            if not added:
+                raise Exception(
+                    f"No views were created from '{model_path}' (the call "
+                    f"returned {created!r}). Check the model has solid "
+                    "geometry and opens on its own."
+                )
+
+            return {
+                "views": added,
+                "model_path": path,
+                "projection": "third_angle" if third_angle else "first_angle",
+                "views_before": len(before),
+                "views_after": len(after),
+            }
+
+        return cast(
+            AdapterResult[dict[str, Any]],
+            adapter._handle_com_operation("create_technical_drawing", _standard),
+        )
+
+    async def add_note(self, payload: Any = None) -> AdapterResult[dict[str, Any]]:
+        """Place a text note on the active drawing sheet.
+
+        Wraps ``IModelDoc2::InsertNote(Text)`` and then positions the returned
+        annotation: ``InsertNote`` places the note wherever SolidWorks likes,
+        so the position is applied afterwards via ``IAnnotation::SetPosition``.
+
+        Args:
+            payload: Tool payload. Reads ``text``, ``position_x``/``position_y``
+                (or a two-element ``position``) in millimetres, and
+                ``font_size`` in **points**, matching the tool schema.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The note text and where it landed.
+
+        Example::
+
+            await adapter.add_note(
+                {"text": "MATERIAL: AISI 1018", "position_x": 200.0,
+                 "position_y": 50.0}
+            )
+        """
+        adapter = self._adapter(self)
+        guard = self._require_drawing()
+        if guard is not None:
+            return cast("AdapterResult[dict[str, Any]]", guard)
+
+        data = _payload(payload)
+        text = _first(data, "text", "note", default="")
+        if not text:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error="add_note requires text",
+            )
+
+        position = data.get("position")
+        if isinstance(position, (list, tuple)) and len(position) >= 2:
+            x, y = float(position[0]), float(position[1])
+        else:
+            x = float(_first(data, "position_x", "x", default=100.0))
+            y = float(_first(data, "position_y", "y", default=50.0))
+
+        # The schema expresses font size in points, not millimetres.
+        font_points = float(_first(data, "font_size", default=0.0) or 0.0)
+        font_mm = font_points * _POINTS_TO_MM
+
+        def _add_note() -> dict[str, Any]:
+            model = adapter.currentModel
+            adapter._attempt(lambda: model.ClearSelection2(True), default=None)
+
+            note = adapter._attempt(
+                lambda: model.InsertNote(str(text)), default=None
+            )
+            if note is None:
+                raise Exception(
+                    "InsertNote returned nothing - the note was not created."
+                )
+
+            positioned = False
+            annotation = adapter._attempt(
+                lambda: _sw_type_info.flagged(note, "INote").GetAnnotation(),
+                default=None,
+            )
+            if annotation is not None:
+                positioned = bool(
+                    adapter._attempt(
+                        lambda: _sw_type_info.flagged(
+                            annotation, "IAnnotation"
+                        ).SetPosition(x / 1000.0, y / 1000.0, 0.0),
+                        default=False,
+                    )
+                )
+
+            if font_mm:
+                adapter._attempt(
+                    lambda: _sw_type_info.flagged(note, "INote").SetTextFormat(
+                        0, False, font_mm / 1000.0
+                    ),
+                    default=None,
+                )
+
+            adapter._attempt(lambda: model.EditRebuild3(), default=None)
+            return {
+                "text": text,
+                "position": {"x": x, "y": y},
+                "positioned": positioned,
+                "font_size_points": font_points or None,
+            }
+
+        return cast(
+            AdapterResult[dict[str, Any]],
+            adapter._handle_com_operation("add_note", _add_note),
+        )
+
+    async def list_drawing_views(self) -> AdapterResult[list[str]]:
+        """List the views on the active drawing.
+
+        Returns:
+            AdapterResult[list[str]]: View names, sheet formats excluded.
+        """
+        adapter = self._adapter(self)
+        guard = self._require_drawing()
+        if guard is not None:
+            return cast("AdapterResult[list[str]]", guard)
+
+        def _list_views() -> list[str]:
+            drawing = _sw_type_info.flagged(adapter.currentModel, "IDrawingDoc")
+            return _view_names(adapter, drawing)
+
+        return cast(
+            AdapterResult[list[str]],
+            adapter._handle_com_operation("list_drawing_views", _list_views),
+        )

--- a/tests/solidworks_mcp/adapters/test_drawing_capabilities.py
+++ b/tests/solidworks_mcp/adapters/test_drawing_capabilities.py
@@ -1,0 +1,319 @@
+"""Contract tests for the drawing capabilities added to the adapter surface.
+
+``create_drawing_view``, ``add_drawing_view``, ``create_technical_drawing``,
+``add_note``, ``auto_dimension_view`` and ``list_drawing_views`` each exist on
+the base adapter, the mock, the circuit breaker and the connection pool. A
+method missing from either wrapper silently degrades to the base "not
+implemented" default at runtime, and mock mode cannot catch it — the mock is
+not wrapped — so the wiring is asserted directly here.
+
+The method names are deliberately the ones ``tools/drawing.py`` already gates
+on with ``hasattr(adapter, ...)``. Renaming any of them re-breaks the tools
+without failing a single existing test, so the names are pinned below.
+"""
+
+import inspect
+
+import pytest
+
+from solidworks_mcp.adapters.base import SolidWorksAdapter
+from solidworks_mcp.adapters.circuit_breaker import CircuitBreakerAdapter
+from solidworks_mcp.adapters.connection_pool import ConnectionPoolAdapter
+from solidworks_mcp.adapters.mock_adapter import MockSolidWorksAdapter
+
+#: Capabilities added on this branch. These names are a contract with the
+#: gates in ``tools/drawing.py`` — see the module docstring.
+CAPABILITIES = [
+    "create_drawing_view",
+    "add_drawing_view",
+    "create_technical_drawing",
+    "add_note",
+    "list_drawing_views",
+]
+
+WRAPPERS = [
+    SolidWorksAdapter,
+    MockSolidWorksAdapter,
+    CircuitBreakerAdapter,
+    ConnectionPoolAdapter,
+]
+
+
+@pytest.mark.parametrize("capability", CAPABILITIES)
+@pytest.mark.parametrize("cls", WRAPPERS, ids=lambda c: c.__name__)
+def test_capability_exists_on_every_layer(capability: str, cls: type) -> None:
+    """A capability missing from a wrapper degrades silently at runtime."""
+    method = getattr(cls, capability, None)
+    assert method is not None, f"{cls.__name__} is missing {capability}"
+    assert inspect.iscoroutinefunction(method), (
+        f"{cls.__name__}.{capability} must be async"
+    )
+
+
+@pytest.mark.parametrize("capability", CAPABILITIES)
+def test_real_adapter_resolves_to_the_com_mixin(capability: str) -> None:
+    """PyWin32Adapter must reach the COM implementation, not the base stub.
+
+    The mixin methods are only reachable if they are defined *inside*
+    ``SolidWorksIOMixin``. Written at module scope in ``io.py`` they still
+    import cleanly, still pass every mock test, and still satisfy the layer
+    checks above — but ``PyWin32Adapter`` then resolves the name to
+    ``SolidWorksAdapter``'s "not implemented" default and the real COM code is
+    never called. That happened on the assembly branch and only showed up
+    under runtime MRO inspection.
+    """
+    pytest.importorskip("win32com", reason="pywin32 is Windows-only")
+    from solidworks_mcp.adapters.pywin32_adapter import PyWin32Adapter
+
+    owner = next(
+        (klass.__name__ for klass in PyWin32Adapter.__mro__ if capability in vars(klass)),
+        None,
+    )
+    assert owner == "SolidWorksIOMixin", (
+        f"PyWin32Adapter.{capability} resolves to {owner}, not the COM mixin. "
+        "The implementation is unreachable and every call silently returns the "
+        "base adapter's 'not implemented' error."
+    )
+
+
+@pytest.mark.parametrize("capability", CAPABILITIES)
+def test_wrappers_do_not_silently_fall_through_to_base(capability: str) -> None:
+    """The breaker and pool must define their own pass-through, not inherit."""
+    for cls in (CircuitBreakerAdapter, ConnectionPoolAdapter):
+        assert capability in vars(cls), (
+            f"{cls.__name__} inherits {capability} from the base adapter, so "
+            "calls to it return 'not implemented' instead of reaching the real "
+            "adapter"
+        )
+
+
+#: Capabilities a tool on this branch already reaches. ``tools/drawing.py``
+#: guards each tool with ``hasattr(adapter, "<name>")``, so a rename here
+#: leaves the tool refusing forever with every adapter test still green.
+GATED_ON_THIS_BRANCH = [
+    "add_drawing_view",
+    "create_technical_drawing",
+]
+
+#: Capabilities whose tool gates arrive with the refuse-instead-of-fabricate
+#: change. The names are chosen to match those gates exactly so that neither
+#: branch has to touch ``tools/drawing.py`` — the tools light up when both
+#: land. Until then these adapter methods are reachable only by direct call.
+GATED_ONCE_REFUSAL_PR_LANDS = [
+    "create_drawing_view",
+    "add_note",
+]
+
+
+@pytest.mark.parametrize("capability", GATED_ON_THIS_BRANCH)
+def test_capability_names_match_the_tool_gates(capability: str) -> None:
+    """A tool on this branch must reach the adapter by this exact name."""
+    from pathlib import Path
+
+    import solidworks_mcp.tools.drawing as drawing_tools
+
+    source = Path(drawing_tools.__file__).read_text(encoding="utf-8")
+    assert f'hasattr(adapter, "{capability}")' in source, (
+        f"no tool in drawing.py gates on adapter.{capability}; either the tool "
+        "gate was renamed or this capability is unreachable"
+    )
+
+
+def test_every_capability_is_accounted_for() -> None:
+    """No capability may be added without deciding how a tool reaches it.
+
+    An adapter method no tool can call is dead weight; this forces the choice
+    to be explicit rather than forgotten.
+    """
+    classified = set(GATED_ON_THIS_BRANCH) | set(GATED_ONCE_REFUSAL_PR_LANDS)
+    unclassified = set(CAPABILITIES) - classified - {"list_drawing_views"}
+    assert not unclassified, (
+        f"{sorted(unclassified)} reach no tool and are not recorded as "
+        "pending; add the gate or say why it is deferred"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mock_view_placement_accumulates_and_lists() -> None:
+    """Placing views records state that list_drawing_views reflects back."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    empty = await adapter.list_drawing_views()
+    assert empty.is_success
+    assert empty.data == []
+
+    first = await adapter.create_drawing_view(
+        {"model_path": "C:/parts/a.sldprt", "orientation": "front"}
+    )
+    assert first.is_success
+    assert first.data["views_before"] == 0
+    assert first.data["views_after"] == 1
+
+    second = await adapter.add_drawing_view(
+        {"model_file": "C:/parts/a.sldprt", "view_type": "top"}
+    )
+    assert second.is_success
+    assert second.data["views_after"] == 2
+
+    listed = await adapter.list_drawing_views()
+    assert listed.is_success
+    assert len(listed.data) == 2
+
+
+@pytest.mark.asyncio
+async def test_mock_technical_drawing_adds_three_views() -> None:
+    """create_technical_drawing lays out front, top and side."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.create_technical_drawing(
+        {"model_file": "C:/parts/a.sldprt"}
+    )
+    assert result.is_success
+    assert len(result.data["views"]) == 3
+    assert result.data["projection"] == "third_angle"
+
+    listed = await adapter.list_drawing_views()
+    assert len(listed.data) == 3
+
+
+@pytest.mark.asyncio
+async def test_mock_first_angle_projection_is_honoured() -> None:
+    """A first-angle request must not silently produce third-angle."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.create_technical_drawing(
+        {"model_file": "C:/parts/a.sldprt", "projection": "first_angle"}
+    )
+    assert result.is_success
+    assert result.data["projection"] == "first_angle"
+
+
+@pytest.mark.asyncio
+async def test_mock_does_not_claim_the_note_was_positioned() -> None:
+    """The mock must not answer a placement check it cannot perform.
+
+    ``positioned`` comes from ``IAnnotation::SetPosition`` on the real
+    adapter. The mock has no sheet, so the only honest answer is "not
+    determinable".
+    """
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.add_note({"text": "MATERIAL: AISI 1018"})
+    assert result.is_success
+    assert result.data["positioned"] is None, (
+        "the mock reported a placement check it cannot perform"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mock_rejects_a_note_with_no_text() -> None:
+    """An empty note is a validation error, not a fabricated success."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.add_note({"text": ""})
+    assert not result.is_success
+
+
+@pytest.mark.asyncio
+async def test_mock_rejects_an_unknown_orientation() -> None:
+    """An unknown orientation must fail rather than default to front."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.create_drawing_view(
+        {"model_path": "C:/parts/a.sldprt", "orientation": "sideways"}
+    )
+    assert not result.is_success
+
+
+@pytest.mark.asyncio
+async def test_mock_view_placement_requires_a_model_path() -> None:
+    """A view of nothing is an error, not an empty success."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.create_drawing_view({})
+    assert not result.is_success
+
+
+def test_dimension_import_is_not_claimed_as_a_capability() -> None:
+    """``auto_dimension_view`` is deliberately absent, and must stay absent.
+
+    ``IDrawingDoc::InsertModelAnnotations3`` could not be made to insert
+    anything on SW 2025: it returns ``None`` with the view selected and
+    activated, for both ``swInsertDimensions`` and
+    ``swInsertDimensionsMarkedForDrawing``, with ``AllViews`` either way, on
+    front and top views, against a part carrying a real sketch dimension, and
+    after a ``ForceRebuild3``. ``IView::GetDisplayDimensionCount`` stayed 0
+    throughout.
+
+    Shipping it anyway would mean shipping a capability never observed to
+    work — the exact failure this branch exists to correct. This test fails
+    if someone adds it back without live proof.
+    """
+    from solidworks_mcp.adapters.base import SolidWorksAdapter as _Base
+
+    assert not hasattr(_Base, "auto_dimension_view"), (
+        "auto_dimension_view is back on the adapter surface; it must not "
+        "ship until InsertModelAnnotations3 is shown to insert a dimension "
+        "against real SolidWorks"
+    )
+
+
+def test_mock_orientations_match_the_com_layer() -> None:
+    """The mock's accepted orientations must match the COM implementation.
+
+    The two lists are maintained separately, so an orientation added to the
+    COM layer alone would be rejected in mock mode and accepted live — and the
+    whole test suite runs against the mock.
+    """
+    from solidworks_mcp.adapters.mock_adapter import _MOCK_NAMED_VIEWS
+    from solidworks_mcp.adapters.solidworks.io import _NAMED_VIEWS
+
+    assert set(_NAMED_VIEWS) == set(_MOCK_NAMED_VIEWS), (
+        "orientation lists have drifted between io.py and mock_adapter.py"
+    )
+
+
+def test_payload_helper_accepts_dicts_models_and_none() -> None:
+    """Tools hand the adapter dicts; direct callers may hand it a model."""
+    from solidworks_mcp.adapters.solidworks.io import _first, _payload
+
+    class _Model:
+        def __init__(self) -> None:
+            self.model_path = "C:/parts/a.sldprt"
+
+        def model_dump(self) -> dict[str, str]:
+            return {"model_path": self.model_path}
+
+    assert _payload(None) == {}
+    assert _payload({"a": 1}) == {"a": 1}
+    assert _payload(_Model())["model_path"] == "C:/parts/a.sldprt"
+
+    # model_file and model_path are the same thing on different schemas.
+    assert _first({"model_file": "x"}, "model_path", "model_file") == "x"
+    assert _first({}, "model_path", default="fallback") == "fallback"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("capability", CAPABILITIES)
+async def test_base_defaults_report_missing_capability(capability: str) -> None:
+    """The base defaults name the missing capability, not a fabrication.
+
+    Called unbound: these defaults never touch ``self``, so this avoids
+    standing up a concrete subclass just to reach them.
+    """
+    method = getattr(SolidWorksAdapter, capability)
+    result = await (
+        method(None) if capability == "list_drawing_views" else method(None, {})
+    )
+
+    assert not result.is_success
+    assert capability in (result.error or ""), (
+        f"the default for {capability} does not name the missing capability"
+    )

--- a/tests/solidworks_mcp/tools/test_drawing.py
+++ b/tests/solidworks_mcp/tools/test_drawing.py
@@ -436,14 +436,24 @@ class TestDrawingToolsBranchCoverage:
     # ── create_technical_drawing: no-adapter path with auto_populate_views=False ──
 
     @pytest.mark.asyncio
-    async def test_create_technical_drawing_no_adapter_no_views(
-        self, mcp_server, mock_adapter, mock_config
+    async def test_create_technical_drawing_reports_the_real_outcome(
+        self, mcp_server, mock_adapter, mock_config, monkeypatch
     ):
-        """Create_technical_drawing refuses when the adapter has no
-        create_technical_drawing capability, rather than inventing a drawing."""
+        """An adapter that cannot do the job produces an error, not a fake success.
+
+        This asserted the tool's own refusal message, which is reached only
+        when the adapter has no ``create_technical_drawing`` at all. The base
+        adapter now defines a default for it, so the ``hasattr`` gate always
+        passes and the adapter's error surfaces instead — still an error, and
+        still naming the capability, just raised one layer deeper.
+
+        Hiding the method on the mock leaves that inherited base default in
+        place, which is exactly the path being asserted.
+        """
         await register_drawing_tools(mcp_server, mock_adapter, mock_config)
-        if hasattr(mock_adapter, "create_technical_drawing"):
-            del mock_adapter.create_technical_drawing
+        monkeypatch.delattr(
+            type(mock_adapter), "create_technical_drawing", raising=False
+        )
 
         input_data = DrawingCreationInput(
             model_file="part.sldprt",
@@ -460,7 +470,7 @@ class TestDrawingToolsBranchCoverage:
         )
         result = await tool_func(input_data=input_data)
         assert result["status"] == "error"
-        assert "does not support create_technical_drawing" in result["message"]
+        assert "create_technical_drawing" in result["message"]
 
     @pytest.mark.asyncio
     async def test_create_technical_drawing_adapter_success(
@@ -493,14 +503,19 @@ class TestDrawingToolsBranchCoverage:
     # ── add_drawing_view: no-adapter simulation path ──────────────────────
 
     @pytest.mark.asyncio
-    async def test_add_drawing_view_no_adapter_simulation(
-        self, mcp_server, mock_adapter, mock_config
+    async def test_add_drawing_view_reports_the_real_outcome(
+        self, mcp_server, mock_adapter, mock_config, monkeypatch
     ):
-        """Add_drawing_view refuses when adapter lacks add_drawing_view,
-        rather than inventing a view."""
+        """A view that was never placed is an error, not an echo of the input.
+
+        The base adapter now defines a default for ``add_drawing_view``, so
+        the tool's ``hasattr`` gate always passes and the adapter's own error
+        surfaces rather than the tool's refusal message. Both are errors and
+        both name the capability; the assertion is narrowed to the part that
+        still holds either way.
+        """
         await register_drawing_tools(mcp_server, mock_adapter, mock_config)
-        if hasattr(mock_adapter, "add_drawing_view"):
-            del mock_adapter.add_drawing_view
+        monkeypatch.delattr(type(mock_adapter), "add_drawing_view", raising=False)
 
         input_data = DrawingViewInput(
             drawing_path="part.slddrw",
@@ -517,7 +532,7 @@ class TestDrawingToolsBranchCoverage:
         )
         result = await tool_func(input_data=input_data)
         assert result["status"] == "error"
-        assert "does not support add_drawing_view" in result["message"]
+        assert "add_drawing_view" in result["message"]
 
     # ── add_annotation: adapter error + no-adapter simulation paths ────────
 
@@ -756,7 +771,11 @@ class TestDrawingToolsBranchCoverage:
         """Legacy drawing utility tools refuse rather than inventing a result
         when the adapter has no matching capability (or, for
         create_section_view/create_detail_view/check_drawing_standards, has
-        no capability at all to compute the answer)."""
+        no capability at all to compute the answer).
+
+        ``create_drawing_view`` and ``add_note`` are excluded from that list:
+        the adapter implements them, so they are asserted to reach it.
+        """
         await register_drawing_tools(mcp_server, mock_adapter, mock_config)
         by_name = {t.name: t.fn for t in await mcp_server.list_tools()}
 
@@ -789,10 +808,13 @@ class TestDrawingToolsBranchCoverage:
         auto_dim = await by_name["auto_dimension_view"]({"view_name": "Front"})
         std = await by_name["check_drawing_standards"]({"standard": "ANSI"})
 
-        assert view["status"] == "error"
-        assert "does not support create_drawing_view" in view["message"]
-        assert note["status"] == "error"
-        assert "does not support add_note" in note["message"]
+        # create_drawing_view and add_note are implemented now, so they reach
+        # the adapter instead of being refused. That is the stronger
+        # assertion: the tool's hasattr gate resolves to a real capability.
+        assert view["status"] == "success", view
+        assert "does not support" not in str(view)
+        assert note["status"] == "success", note
+        assert "does not support" not in str(note)
         assert section["status"] == "error"
         assert "section line" in section["message"].lower()
         assert detail["status"] == "error"

--- a/tests/test_live_sw_regression.py
+++ b/tests/test_live_sw_regression.py
@@ -2319,3 +2319,88 @@ async def test_assembly_insert_list_and_mate_change_real_geometry(connected_adap
         )
     finally:
         adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))
+
+
+@pytest.mark.asyncio
+async def test_drawing_views_and_notes_produce_real_artifacts(connected_adapter):
+    """Place views and a note on a drawing - verified by what is on the sheet.
+
+    ``CreateDrawViewFromModelView3`` returns ``None`` for a model SolidWorks
+    could not resolve and ``Create3rdAngleViews2`` returns a bare boolean, so
+    neither return value proves a view exists. This asserts on the sheet's
+    view list instead.
+    """
+    import tempfile
+    from pathlib import Path
+
+    from solidworks_mcp.adapters.base import ExtrusionParameters
+
+    adapter = connected_adapter
+    part_path = Path(tempfile.mkdtemp(prefix="swmcp_dwg_")) / "plate.SLDPRT"
+
+    try:
+        await adapter.create_part()
+        await adapter.create_sketch("Top")
+        await adapter.add_rectangle(-40.0, -20.0, 40.0, 20.0)
+        await adapter.exit_sketch()
+        await adapter.create_extrusion(ExtrusionParameters(depth=10.0))
+        saved = await adapter.save_file(str(part_path))
+        assert saved.is_success, saved.error
+        assert part_path.exists()
+
+        # create_drawing reads template slot 10; slot 1 comes back empty on
+        # SW 2025 and used to leave NewDocument with an empty path.
+        created = await adapter.create_drawing()
+        assert created.is_success, created.error
+
+        empty = await adapter.list_drawing_views()
+        assert empty.is_success, empty.error
+        assert empty.data == [], empty.data
+
+        placed = await adapter.create_drawing_view(
+            {
+                "model_path": str(part_path),
+                "orientation": "front",
+                "position_x": 100.0,
+                "position_y": 150.0,
+            }
+        )
+        assert placed.is_success, placed.error
+        assert placed.data["views_before"] == 0
+        assert placed.data["views_after"] == 1
+        assert placed.data["name"], placed.data
+
+        one = await adapter.list_drawing_views()
+        assert one.is_success, one.error
+        assert len(one.data) == 1, one.data
+        assert one.data[0] == placed.data["name"]
+
+        note = await adapter.add_note(
+            {
+                "text": "MATERIAL: AISI 1018",
+                "position_x": 200.0,
+                "position_y": 50.0,
+                "font_size": 12.0,
+            }
+        )
+        assert note.is_success, note.error
+        assert note.data["positioned"] is True, (
+            f"the note was created but SetPosition did not place it: "
+            f"{note.data}"
+        )
+
+        # Standard views, on a second sheet so the count is unambiguous.
+        second = await adapter.create_drawing()
+        assert second.is_success, second.error
+
+        standard = await adapter.create_technical_drawing(
+            {"model_file": str(part_path)}
+        )
+        assert standard.is_success, standard.error
+        assert len(standard.data["views"]) == 3, standard.data
+
+        three = await adapter.list_drawing_views()
+        assert three.is_success, three.error
+        assert len(three.data) == 3, three.data
+    finally:
+        adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))


### PR DESCRIPTION
Upstream registers twelve drawing tools and can satisfy none of them: the adapter has no drawing capabilities at all, so the server can analyse a drawing but cannot create one. This adds the COM layer for five of them.

- create_drawing_view / add_drawing_view - place a named view of a model
- create_technical_drawing - front, top and side in one call
- add_note - a text note, positioned on the sheet
- list_drawing_views - what is actually on the sheet

The names are deliberately the ones tools/drawing.py already gates on with hasattr(adapter, ...). That way this branch does not touch drawing.py at all, which keeps it clear of the refuse-instead-of-fabricate PR that rewrites 265 lines of that same file. Both can merge in either order.

create_drawing was broken and is fixed here, because nothing else in this change is reachable without it. It read template slot 1, which comes back empty on SW 2025, then fell back to slot 0 with .replace("Part", "Drawing") on another empty string - so NewDocument got "" and every drawing operation failed. Measured live: 8=Part.prtdot, 9=Assembly.asmdot, 10=Drawing.drwdot, slots 0-3 all empty. It now uses the existing _resolve_template_path helper the same way create_part and create_assembly already do.

Verified against real SolidWorks by artifact, not by return code, because neither call is trustworthy: CreateDrawViewFromModelView3 returns None for a model SolidWorks cannot resolve, and Create3rdAngleViews2 returns a bare boolean. Both are checked against the sheet's view list instead. Live: 0 views -> place one -> exactly 1, named back as "Drawing View1"; create_technical_drawing -> exactly 3; add_note -> positioned True from IAnnotation::SetPosition.

Two upstream port bugs were found and not carried over. The reference implementation passed Types=1 to InsertModelAnnotations3, which is swInsertCThreads (cosmetic threads) rather than dimensions, and read the return value as an int when the call returns an array of annotations - so its count was always 0 and it could never have succeeded. It also treated the schema's font_size as millimetres when it is points.

auto_dimension_view is deliberately not included. Its COM call could not be made to insert anything on SW 2025: InsertModelAnnotations3 returns None with the view selected and activated, for swInsertDimensions and for swInsertDimensionsMarkedForDrawing, with AllViews either way, on front and top views, against a part carrying a real sketch dimension, and after a ForceRebuild3 - with GetDisplayDimensionCount stuck at 0 throughout. Shipping it would mean shipping a capability never observed to work. A test pins it out so it cannot return without live proof.

Side effect worth noting: defining base-adapter defaults makes every hasattr(adapter, ...) gate in drawing.py pass, so the tools' "simulation" fallbacks are now unreachable. Those returned status: success with an empty view list, or echoed back a view_name for a view that was never placed. They now surface the adapter's honest error. Two tests that asserted the fabricated behaviour were updated to assert the real one.

Wired through all five layers. test_drawing_capabilities.py asserts the wiring, including that PyWin32Adapter resolves each name to SolidWorksIOMixin - written at module scope in io.py these methods still import, still pass every mock test, and still satisfy the per-layer checks, while the adapter resolves them to the base stub and the COM code never runs.

Live regression test added to tests/test_live_sw_regression.py.

1936 passed serial and under xdist, coverage 96.33%, ruff unchanged at the 14 findings already on main.