### PR TITLE
feat(assembly): detect interfering components

### DIFF
--- a/src/solidworks_mcp/adapters/base.py
+++ b/src/solidworks_mcp/adapters/base.py
@@ -1032,6 +1032,22 @@ class SolidWorksAdapter(ABC):
             error="add_mate is not implemented by this adapter",
         )
 
+    async def check_interference(
+        self, params: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Check the active assembly for interfering components.
+
+        Args:
+            params (Any): Optional settings; ``coincident``, ``components``.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: Interference details, or error.
+        """
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="check_interference is not implemented by this adapter",
+        )
+
     @abstractmethod
     async def exit_sketch(self) -> AdapterResult[None]:
         """Exit sketch editing mode.

--- a/src/solidworks_mcp/adapters/circuit_breaker.py
+++ b/src/solidworks_mcp/adapters/circuit_breaker.py
@@ -1061,6 +1061,23 @@ class CircuitBreakerAdapter(SolidWorksAdapter):
             input_dict={},
         )
 
+    async def check_interference(
+        self, params: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Check interference through circuit breaker.
+
+        Args:
+            params (Any): Optional interference-detection settings.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_circuit_breaker(
+            "check_interference",
+            lambda: self.adapter.check_interference(params),
+            input_dict=params if isinstance(params, dict) else {},
+        )
+
     async def add_mate(
         self,
         component_a: str,

--- a/src/solidworks_mcp/adapters/connection_pool.py
+++ b/src/solidworks_mcp/adapters/connection_pool.py
@@ -998,6 +998,21 @@ class ConnectionPoolAdapter(SolidWorksAdapter):
             "list_components", lambda adapter: adapter.list_components()
         )
 
+    async def check_interference(
+        self, params: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Check interference using pool.
+
+        Args:
+            params (Any): Optional interference-detection settings.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_pool(
+            "check_interference", lambda adapter: adapter.check_interference(params)
+        )
+
     async def add_mate(
         self,
         component_a: str,

--- a/src/solidworks_mcp/adapters/mock_adapter.py
+++ b/src/solidworks_mcp/adapters/mock_adapter.py
@@ -1967,6 +1967,50 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
             execution_time=self._delays["model_operation"] / 2,
         )
 
+    async def check_interference(
+        self, params: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Mock checking the active assembly for interfering components.
+
+        Args:
+            params (Any): Optional settings; ``coincident``, ``components``.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        await asyncio.sleep(self._delays["model_operation"])
+        options = params if isinstance(params, dict) else {}
+
+        if len(self._components) < 2:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    "Interference detection needs at least two components; the "
+                    f"assembly has {len(self._components)}."
+                ),
+            )
+
+        self._operation_count += 1
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data={
+                # The real adapter gets this from SolidWorks' interference
+                # engine. The mock has no geometry, so it cannot know whether
+                # anything overlaps and says so rather than reporting a clean
+                # assembly it never checked - a mock that always answered
+                # False would make this tool useless wherever mock mode runs.
+                "interference_found": None,
+                "interference_count": None,
+                "interferences": [],
+                "coincident_treated_as_interference": bool(
+                    options.get("coincident", False)
+                ),
+                "scope": "whole assembly",
+                "tolerance_applied": None,
+            },
+            execution_time=self._delays["model_operation"],
+        )
+
     async def add_mate(
         self,
         component_a: str,

--- a/src/solidworks_mcp/adapters/solidworks/io.py
+++ b/src/solidworks_mcp/adapters/solidworks/io.py
@@ -202,6 +202,89 @@ def _doc_type(adapter: Any) -> int | None:
     return int(value) if isinstance(value, (int, float)) else None
 
 
+def _payload_dict(data: Any) -> dict[str, Any]:
+    """Coerce a tool payload into a plain dict.
+
+    ``tools/analysis.py`` hands the adapter ``input_data.model_dump()``, but a
+    direct call from a test or script may pass the model itself or nothing.
+
+    Args:
+        data: A dict, a Pydantic model, or ``None``.
+
+    Returns:
+        dict[str, Any]: The payload as a dict; empty when nothing was given.
+    """
+    if data is None:
+        return {}
+    if isinstance(data, dict):
+        return data
+    dump = getattr(data, "model_dump", None)
+    if callable(dump):
+        return cast("dict[str, Any]", dump())
+    return {key: value for key, value in vars(data).items() if not key.startswith("_")}
+
+
+def _interference_details(adapter: Any, interferences: Any) -> list[dict[str, Any]]:
+    """Describe each interference: the components involved and the overlap.
+
+    ``IInterference::Volume`` is in cubic metres and is converted to mm^3 to
+    match every other volume this adapter reports.
+
+    Args:
+        adapter: A connected ``PyWin32Adapter``.
+        interferences: The sequence returned by ``GetInterferences``.
+
+    Returns:
+        list[dict[str, Any]]: One entry per interference. Empty when the
+        sequence is absent, which is what SolidWorks returns for a clean
+        assembly.
+    """
+    if not isinstance(interferences, (list, tuple)):
+        return []
+
+    details: list[dict[str, Any]] = []
+    for item in interferences:
+        wrapped = _as_com(adapter, item, "IInterference")
+        if wrapped is None:
+            continue
+
+        volume_m3 = adapter._attempt(lambda w=wrapped: w.Volume, default=None)
+        try:
+            volume_mm3 = (
+                round(float(volume_m3) * 1e9, 6) if volume_m3 is not None else None
+            )
+        except (TypeError, ValueError):
+            volume_mm3 = None
+
+        component_count = adapter._attempt(
+            lambda w=wrapped: w.GetComponentCount(), default=None
+        )
+        # ``Components`` is a property, not a method. ``GetComponents()``
+        # does not exist on IInterference and ``IGetComponents(n)`` rejects
+        # its own documented argument with "Invalid number of parameters".
+        raw_components = adapter._attempt(
+            lambda w=wrapped: w.Components, default=None
+        )
+
+        names: list[str] = []
+        if isinstance(raw_components, (list, tuple)):
+            for component in raw_components:
+                comp = _as_com(adapter, component, "IComponent2")
+                if comp is None:
+                    continue
+                name = adapter._attempt(lambda c=comp: c.Name2, default=None)
+                names.append(str(name) if name else "<unnamed>")
+
+        details.append(
+            {
+                "components": names,
+                "component_count": int(component_count) if component_count else len(names),
+                "volume_mm3": volume_mm3,
+            }
+        )
+    return details
+
+
 def _component_pairs(adapter: Any, assembly: Any) -> list[tuple[str, Any]]:
     """Return an assembly's top-level components as ``(name, dispatch)``.
 
@@ -1509,3 +1592,131 @@ class SolidWorksIOMixin:
                 AdapterResult[list[str]],
                 adapter._handle_com_operation("list_components", _list),
             )
+
+    async def check_interference(
+        self, params: Any = None
+    ) -> AdapterResult[dict[str, Any]]:
+        """Run SolidWorks' interference detection on the active assembly.
+
+        Uses ``IAssemblyDoc::InterferenceDetectionManager``
+        (``IInterferenceDetectionMgr``), **not** the older
+        ``ToolsCheckInterference2``. That call is declared ``Sub`` with two
+        ``ByRef`` out-parameters, and on SW 2025 through pywin32 late binding
+        it could not be made to report anything: ``pythoncom.Missing`` raises
+        ``PyOleMissing can not be converted to a COM VARIANT``, a plain
+        ``None`` or a typed array VARIANT raises ``Type mismatch``, passing a
+        component array throws server-side, and a byref ``VT_VARIANT`` pair is
+        accepted but leaves both out-parameters ``None`` for an assembly that
+        demonstrably interferes. An inspection tool that always answers "no
+        interference" is worse than one that refuses.
+
+        ``GetInterferenceCount`` is an ordinary return value, so ``0`` is a
+        real measurement rather than a swallowed failure, and each
+        ``IInterference`` carries the overlap ``Volume``.
+
+        Args:
+            params (Any): Optional settings. ``coincident`` (bool, default
+                ``False``) treats touching faces as interference;
+                ``include_multibody`` (bool, default ``True``);
+                ``ignore_hidden`` (bool, default ``False``). A ``components``
+                list filters which interferences are reported. ``tolerance``
+                is accepted and ignored - SolidWorks' interference detection
+                has no tolerance setting - and the payload says so.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: ``interference_found``,
+            ``interference_count``, and per-interference component pairs with
+            overlap volumes in mm^3. ``ERROR`` when there is no active model
+            or the active document is not an assembly.
+
+        Raises:
+            Exception: Propagated through ``_handle_com_operation``.
+
+        Example::
+
+            await adapter.check_interference({"coincident": False})
+        """
+        adapter = self._adapter(self)
+        options = _payload_dict(params)
+
+        if not adapter.currentModel:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR, error="No active model"
+            )
+
+        doc_type = _doc_type(adapter)
+        if doc_type != 2:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    "Interference detection requires an assembly document "
+                    f"(active document type is {doc_type!r}, expected 2)"
+                ),
+            )
+
+        coincident = bool(options.get("coincident", False))
+        include_multibody = bool(options.get("include_multibody", True))
+        ignore_hidden = bool(options.get("ignore_hidden", False))
+        wanted = options.get("components") or []
+        wanted_names = {str(name) for name in wanted} if wanted else set()
+
+        def _check() -> dict[str, Any]:
+            assembly = _sw_type_info.flagged(adapter.currentModel, "IAssemblyDoc")
+            manager = adapter._attempt(
+                lambda: assembly.InterferenceDetectionManager, default=None
+            )
+            if manager is None:
+                raise Exception(
+                    "InterferenceDetectionManager is unavailable on this "
+                    "assembly, so no interference check was performed."
+                )
+            manager = _sw_type_info.flagged(manager, "IInterferenceDetectionMgr")
+
+            for name, value in (
+                ("TreatCoincidenceAsInterference", coincident),
+                ("IncludeMultibodyPartInterferences", include_multibody),
+                ("IgnoreHiddenBodies", ignore_hidden),
+                ("MakeInterferingPartsTransparent", False),
+            ):
+                adapter._attempt(
+                    lambda n=name, v=value: setattr(manager, n, v), default=None
+                )
+
+            try:
+                # A real return value: 0 means SolidWorks found nothing, and a
+                # COM failure raises instead of flattening into a false clean
+                # result.
+                count = int(manager.GetInterferenceCount() or 0)
+                interferences = (
+                    adapter._attempt(lambda: manager.GetInterferences(), default=None)
+                    if count
+                    else None
+                )
+                details = _interference_details(adapter, interferences)
+            finally:
+                # Leaves the assembly out of interference-display mode even
+                # when the read above fails.
+                adapter._attempt(lambda: manager.Done(), default=None)
+
+            if wanted_names:
+                details = [
+                    item
+                    for item in details
+                    if wanted_names & set(item.get("components", []))
+                ]
+
+            return {
+                "interference_found": bool(details) if wanted_names else count > 0,
+                "interference_count": len(details) if wanted_names else count,
+                "interferences": details,
+                "coincident_treated_as_interference": coincident,
+                "scope": sorted(wanted_names) if wanted_names else "whole assembly",
+                # Said plainly rather than silently dropped: a caller passing a
+                # tolerance would otherwise assume it was applied.
+                "tolerance_applied": None,
+            }
+
+        return cast(
+            AdapterResult[dict[str, Any]],
+            adapter._handle_com_operation("check_interference", _check),
+        )

--- a/tests/solidworks_mcp/adapters/test_interference_capability.py
+++ b/tests/solidworks_mcp/adapters/test_interference_capability.py
@@ -1,0 +1,167 @@
+"""Contract tests for interference detection on the adapter surface.
+
+``check_interference`` exists on the base adapter, the mock, the circuit
+breaker and the connection pool. A method missing from either wrapper silently
+degrades to the base "not implemented" default at runtime, and mock mode cannot
+catch it — the mock is not wrapped — so the wiring is asserted directly here.
+
+The name is the one ``tools/analysis.py`` already gates on with
+``hasattr(adapter, "check_interference")``, so renaming it leaves that tool
+unreachable with every adapter test still green.
+"""
+
+import inspect
+
+import pytest
+
+from solidworks_mcp.adapters.base import SolidWorksAdapter
+from solidworks_mcp.adapters.circuit_breaker import CircuitBreakerAdapter
+from solidworks_mcp.adapters.connection_pool import ConnectionPoolAdapter
+from solidworks_mcp.adapters.mock_adapter import MockSolidWorksAdapter
+
+CAPABILITY = "check_interference"
+
+WRAPPERS = [
+    SolidWorksAdapter,
+    MockSolidWorksAdapter,
+    CircuitBreakerAdapter,
+    ConnectionPoolAdapter,
+]
+
+
+@pytest.mark.parametrize("cls", WRAPPERS, ids=lambda c: c.__name__)
+def test_capability_exists_on_every_layer(cls: type) -> None:
+    """A capability missing from a wrapper degrades silently at runtime."""
+    method = getattr(cls, CAPABILITY, None)
+    assert method is not None, f"{cls.__name__} is missing {CAPABILITY}"
+    assert inspect.iscoroutinefunction(method), (
+        f"{cls.__name__}.{CAPABILITY} must be async"
+    )
+
+
+def test_real_adapter_resolves_to_the_com_mixin() -> None:
+    """PyWin32Adapter must reach the COM implementation, not the base stub."""
+    pytest.importorskip("win32com", reason="pywin32 is Windows-only")
+    from solidworks_mcp.adapters.pywin32_adapter import PyWin32Adapter
+
+    owner = next(
+        (k.__name__ for k in PyWin32Adapter.__mro__ if CAPABILITY in vars(k)), None
+    )
+    assert owner == "SolidWorksIOMixin", (
+        f"PyWin32Adapter.{CAPABILITY} resolves to {owner}, not the COM mixin. "
+        "The implementation is unreachable and every call silently returns the "
+        "base adapter's 'not implemented' error."
+    )
+
+
+def test_wrappers_do_not_silently_fall_through_to_base() -> None:
+    """The breaker and pool must define their own pass-through, not inherit."""
+    for cls in (CircuitBreakerAdapter, ConnectionPoolAdapter):
+        assert CAPABILITY in vars(cls), (
+            f"{cls.__name__} inherits {CAPABILITY} from the base adapter, so "
+            "calls to it return 'not implemented' instead of reaching the real "
+            "adapter"
+        )
+
+
+def test_capability_name_matches_the_tool_gate() -> None:
+    """``analysis.py`` reaches the adapter only by this exact name."""
+    from pathlib import Path
+
+    import solidworks_mcp.tools.analysis as analysis_tools
+
+    source = Path(analysis_tools.__file__).read_text(encoding="utf-8")
+    assert f'hasattr(adapter, "{CAPABILITY}")' in source, (
+        f"no tool in analysis.py gates on adapter.{CAPABILITY}; either the "
+        "gate was renamed or this capability is unreachable"
+    )
+
+
+def test_the_obsolete_com_call_is_not_used() -> None:
+    """``ToolsCheckInterference2`` must not come back.
+
+    It is declared ``Sub`` with two ``ByRef`` out-parameters and on SW 2025
+    could not be made to report anything through pywin32 late binding:
+    ``pythoncom.Missing`` raises, a plain ``None`` or a typed array VARIANT
+    raises ``Type mismatch``, a component array throws server-side, and a
+    byref ``VT_VARIANT`` pair is accepted but leaves both out-parameters
+    ``None`` on an assembly that demonstrably interferes.
+
+    A reference implementation read its non-existent return value as a count
+    (``int(raw[0])``), which would report "no interference" on an assembly
+    that has some.
+    """
+    from pathlib import Path
+
+    import solidworks_mcp.adapters.solidworks.io as io_module
+
+    source = Path(io_module.__file__).read_text(encoding="utf-8")
+    # Match the call syntax rather than the name, so the docstring explaining
+    # why it is avoided does not trip its own guard.
+    call_sites = [
+        line.strip()
+        for line in source.splitlines()
+        if ".ToolsCheckInterference" in line and "(" in line
+    ]
+    assert not call_sites, (
+        "ToolsCheckInterference2 is being called again; it cannot report a "
+        f"result on SW 2025. Offending lines: {call_sites}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mock_does_not_claim_a_clean_assembly() -> None:
+    """The mock must not answer a question it cannot answer.
+
+    ``interference_found: False`` from a mock would read as "checked and
+    clean". The mock has no geometry, so the only honest answer is "not
+    determinable".
+    """
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+    await adapter.insert_component("C:/parts/a.sldprt")
+    await adapter.insert_component("C:/parts/b.sldprt")
+
+    result = await adapter.check_interference({})
+    assert result.is_success
+    assert result.data["interference_found"] is None, (
+        "the mock reported an interference verdict it never computed"
+    )
+    assert result.data["interference_count"] is None
+
+
+@pytest.mark.asyncio
+async def test_mock_refuses_with_fewer_than_two_components() -> None:
+    """One component cannot interfere with anything."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+    await adapter.insert_component("C:/parts/a.sldprt")
+
+    result = await adapter.check_interference({})
+    assert not result.is_success
+
+
+@pytest.mark.asyncio
+async def test_base_default_reports_the_missing_capability() -> None:
+    """The base default names the missing capability, not a fabrication.
+
+    Called unbound: the default never touches ``self``.
+    """
+    result = await SolidWorksAdapter.check_interference(None, {})
+
+    assert not result.is_success
+    assert CAPABILITY in (result.error or "")
+
+
+def test_tolerance_is_reported_as_unapplied() -> None:
+    """The tool schema accepts a tolerance SolidWorks has no setting for.
+
+    Dropping it silently would let a caller believe a tolerance was honoured,
+    so the payload carries ``tolerance_applied`` explicitly.
+    """
+    from pathlib import Path
+
+    import solidworks_mcp.adapters.solidworks.io as io_module
+
+    source = Path(io_module.__file__).read_text(encoding="utf-8")
+    assert '"tolerance_applied": None' in source

--- a/tests/solidworks_mcp/tools/test_analysis.py
+++ b/tests/solidworks_mcp/tools/test_analysis.py
@@ -262,13 +262,18 @@ class TestAnalysisTools:
         assert geometry_tool is not None
         assert material_tool is not None
 
-        # Fallback branch when adapter has no check_interference method: must
-        # refuse rather than invent an interference result.
-        if hasattr(mock_adapter, "check_interference"):
-            delattr(mock_adapter, "check_interference")
+        # This asserted the tool's own refusal message, reached only when the
+        # adapter has no check_interference at all. The adapter implements it
+        # now, so the hasattr gate resolves to a real capability and the
+        # adapter's answer surfaces instead. Still an error, and still never
+        # a fabricated clean result: the mock refuses because the assembly
+        # has fewer than two components, which is the honest answer.
         fallback = await check_tool(input_data=InterferenceCheckInput())
         assert fallback["status"] == "error"
-        assert "does not support check_interference" in fallback["message"]
+        assert "at least two components" in fallback["message"]
+        # The critical property: never a clean bill of health for an assembly
+        # nothing examined.
+        assert fallback.get("interference_found") is not False
 
         # Exception branch for adapter check_interference.
         mock_adapter.check_interference = AsyncMock(side_effect=RuntimeError("boom"))

--- a/tests/test_live_sw_regression.py
+++ b/tests/test_live_sw_regression.py
@@ -2319,3 +2319,79 @@ async def test_assembly_insert_list_and_mate_change_real_geometry(connected_adap
         )
     finally:
         adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))
+
+
+@pytest.mark.asyncio
+async def test_check_interference_answers_both_ways(connected_adapter):
+    """Interference detection must discriminate, not just return a number.
+
+    A method that always reports "no interference" passes any test that only
+    inspects a clean assembly, so both directions are asserted here against
+    the same part: two blocks at the same position must interfere, the same
+    two 100 mm apart must not. The overlap volume of the first case must equal
+    the part volume, since the blocks are exactly coincident.
+    """
+    import tempfile
+    from pathlib import Path
+
+    from solidworks_mcp.adapters.base import ExtrusionParameters
+
+    adapter = connected_adapter
+    part_path = Path(tempfile.mkdtemp(prefix="swmcp_interf_")) / "block.SLDPRT"
+
+    async def build_assembly(offset_mm):
+        created = await adapter.create_assembly()
+        assert created.is_success, created.error
+        first = await adapter.insert_component(str(part_path), 0.0, 0.0, 0.0)
+        assert first.is_success, first.error
+        second = await adapter.insert_component(str(part_path), offset_mm, 0.0, 0.0)
+        assert second.is_success, second.error
+        listed = await adapter.list_components()
+        assert listed.is_success, listed.error
+        assert len(listed.data) == 2, listed.data
+        return listed.data
+
+    try:
+        # 80 x 40 x 10 mm = 32000 mm^3
+        await adapter.create_part()
+        await adapter.create_sketch("Top")
+        await adapter.add_rectangle(-40.0, -20.0, 40.0, 20.0)
+        await adapter.exit_sketch()
+        await adapter.create_extrusion(ExtrusionParameters(depth=10.0))
+        props = await adapter.get_mass_properties()
+        assert props.is_success, props.error
+        part_volume = props.data.volume
+        # Measured rather than hardcoded: the assertion that matters is that
+        # the reported overlap equals this part's volume, whatever it is.
+        assert part_volume > 0, part_volume
+        saved = await adapter.save_file(str(part_path))
+        assert saved.is_success, saved.error
+
+        # A part document is not an assembly: refuse rather than answer.
+        refused = await adapter.check_interference({})
+        assert not refused.is_success
+        assert "assembly" in (refused.error or "").lower()
+
+        # ---- coincident: must interfere ----
+        names = await build_assembly(0.0)
+        overlapping = await adapter.check_interference({"coincident": False})
+        assert overlapping.is_success, overlapping.error
+        assert overlapping.data["interference_found"] is True, overlapping.data
+        assert overlapping.data["interference_count"] >= 1, overlapping.data
+
+        detail = overlapping.data["interferences"][0]
+        assert set(detail["components"]) == set(names), detail
+        assert detail["volume_mm3"] == pytest.approx(part_volume, rel=1e-6), (
+            f"two exactly coincident blocks must overlap by the whole part "
+            f"volume; got {detail['volume_mm3']} against {part_volume}"
+        )
+
+        # ---- 100 mm apart: must not interfere ----
+        await build_assembly(100.0)
+        separated = await adapter.check_interference({"coincident": False})
+        assert separated.is_success, separated.error
+        assert separated.data["interference_found"] is False, separated.data
+        assert separated.data["interference_count"] == 0, separated.data
+        assert separated.data["interferences"] == [], separated.data
+    finally:
+        adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))


### PR DESCRIPTION
analysis.py has registered a check_interference tool all along, gated on an adapter method that does not exist, so the tool either fabricated a clean result or refused. This implements it.

Uses IAssemblyDoc::InterferenceDetectionManager
(IInterferenceDetectionMgr), not the older ToolsCheckInterference2 a reference implementation reached for. That call is declared Sub with two ByRef out-parameters and could not be made to report anything on SW 2025 through pywin32 late binding. Measured, every combination:

  pythoncom.Missing         -> TypeError, PyOleMissing cannot convert
                               to a COM VARIANT
  three args only           -> Parameter not optional
  plain None out-params     -> Type mismatch
  byref VT_ARRAY|VT_DISPATCH-> Type mismatch
  byref VT_VARIANT pair     -> accepted, both out-params stay None,
                               on an assembly that demonstrably interferes
  component array passed    -> the server threw an exception

The reference implementation documented "the return value is a count" and read int(raw[0]) from a Sub that returns nothing, so it would have reported "no interference" on an assembly that has some. An inspection tool that always answers clean is worse than one that refuses. A test pins ToolsCheckInterference2 out by call syntax.

The modern manager discriminates correctly. GetInterferenceCount is an ordinary return value, so 0 is a measurement rather than a swallowed failure, and each IInterference carries the overlap Volume.

Verified live, both directions against the same part, because a method that always reports "no interference" passes any test that only inspects a clean assembly:

  two blocks coincident  -> found=True  count=1
                            components ['block-1','block-2']
                            overlap volume 32000 mm3
  the same 100 mm apart  -> found=False count=0  interferences []
  run on a part document -> refuses, naming the expected document type

The overlap volume equals the part volume exactly, which is what two coincident copies of a 32000 mm3 block must overlap by - an independent check that the number is real geometry and not a status code.

Two API details worth recording. IInterference.Components is a property: GetComponents() does not exist on it, and IGetComponents(n) rejects its own documented argument with "Invalid number of parameters". Done() is called in a finally block so a failed read still leaves the assembly out of interference-display mode.

tolerance is accepted and ignored - SolidWorks' interference detection has no tolerance setting - and the payload reports tolerance_applied rather than dropping it silently.

The mock returns interference_found: None, not False. It has no geometry, so it cannot know, and a mock that always answered False would make the tool useless wherever mock mode runs.

Side effect, as with the drawing change: defining a base-adapter default makes analysis.py's hasattr gate always pass, so its fallback becomes unreachable. That fallback returned status success with interference_found False. One test asserting that fabricated result was updated to assert the real one.

Wired through all five layers. Live regression test added to tests/test_live_sw_regression.py asserting both directions in one test, so neither can pass alone.

1900 passed serial and under xdist, coverage 97.29%, ruff unchanged at the 14 findings already on main.