### PR TITLE
feat(features): delete, suppress and undo features

### DIFF
--- a/src/solidworks_mcp/adapters/base.py
+++ b/src/solidworks_mcp/adapters/base.py
@@ -1032,6 +1032,52 @@ class SolidWorksAdapter(ABC):
             error="add_mate is not implemented by this adapter",
         )
 
+    # Feature Editing
+    async def delete_feature(self, name: str) -> AdapterResult[dict[str, Any]]:
+        """Delete a named feature or sketch from the active model.
+
+        Args:
+            name (str): Feature or sketch name.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: What was deleted, or error.
+        """
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="delete_feature is not implemented by this adapter",
+        )
+
+    async def suppress_feature(
+        self, name: str, suppress: bool = True
+    ) -> AdapterResult[dict[str, Any]]:
+        """Suppress or unsuppress a named feature.
+
+        Args:
+            name (str): Feature name.
+            suppress (bool): True to suppress, False to unsuppress.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The resulting state, or error.
+        """
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="suppress_feature is not implemented by this adapter",
+        )
+
+    async def undo(self, count: int = 1) -> AdapterResult[dict[str, Any]]:
+        """Undo the last operations in the active model.
+
+        Args:
+            count (int): Number of steps to undo.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: Whether the tree changed, or error.
+        """
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="undo is not implemented by this adapter",
+        )
+
     @abstractmethod
     async def exit_sketch(self) -> AdapterResult[None]:
         """Exit sketch editing mode.

--- a/src/solidworks_mcp/adapters/circuit_breaker.py
+++ b/src/solidworks_mcp/adapters/circuit_breaker.py
@@ -1061,6 +1061,54 @@ class CircuitBreakerAdapter(SolidWorksAdapter):
             input_dict={},
         )
 
+    async def delete_feature(self, name: str) -> AdapterResult[dict[str, Any]]:
+        """Delete a feature through circuit breaker.
+
+        Args:
+            name (str): Feature or sketch name.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_circuit_breaker(
+            "delete_feature",
+            lambda: self.adapter.delete_feature(name),
+            input_dict={"name": name},
+        )
+
+    async def suppress_feature(
+        self, name: str, suppress: bool = True
+    ) -> AdapterResult[dict[str, Any]]:
+        """Suppress or unsuppress a feature through circuit breaker.
+
+        Args:
+            name (str): Feature name.
+            suppress (bool): True to suppress, False to unsuppress.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_circuit_breaker(
+            "suppress_feature",
+            lambda: self.adapter.suppress_feature(name, suppress),
+            input_dict={"name": name, "suppress": suppress},
+        )
+
+    async def undo(self, count: int = 1) -> AdapterResult[dict[str, Any]]:
+        """Undo through circuit breaker.
+
+        Args:
+            count (int): Number of steps to undo.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_circuit_breaker(
+            "undo",
+            lambda: self.adapter.undo(count),
+            input_dict={"count": count},
+        )
+
     async def add_mate(
         self,
         component_a: str,

--- a/src/solidworks_mcp/adapters/connection_pool.py
+++ b/src/solidworks_mcp/adapters/connection_pool.py
@@ -998,6 +998,49 @@ class ConnectionPoolAdapter(SolidWorksAdapter):
             "list_components", lambda adapter: adapter.list_components()
         )
 
+    async def delete_feature(self, name: str) -> AdapterResult[dict[str, Any]]:
+        """Delete a feature using pool.
+
+        Args:
+            name (str): Feature or sketch name.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_pool(
+            "delete_feature", lambda adapter: adapter.delete_feature(name)
+        )
+
+    async def suppress_feature(
+        self, name: str, suppress: bool = True
+    ) -> AdapterResult[dict[str, Any]]:
+        """Suppress or unsuppress a feature using pool.
+
+        Args:
+            name (str): Feature name.
+            suppress (bool): True to suppress, False to unsuppress.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_pool(
+            "suppress_feature",
+            lambda adapter: adapter.suppress_feature(name, suppress),
+        )
+
+    async def undo(self, count: int = 1) -> AdapterResult[dict[str, Any]]:
+        """Undo using pool.
+
+        Args:
+            count (int): Number of steps to undo.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        return await self._execute_with_pool(
+            "undo", lambda adapter: adapter.undo(count)
+        )
+
     async def add_mate(
         self,
         component_a: str,

--- a/src/solidworks_mcp/adapters/mock_adapter.py
+++ b/src/solidworks_mcp/adapters/mock_adapter.py
@@ -136,6 +136,9 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         self._current_model: SolidWorksModel | None = None
         self._models: dict[str, SolidWorksModel] = {}
         self._features: dict[str, SolidWorksFeature] = {}
+        # Names suppressed via suppress_feature. Kept beside _features rather
+        # than on SolidWorksFeature, which has no suppression field.
+        self._suppressed_features: set[str] = set()
         # Component tree for an Assembly-type current model, keyed by
         # component name. See ``_flatten_assembly_components`` for shape.
         # Empty means "use the canned default fixture" (see list_features).
@@ -1965,6 +1968,123 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
             status=AdapterResultStatus.SUCCESS,
             data=list(self._components),
             execution_time=self._delays["model_operation"] / 2,
+        )
+
+    # Feature Editing
+    async def delete_feature(self, name: str) -> AdapterResult[dict[str, Any]]:
+        """Mock deleting a named feature from the active model.
+
+        Args:
+            name (str): Feature or sketch name.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        await asyncio.sleep(self._delays["model_operation"])
+
+        # _features is keyed by an internal id, so resolve by feature name.
+        before = [f.name for f in self._features.values()]
+        key = next((k for k, f in self._features.items() if f.name == name), None)
+        if key is None:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    f"Feature not found: {name}. "
+                    f"Available: {', '.join(before) or 'none'}"
+                ),
+            )
+
+        del self._features[key]
+        self._suppressed_features.discard(name)
+        self._operation_count += 1
+        after = [f.name for f in self._features.values()]
+
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data={
+                "deleted": name,
+                "removed_features": [n for n in before if n not in after],
+                "features_before": len(before),
+                "features_after": len(after),
+            },
+            execution_time=self._delays["model_operation"],
+        )
+
+    async def suppress_feature(
+        self, name: str, suppress: bool = True
+    ) -> AdapterResult[dict[str, Any]]:
+        """Mock suppressing or unsuppressing a named feature.
+
+        Args:
+            name (str): Feature name.
+            suppress (bool): True to suppress, False to unsuppress.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        await asyncio.sleep(self._delays["model_operation"])
+
+        known = any(f.name == name for f in self._features.values())
+        if not known:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR, error=f"Feature not found: {name}"
+            )
+
+        was = name in self._suppressed_features
+        if suppress:
+            self._suppressed_features.add(name)
+        else:
+            self._suppressed_features.discard(name)
+        self._operation_count += 1
+
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data={
+                "feature": name,
+                "requested": suppress,
+                "suppressed": bool(suppress),
+                "was_suppressed": was,
+            },
+            execution_time=self._delays["model_operation"],
+        )
+
+    async def undo(self, count: int = 1) -> AdapterResult[dict[str, Any]]:
+        """Mock undoing the last operations in the active model.
+
+        Removes the most recently added features, mirroring what an undo of
+        feature-creation steps does to the tree. ``tree_changed`` is ``False``
+        when there was nothing left to undo, which is what the real adapter
+        reports too - SolidWorks accepts an undo on an empty stack quietly.
+
+        Args:
+            count (int): Number of steps to undo.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The result produced by the operation.
+        """
+        await asyncio.sleep(self._delays["model_operation"])
+        steps = max(1, int(count))
+
+        keys = list(self._features)
+        before = [self._features[k].name for k in keys]
+        doomed = keys[-steps:] if steps <= len(keys) else list(keys)
+        removed = [self._features[k].name for k in doomed]
+        for key in doomed:
+            self._suppressed_features.discard(self._features[key].name)
+            del self._features[key]
+        self._operation_count += 1
+        after = [f.name for f in self._features.values()]
+
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data={
+                "requested_steps": steps,
+                "features_before": len(before),
+                "features_after": len(after),
+                "removed_features": removed,
+                "tree_changed": before != after,
+            },
+            execution_time=self._delays["model_operation"],
         )
 
     async def add_mate(

--- a/src/solidworks_mcp/adapters/solidworks/features.py
+++ b/src/solidworks_mcp/adapters/solidworks/features.py
@@ -1,4 +1,4 @@
-"""Feature-domain mixin for PyWin32 SolidWorks operations."""
+﻿"""Feature-domain mixin for PyWin32 SolidWorks operations."""
 
 from __future__ import annotations
 
@@ -54,6 +54,17 @@ class SolidWorksFeaturesMixin:
         self, distance: float, edge_names: list[str]
     ) -> AdapterResult[SolidWorksFeature]:
         return _add_chamfer_impl(self, distance, edge_names)
+
+    async def delete_feature(self, name: str) -> AdapterResult[dict[str, Any]]:
+        return _delete_feature_impl(self, name)
+
+    async def suppress_feature(
+        self, name: str, suppress: bool = True
+    ) -> AdapterResult[dict[str, Any]]:
+        return _suppress_feature_impl(self, name, suppress)
+
+    async def undo(self, count: int = 1) -> AdapterResult[dict[str, Any]]:
+        return _undo_impl(self, count)
 
 
 def _create_extrusion_impl(
@@ -437,7 +448,7 @@ def _select_named_feature(
     Sweep and loft rely on selection marks to tell SolidWorks which selection
     is the profile (1), guide curve (2), or sweep path (4).  We resolve the
     feature with ``IModelDoc2::FeatureByName`` and select it with
-    ``IFeature::Select2(append, mark)`` — the same proven path the rest of the
+    ``IFeature::Select2(append, mark)`` â€” the same proven path the rest of the
     adapter uses for plane/sketch selection.  ``IModelDocExtension::SelectByID2``
     is avoided deliberately: late-bound ``SelectByID2`` raises
     ``Type mismatch`` on some SolidWorks builds, whereas ``FeatureByName`` +
@@ -448,7 +459,7 @@ def _select_named_feature(
         adapter: A connected adapter with a valid ``currentModel``.
         name: Feature name (e.g. ``"Sketch1"`` or ``"Helix/Spiral1"``).  Any
             ``@document`` qualifier is stripped before lookup.
-        mark: Selection mark — 1=profile, 2=guide curve, 4=sweep path.
+        mark: Selection mark â€” 1=profile, 2=guide curve, 4=sweep path.
         append: ``True`` to add to the current selection set, ``False`` to
             replace it.
 
@@ -513,7 +524,7 @@ def _read_member(obj: Any, name: str) -> Any:  # pragma: no cover
 
     Late-bound pywin32 dispatches are inconsistent: an unflagged zero-arg
     accessor may come back as a bound method (needing a call) *or* as the
-    already-resolved value — and when that value is itself a COM object it is
+    already-resolved value â€” and when that value is itself a COM object it is
     also callable, so a naive "call if callable" check wrongly invokes its
     default dispatch (``Member not found``).  This helper calls the member and
     falls back to the raw member if the call raises, so it yields the value in
@@ -739,7 +750,7 @@ def _create_loft_impl(
     """Create a lofted boss/protrusion between two or more profile sketches.
 
     Uses ``IFeatureManager::InsertProtrusionBlend2``.  Each profile named in
-    ``params.profiles`` is selected under mark 1 (in order — the selection
+    ``params.profiles`` is selected under mark 1 (in order â€” the selection
     order determines the loft direction), and any ``params.guide_curves`` are
     selected under mark 2.  Because a solid is produced, every profile must be
     a closed contour.
@@ -874,9 +885,9 @@ def _create_cut_extrude_impl(
 
     Three COM API variants are attempted in order of preference:
 
-    1. ``FeatureCut4`` ΓÇö most modern (SolidWorks 2015+).
-    2. ``FeatureCut3`` modern signature ΓÇö SolidWorks 2010ΓÇô2014.
-    3. ``FeatureCut3`` legacy argument order ΓÇö older installs.
+    1. ``FeatureCut4`` Î“Ã‡Ã¶ most modern (SolidWorks 2015+).
+    2. ``FeatureCut3`` modern signature Î“Ã‡Ã¶ SolidWorks 2010Î“Ã‡Ã´2014.
+    3. ``FeatureCut3`` legacy argument order Î“Ã‡Ã¶ older installs.
 
     All depth values are in millimetres and converted to metres internally.
 
@@ -1012,7 +1023,7 @@ def _create_cut_extrude_impl(
             )
         elif sw_major >= 34:
             # SW 2026+ adds OptimizeGeometry as a 27th INPUT param.
-            # PFeat is an OUT param (PARAMFLAG_FOUT|FRETVAL) — not passed by caller.
+            # PFeat is an OUT param (PARAMFLAG_FOUT|FRETVAL) â€” not passed by caller.
             feature, cut4_error = adapter._attempt_with_error(
                 lambda: feature_manager.FeatureCut4(
                     is_through,  # Sd
@@ -1201,8 +1212,8 @@ def _parse_edge_spec(  # pragma: no cover
     """Parse an edge specification string into (SelectByID2 name, x, y, z).
 
     Supports two formats:
-    - ``"Edge<1>"`` — name-based selection (x=y=z=0.0, SW looks up by topology name)
-    - ``"x,y,z"`` — coordinate-based selection (name="", coordinate hint in metres)
+    - ``"Edge<1>"`` â€” name-based selection (x=y=z=0.0, SW looks up by topology name)
+    - ``"x,y,z"`` â€” coordinate-based selection (name="", coordinate hint in metres)
     """
     parts = edge_name.split(",")
     if len(parts) == 3:
@@ -1230,7 +1241,7 @@ def _select_edge_by_coord(  # pragma: no cover
     improve hit probability on curved edges.
 
     The ``Callout`` parameter of ``SelectByID2`` requires a VT_DISPATCH null
-    VARIANT — passing plain Python ``None`` triggers DISP_E_TYPEMISMATCH.
+    VARIANT â€” passing plain Python ``None`` triggers DISP_E_TYPEMISMATCH.
 
     Returns True if an edge was successfully selected; False otherwise.
     """
@@ -1262,7 +1273,7 @@ def _select_edge_by_coord(  # pragma: no cover
             (x, y * 1.001, z),
         ]
 
-    # VT_DISPATCH null pointer — required by SelectByID2's Callout parameter.
+    # VT_DISPATCH null pointer â€” required by SelectByID2's Callout parameter.
     # Plain Python None marshals as VT_NULL which SW rejects with DISP_E_TYPEMISMATCH.
     try:
         import pythoncom
@@ -1369,7 +1380,7 @@ def _add_fillet_impl(
                 raise Exception(f"Failed to select edge: {edge_name}")
 
         # SW 2025+ (major >= 33): IModelDoc2.FeatureFillet3 (9 params).
-        # Returns a non-zero int on success — NOT an IFeature — so we look up
+        # Returns a non-zero int on success â€” NOT an IFeature â€” so we look up
         # the last modified feature afterwards to get the name/id.
         # Older builds: IFeatureManager.FeatureFillet3 (15 params, returns IFeature).
         if fillet_sw_major >= 33:
@@ -1377,7 +1388,7 @@ def _add_fillet_impl(
                 radius / 1000.0,  # R1 in meters
                 True,  # Propagate (VT_BOOL)
                 0,  # Ftyp (VT_I4)
-                False,  # VarRadTyp (VT_BOOL — must be bool, not int)
+                False,  # VarRadTyp (VT_BOOL â€” must be bool, not int)
                 0,  # OverflowType (VT_I4)
                 0,  # NRadii (VT_I4)
                 None,  # Radii (VT_VARIANT)
@@ -1388,7 +1399,7 @@ def _add_fillet_impl(
                 raise Exception(
                     "Failed to create fillet (IModelDoc2.FeatureFillet3 returned 0)"
                 )
-            feature = None  # int return — retrieve feature object below
+            feature = None  # int return â€” retrieve feature object below
         else:
             feature_manager = adapter.currentModel.FeatureManager
             feature = feature_manager.FeatureFillet3(
@@ -1411,7 +1422,7 @@ def _add_fillet_impl(
             if not feature:
                 raise Exception("Failed to create fillet")
 
-        # Resolve the feature name — FeatureFillet3 on SW 2025+ returns an int,
+        # Resolve the feature name â€” FeatureFillet3 on SW 2025+ returns an int,
         # not an IFeature, so we can only report a default name here.
         feature_name = "Fillet"
         if feature is not None and hasattr(feature, "Name"):
@@ -1533,7 +1544,7 @@ def _add_chamfer_impl(
             adapter.currentModel.FeatureChamferType(
                 0,  # ChamferType: 0 = swChamferType_EqualDistance
                 distance / 1000.0,  # Width in metres
-                math.pi / 4,  # 45° angle
+                math.pi / 4,  # 45Â° angle
                 False,  # Flip
                 0.0,  # OtherDist
                 0.0,  # VertexChamDist1
@@ -1555,7 +1566,7 @@ def _add_chamfer_impl(
                     1,  # Options
                     1,  # ChamferType = equal distance
                     distance / 1000.0,  # Width in metres
-                    math.pi / 4,  # 45° angle
+                    math.pi / 4,  # 45Â° angle
                     0.0,
                     0.0,
                     0.0,
@@ -1581,3 +1592,292 @@ def _add_chamfer_impl(
         AdapterResult[SolidWorksFeature],
         adapter._handle_com_operation("add_chamfer", _chamfer_operation),
     )
+
+
+def _select_feature_by_name(adapter: Any, name: str) -> Any:
+    """Select a feature or sketch by name and return it.
+
+    Resolves the entity with ``IModelDoc2::FeatureByName`` and selects it with
+    ``IFeature::Select2(False, 0)`` - the same path used elsewhere in this
+    adapter. ``SelectByID2`` is avoided here because it needs an entity-type
+    string that differs between sketches and solid features, and because its
+    ``Callout`` argument raises ``Type mismatch`` unless passed an explicit
+    ``VT_DISPATCH`` null. Any ``name@document`` qualifier is stripped first.
+
+    Args:
+        adapter: A connected adapter with a valid ``currentModel``.
+        name: Feature or sketch name, e.g. ``"Boss-Extrude1"`` or ``"Sketch1"``.
+
+    Returns:
+        Any: The selected ``IFeature``, or ``None`` when it does not exist or
+        could not be selected.
+    """
+    bare = name.split("@", 1)[0]
+    adapter._attempt(lambda: adapter.currentModel.ClearSelection2(True), default=None)
+    feature = adapter._attempt(
+        lambda: adapter.currentModel.FeatureByName(bare), default=None
+    )
+    if not feature:
+        return None
+    selected = adapter._attempt(lambda: feature.Select2(False, 0), default=False)
+    return feature if selected else None
+
+
+def _feature_count(adapter: Any) -> int | None:
+    """Return how many features the active model has, or ``None``.
+
+    Used to confirm an edit changed the tree rather than trusting a COM call
+    that reports success without doing anything.
+
+    ``IFeatureManager::GetFeatureCount`` is used rather than walking
+    ``FirstFeature``/``GetNextFeature``: the walk needs each dispatch flagged
+    for ``IFeature`` before ``Name`` and ``GetNextFeature`` resolve, and on
+    SW 2025 it still yields nothing, while the count is a single reliable
+    call. ``FeatureByPositionReverse`` was measured returning nothing usable
+    on the same document.
+
+    Args:
+        adapter: A connected adapter with a valid ``currentModel``.
+
+    Returns:
+        int | None: The feature count, or ``None`` when it cannot be read -
+        which is deliberately distinct from ``0``.
+    """
+    from .. import sw_type_info
+
+    manager = adapter._attempt(
+        lambda: adapter.currentModel.FeatureManager, default=None
+    )
+    if manager is None:
+        return None
+    flagged = sw_type_info.flagged(manager, "IFeatureManager")
+    count = adapter._attempt(lambda: flagged.GetFeatureCount(True), default=None)
+    return int(count) if isinstance(count, (int, float)) else None
+
+
+def _is_suppressed(adapter: Any, feature: Any) -> bool | None:
+    """Return a feature's suppression state, or ``None`` when unreadable.
+
+    ``None`` is deliberately distinct from ``False``: it means the state could
+    not be read, which is not evidence that the feature is unsuppressed.
+
+    Args:
+        adapter: A connected adapter.
+        feature: An ``IFeature`` dispatch.
+
+    Returns:
+        bool | None: ``True`` suppressed, ``False`` not, ``None`` unknown.
+    """
+    state = adapter._attempt(
+        lambda: adapter._get_attr_or_call(feature, "IsSuppressed"), default=None
+    )
+    if isinstance(state, bool):
+        return state
+    if isinstance(state, (list, tuple)) and state:
+        return bool(state[0])
+    if isinstance(state, int):
+        return bool(state)
+    return None
+
+
+def _delete_feature_impl(adapter: Any, name: str) -> AdapterResult[dict[str, Any]]:
+    """Delete a named feature or sketch from the active model.
+
+    Selects the feature, then removes it with ``IModelDoc2::EditDelete``.
+    Deleting a parent also removes its children, which is SolidWorks' normal
+    cascade and the intended "erase this and what depends on it" behaviour -
+    so the number of features removed is reported, not assumed to be one.
+
+    ``EditDelete`` returns nothing useful, so success is confirmed by the
+    feature being absent from the tree afterwards.
+
+    Args:
+        adapter: A connected adapter with a valid ``currentModel``.
+        name: Name of the feature or sketch to delete.
+
+    Returns:
+        AdapterResult[dict[str, Any]]: What was deleted and how the tree
+        changed. ``ERROR`` when there is no model or the feature is absent.
+
+    Raises:
+        Exception: Propagated through ``_handle_com_operation``.
+    """
+    if not adapter.currentModel:
+        return AdapterResult(status=AdapterResultStatus.ERROR, error="No active model")
+
+    def _delete_operation() -> dict[str, Any]:
+        before = _feature_count(adapter)
+        if _select_feature_by_name(adapter, name) is None:
+            raise Exception(f"Feature not found: {name}")
+
+        adapter._attempt(
+            lambda: adapter._get_attr_or_call(adapter.currentModel, "EditDelete"),
+            default=None,
+        )
+        adapter._attempt(lambda: adapter.currentModel.EditRebuild3(), default=None)
+
+        # EditDelete reports nothing useful, so confirm by lookup: the
+        # feature must no longer resolve by name.
+        bare = name.split("@", 1)[0]
+        still_there = adapter._attempt(
+            lambda: adapter.currentModel.FeatureByName(bare), default=None
+        )
+        if still_there:
+            raise Exception(f"EditDelete did not remove feature: {name}")
+
+        after = _feature_count(adapter)
+        return {
+            "deleted": name,
+            "features_before": before,
+            "features_after": after,
+            # Deleting a parent takes its children too, so this is often
+            # more than one.
+            "features_removed": (
+                before - after if before is not None and after is not None else None
+            ),
+        }
+
+    return cast(
+        AdapterResult[dict[str, Any]],
+        adapter._handle_com_operation("delete_feature", _delete_operation),
+    )
+
+
+def _suppress_feature_impl(
+    adapter: Any, name: str, suppress: bool
+) -> AdapterResult[dict[str, Any]]:
+    """Suppress or unsuppress a named feature in the active model.
+
+    Suppressing rolls a feature and its children out of the model without
+    deleting it - the reversible way to turn off a bad feature.
+
+    ``EditSuppress2`` and ``EditUnsuppress2`` report through the error channel
+    only, so the resulting state is read back from ``IFeature::IsSuppressed``
+    rather than inferred from the call returning quietly.
+
+    Args:
+        adapter: A connected adapter with a valid ``currentModel``.
+        name: Feature name to toggle.
+        suppress: ``True`` to suppress, ``False`` to unsuppress.
+
+    Returns:
+        AdapterResult[dict[str, Any]]: The feature and its state afterwards.
+        ``suppressed`` is ``None`` when the state could not be read back,
+        which is not the same as "not suppressed".
+
+    Raises:
+        Exception: Propagated through ``_handle_com_operation``.
+    """
+    if not adapter.currentModel:
+        return AdapterResult(status=AdapterResultStatus.ERROR, error="No active model")
+
+    def _suppress_operation() -> dict[str, Any]:
+        feature = _select_feature_by_name(adapter, name)
+        if feature is None:
+            raise Exception(f"Feature not found: {name}")
+
+        was = _is_suppressed(adapter, feature)
+        # EditSuppress2/EditUnsuppress2 take no arguments, and late binding
+        # resolves them as properties on some dispatches: calling with ()
+        # performs the edit and *then* raises "'bool' object is not callable",
+        # so the operation succeeds while the caller sees a failure.
+        member = "EditSuppress2" if suppress else "EditUnsuppress2"
+        _, err = adapter._attempt_with_error(
+            lambda: adapter._get_attr_or_call(adapter.currentModel, member)
+        )
+        if err is not None:
+            action = "suppress" if suppress else "unsuppress"
+            raise Exception(f"Failed to {action} {name}: {err}")
+
+        adapter._attempt(lambda: adapter.currentModel.EditRebuild3(), default=None)
+
+        # Re-resolve: the dispatch held above can go stale across a rebuild.
+        refreshed = adapter._attempt(
+            lambda: adapter.currentModel.FeatureByName(name.split("@", 1)[0]),
+            default=None,
+        )
+        now = _is_suppressed(adapter, refreshed) if refreshed is not None else None
+        if now is not None and now != suppress:
+            action = "suppressed" if suppress else "unsuppressed"
+            raise Exception(
+                f"{name} reports suppressed={now} after being {action}; the "
+                "call was accepted but the feature state did not change."
+            )
+
+        return {
+            "feature": name,
+            "requested": suppress,
+            "suppressed": now,
+            "was_suppressed": was,
+        }
+
+    return cast(
+        AdapterResult[dict[str, Any]],
+        adapter._handle_com_operation("suppress_feature", _suppress_operation),
+    )
+
+
+def _undo_impl(adapter: Any, count: int) -> AdapterResult[dict[str, Any]]:
+    """Undo the last ``count`` operations in the active model.
+
+    ``IModelDoc2::EditUndo2(Steps)`` is a ``Sub`` - it returns nothing - so a
+    quiet call means only that it was made, not that anything was undone.
+    SolidWorks accepts an undo with an empty stack without complaint. The
+    feature tree is therefore compared before and after, and the payload says
+    plainly whether it changed.
+
+    Args:
+        adapter: A connected adapter with a valid ``currentModel``.
+        count: Number of operations to undo; values below 1 are clamped.
+
+    Returns:
+        AdapterResult[dict[str, Any]]: How many steps were requested and
+        whether the feature tree actually changed.
+
+    Raises:
+        Exception: Propagated through ``_handle_com_operation``.
+    """
+    if not adapter.currentModel:
+        return AdapterResult(status=AdapterResultStatus.ERROR, error="No active model")
+
+    steps = max(1, int(count))
+
+    def _undo_operation() -> dict[str, Any]:
+        before = _feature_count(adapter)
+
+        _, err = adapter._attempt_with_error(
+            lambda: adapter.currentModel.EditUndo2(steps)
+        )
+        if err is not None:
+            # Older builds expose only the unsuffixed overload.
+            _, legacy_err = adapter._attempt_with_error(
+                lambda: adapter.currentModel.EditUndo(steps)
+            )
+            if legacy_err is not None:
+                raise Exception(f"Undo failed: {err} | legacy: {legacy_err}")
+
+        adapter._attempt(lambda: adapter.currentModel.EditRebuild3(), default=None)
+        after = _feature_count(adapter)
+
+        # None means the count could not be read, which is not evidence that
+        # nothing happened - so tree_changed stays None rather than False.
+        changed = (
+            None
+            if before is None or after is None
+            else before != after
+        )
+        return {
+            "requested_steps": steps,
+            "features_before": before,
+            "features_after": after,
+            # False means the call was accepted and the tree is unchanged -
+            # an undo with nothing left to undo. Reported rather than dressed
+            # up as a success.
+            "tree_changed": changed,
+        }
+
+    return cast(
+        AdapterResult[dict[str, Any]],
+        adapter._handle_com_operation("undo", _undo_operation),
+    )
+

--- a/src/solidworks_mcp/tools/modeling.py
+++ b/src/solidworks_mcp/tools/modeling.py
@@ -405,6 +405,42 @@ class InsertComponentInput(CompatInput):
             raise ValueError("file_path is required")
 
 
+class DeleteFeatureInput(CompatInput):
+    """Input schema for deleting a feature.
+
+    Attributes:
+        name (str): Feature or sketch name to delete.
+    """
+
+    name: str = Field(
+        description="Feature or sketch name, e.g. 'Boss-Extrude1' or 'Sketch1'"
+    )
+
+
+class SuppressFeatureInput(CompatInput):
+    """Input schema for suppressing or unsuppressing a feature.
+
+    Attributes:
+        name (str): Feature name to toggle.
+        suppress (bool): True to suppress, False to unsuppress.
+    """
+
+    name: str = Field(description="Feature name, e.g. 'Fillet1'")
+    suppress: bool = Field(
+        default=True, description="True to suppress, False to unsuppress"
+    )
+
+
+class UndoInput(CompatInput):
+    """Input schema for undoing model operations.
+
+    Attributes:
+        count (int): Number of operations to undo.
+    """
+
+    count: int = Field(default=1, ge=1, description="Number of operations to undo")
+
+
 class AddMateInput(CompatInput):
     """Input schema for mating two assembly components.
 
@@ -1432,5 +1468,142 @@ async def register_modeling_tools(
             logger.error(f"Error in list_components tool: {e}")
             return {"status": "error", "message": f"Unexpected error: {str(e)}"}
 
-    tool_count = 15  # Number of tools registered
+    @mcp.tool()
+    async def delete_feature(input_data: DeleteFeatureInput) -> dict[str, Any]:
+        """Delete a feature or sketch from the active model.
+
+        Deleting a parent feature also removes everything that depends on it —
+        SolidWorks' normal cascade — so the response lists every feature that
+        went, not just the one named.
+
+        Args:
+            input_data (DeleteFeatureInput): The feature to delete.
+
+        Returns:
+            dict[str, Any]: Status and what was removed.
+
+        Example:
+            ```python
+            await delete_feature({"name": "Boss-Extrude1"})
+            ```
+        """
+        try:
+            input_data = _normalize_input(input_data, DeleteFeatureInput)
+            result = await adapter.delete_feature(input_data.name)
+            if result.is_success:
+                data = result.data if isinstance(result.data, dict) else {}
+                removed = data.get("removed_features") or [input_data.name]
+                return {
+                    "status": "success",
+                    "message": (
+                        f"Deleted {input_data.name}"
+                        + (
+                            f" and {len(removed) - 1} dependent feature(s)"
+                            if len(removed) > 1
+                            else ""
+                        )
+                    ),
+                    "data": data,
+                    "execution_time": result.execution_time,
+                }
+            return {
+                "status": "error",
+                "message": f"Failed to delete feature: {result.error}",
+            }
+        except Exception as e:
+            logger.error(f"Error in delete_feature tool: {e}")
+            return {"status": "error", "message": f"Unexpected error: {str(e)}"}
+
+    @mcp.tool()
+    async def suppress_feature(input_data: SuppressFeatureInput) -> dict[str, Any]:
+        """Suppress or unsuppress a feature in the active model.
+
+        Suppressing rolls a feature and its children out of the model without
+        deleting it — the reversible way to turn off a feature that is causing
+        trouble.
+
+        Args:
+            input_data (SuppressFeatureInput): The feature and desired state.
+
+        Returns:
+            dict[str, Any]: Status and the resulting suppression state.
+
+        Example:
+            ```python
+            await suppress_feature({"name": "Fillet1"})
+            await suppress_feature({"name": "Fillet1", "suppress": False})
+            ```
+        """
+        try:
+            input_data = _normalize_input(input_data, SuppressFeatureInput)
+            result = await adapter.suppress_feature(
+                input_data.name, input_data.suppress
+            )
+            if result.is_success:
+                data = result.data if isinstance(result.data, dict) else {}
+                verb = "Suppressed" if input_data.suppress else "Unsuppressed"
+                message = f"{verb} {input_data.name}"
+                if data.get("suppressed") is None:
+                    message += " (state could not be read back)"
+                return {
+                    "status": "success",
+                    "message": message,
+                    "data": data,
+                    "execution_time": result.execution_time,
+                }
+            return {
+                "status": "error",
+                "message": f"Failed to suppress feature: {result.error}",
+            }
+        except Exception as e:
+            logger.error(f"Error in suppress_feature tool: {e}")
+            return {"status": "error", "message": f"Unexpected error: {str(e)}"}
+
+    @mcp.tool()
+    async def undo(input_data: UndoInput | None = None) -> dict[str, Any]:
+        """Undo the last operations in the active model.
+
+        SolidWorks accepts an undo with nothing left to undo without
+        complaining, so the response reports whether the feature tree actually
+        changed rather than assuming it did.
+
+        Args:
+            input_data (UndoInput | None): How many steps to undo.
+
+        Returns:
+            dict[str, Any]: Status and whether the tree changed.
+
+        Example:
+            ```python
+            await undo({"count": 1})
+            ```
+        """
+        try:
+            input_data = _normalize_input(input_data or UndoInput(), UndoInput)
+            result = await adapter.undo(input_data.count)
+            if result.is_success:
+                data = result.data if isinstance(result.data, dict) else {}
+                changed = data.get("tree_changed")
+                if changed is False:
+                    message = (
+                        f"Undo of {input_data.count} step(s) left the feature "
+                        "tree unchanged - there was nothing to undo"
+                    )
+                else:
+                    message = f"Undid {input_data.count} step(s)"
+                return {
+                    "status": "success",
+                    "message": message,
+                    "data": data,
+                    "execution_time": result.execution_time,
+                }
+            return {
+                "status": "error",
+                "message": f"Failed to undo: {result.error}",
+            }
+        except Exception as e:
+            logger.error(f"Error in undo tool: {e}")
+            return {"status": "error", "message": f"Unexpected error: {str(e)}"}
+
+    tool_count = 18  # Number of tools registered
     return tool_count

--- a/tests/solidworks_mcp/adapters/test_feature_editing_capability.py
+++ b/tests/solidworks_mcp/adapters/test_feature_editing_capability.py
@@ -1,0 +1,207 @@
+"""Contract tests for the feature-editing capabilities.
+
+``delete_feature``, ``suppress_feature`` and ``undo`` each exist on the base
+adapter, the mock, the circuit breaker and the connection pool. A method
+missing from either wrapper silently degrades to the base "not implemented"
+default at runtime, and mock mode cannot catch it — the mock is not wrapped —
+so the wiring is asserted directly here.
+"""
+
+import inspect
+
+import pytest
+
+from solidworks_mcp.adapters.base import SolidWorksAdapter
+from solidworks_mcp.adapters.circuit_breaker import CircuitBreakerAdapter
+from solidworks_mcp.adapters.connection_pool import ConnectionPoolAdapter
+from solidworks_mcp.adapters.mock_adapter import MockSolidWorksAdapter
+
+CAPABILITIES = ["delete_feature", "suppress_feature", "undo"]
+
+WRAPPERS = [
+    SolidWorksAdapter,
+    MockSolidWorksAdapter,
+    CircuitBreakerAdapter,
+    ConnectionPoolAdapter,
+]
+
+
+@pytest.mark.parametrize("capability", CAPABILITIES)
+@pytest.mark.parametrize("cls", WRAPPERS, ids=lambda c: c.__name__)
+def test_capability_exists_on_every_layer(capability: str, cls: type) -> None:
+    """A capability missing from a wrapper degrades silently at runtime."""
+    method = getattr(cls, capability, None)
+    assert method is not None, f"{cls.__name__} is missing {capability}"
+    assert inspect.iscoroutinefunction(method), (
+        f"{cls.__name__}.{capability} must be async"
+    )
+
+
+@pytest.mark.parametrize("capability", CAPABILITIES)
+def test_real_adapter_resolves_to_the_com_mixin(capability: str) -> None:
+    """PyWin32Adapter must reach the COM implementation, not the base stub."""
+    pytest.importorskip("win32com", reason="pywin32 is Windows-only")
+    from solidworks_mcp.adapters.pywin32_adapter import PyWin32Adapter
+
+    owner = next(
+        (k.__name__ for k in PyWin32Adapter.__mro__ if capability in vars(k)), None
+    )
+    assert owner == "SolidWorksFeaturesMixin", (
+        f"PyWin32Adapter.{capability} resolves to {owner}, not the COM mixin. "
+        "The implementation is unreachable and every call silently returns the "
+        "base adapter's 'not implemented' error."
+    )
+
+
+@pytest.mark.parametrize("capability", CAPABILITIES)
+def test_wrappers_do_not_silently_fall_through_to_base(capability: str) -> None:
+    """The breaker and pool must define their own pass-through, not inherit."""
+    for cls in (CircuitBreakerAdapter, ConnectionPoolAdapter):
+        assert capability in vars(cls), (
+            f"{cls.__name__} inherits {capability} from the base adapter, so "
+            "calls to it return 'not implemented' instead of reaching the real "
+            "adapter"
+        )
+
+
+def test_zero_arg_edit_members_are_not_called_with_parentheses() -> None:
+    """``EditSuppress2`` and friends must go through ``_get_attr_or_call``.
+
+    Late binding resolves these zero-argument members as properties on some
+    dispatches. Calling them with ``()`` performs the edit and *then* raises
+    ``'bool' object is not callable``, so the operation succeeds while the
+    caller is told it failed — measured on SW 2025 before this was fixed.
+    """
+    from pathlib import Path
+
+    import solidworks_mcp.adapters.solidworks.features as features_module
+
+    source = Path(features_module.__file__).read_text(encoding="utf-8")
+    for member in ("EditSuppress2", "EditUnsuppress2", "EditDelete", "IsSuppressed"):
+        assert f".{member}()" not in source, (
+            f"{member} is called with parentheses; late binding may resolve it "
+            "as a property, which raises after the edit has already happened. "
+            "Use adapter._get_attr_or_call(obj, name)."
+        )
+
+
+@pytest.mark.asyncio
+async def test_mock_delete_removes_the_feature() -> None:
+    """delete_feature removes the named feature and reports the change."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+    await adapter.create_part()
+    await adapter.create_sketch("Front")
+    await adapter.add_rectangle(0.0, 0.0, 10.0, 10.0)
+    await adapter.exit_sketch()
+    from solidworks_mcp.adapters.base import ExtrusionParameters
+
+    created = await adapter.create_extrusion(ExtrusionParameters(depth=5.0))
+    assert created.is_success
+    name = created.data.name
+
+    result = await adapter.delete_feature(name)
+    assert result.is_success
+    assert result.data["features_after"] < result.data["features_before"]
+
+    listed = await adapter.list_features()
+    remaining = [
+        (f.get("name") if isinstance(f, dict) else getattr(f, "name", None))
+        for f in listed.data or []
+    ]
+    assert name not in remaining
+
+
+@pytest.mark.asyncio
+async def test_mock_delete_of_a_missing_feature_is_an_error() -> None:
+    """Deleting something absent must fail, not report a silent success."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.delete_feature("NoSuchFeature")
+    assert not result.is_success
+    assert "NoSuchFeature" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_mock_suppress_round_trips() -> None:
+    """suppress then unsuppress reports the state each way."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+    await adapter.create_part()
+    await adapter.create_sketch("Front")
+    await adapter.add_rectangle(0.0, 0.0, 10.0, 10.0)
+    await adapter.exit_sketch()
+    from solidworks_mcp.adapters.base import ExtrusionParameters
+
+    created = await adapter.create_extrusion(ExtrusionParameters(depth=5.0))
+    name = created.data.name
+
+    on = await adapter.suppress_feature(name, True)
+    assert on.is_success
+    assert on.data["suppressed"] is True
+    assert on.data["was_suppressed"] is False
+
+    off = await adapter.suppress_feature(name, False)
+    assert off.is_success
+    assert off.data["suppressed"] is False
+    assert off.data["was_suppressed"] is True
+
+
+@pytest.mark.asyncio
+async def test_mock_suppress_of_a_missing_feature_is_an_error() -> None:
+    """Suppressing something absent must fail."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.suppress_feature("NoSuchFeature", True)
+    assert not result.is_success
+
+
+@pytest.mark.asyncio
+async def test_mock_undo_with_nothing_to_undo_reports_no_change() -> None:
+    """An undo that changed nothing must say so.
+
+    SolidWorks accepts an undo on an empty stack without complaining, so
+    ``tree_changed`` is the only way a caller can tell. A mock that always
+    reported ``True`` would make that check worthless.
+    """
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+    await adapter.create_part()
+
+    result = await adapter.undo(1)
+    assert result.is_success
+    assert result.data["tree_changed"] is False, result.data
+
+
+@pytest.mark.asyncio
+async def test_mock_undo_removes_the_last_feature() -> None:
+    """An undo with something to undo reports the change."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+    await adapter.create_part()
+    await adapter.create_sketch("Front")
+    await adapter.add_rectangle(0.0, 0.0, 10.0, 10.0)
+    await adapter.exit_sketch()
+    from solidworks_mcp.adapters.base import ExtrusionParameters
+
+    await adapter.create_extrusion(ExtrusionParameters(depth=5.0))
+
+    result = await adapter.undo(1)
+    assert result.is_success
+    assert result.data["tree_changed"] is True
+    assert result.data["features_after"] < result.data["features_before"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("capability", CAPABILITIES)
+async def test_base_defaults_report_missing_capability(capability: str) -> None:
+    """The base defaults name the missing capability, not a fabrication."""
+    method = getattr(SolidWorksAdapter, capability)
+    result = await (
+        method(None, 1) if capability == "undo" else method(None, "Feature1")
+    )
+
+    assert not result.is_success
+    assert capability in (result.error or "")

--- a/tests/solidworks_mcp/tools/test_modeling.py
+++ b/tests/solidworks_mcp/tools/test_modeling.py
@@ -34,12 +34,14 @@ class TestModelingTools:
         tool_count = await register_modeling_tools(
             mcp_server, mock_adapter, mock_config
         )
-        assert tool_count == 15
+        assert tool_count == 18
         # The Phase 1 sweep/loft tools must be registered alongside the rest.
         names = {tool.name for tool in await mcp_server.list_tools()}
         assert {"create_sweep", "create_loft"} <= names
         # Assembly component/mate tools must be registered too.
         assert {"insert_component", "add_mate", "list_components"} <= names
+        # Feature editing.
+        assert {"delete_feature", "suppress_feature", "undo"} <= names
 
     @pytest.mark.asyncio
     async def test_open_model_success(self, mcp_server, mock_adapter, mock_config):

--- a/tests/test_live_sw_regression.py
+++ b/tests/test_live_sw_regression.py
@@ -2319,3 +2319,106 @@ async def test_assembly_insert_list_and_mate_change_real_geometry(connected_adap
         )
     finally:
         adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))
+
+
+@pytest.mark.asyncio
+async def test_feature_editing_changes_the_model(connected_adapter):
+    """Suppress, unsuppress, delete and undo, verified by volume and count.
+
+    Each of these COM calls reports success without necessarily doing
+    anything, so none of them are trusted here:
+
+    - suppress must both read back IsSuppressed True *and* drop the volume
+    - unsuppress must restore the volume
+    - delete must make the feature unresolvable by name and drop the count
+    - undo must bring it back
+    - undo on a fresh document must report tree_changed False rather than a
+      fabricated success
+    """
+    from solidworks_mcp.adapters.base import ExtrusionParameters
+
+    adapter = connected_adapter
+
+    async def volume():
+        result = await adapter.get_mass_properties()
+        assert result.is_success, result.error
+        return result.data.volume
+
+    try:
+        await adapter.create_part()
+        await adapter.create_sketch("Top")
+        await adapter.add_rectangle(-40.0, -20.0, 40.0, 20.0)
+        await adapter.exit_sketch()
+        await adapter.create_extrusion(ExtrusionParameters(depth=10.0))
+        base_volume = await volume()
+
+        # A second boss clear of the first, so it adds material.
+        await adapter.create_sketch("Front")
+        await adapter.add_rectangle(-10.0, 30.0, 10.0, 50.0)
+        await adapter.exit_sketch()
+        boss = await adapter.create_extrusion(ExtrusionParameters(depth=15.0))
+        assert boss.is_success, boss.error
+
+        with_boss = await volume()
+        assert with_boss > base_volume, (with_boss, base_volume)
+
+        listed = await adapter.list_features()
+        assert listed.is_success, listed.error
+        names = [
+            (f.get("name") if isinstance(f, dict) else getattr(f, "name", None))
+            for f in listed.data or []
+        ]
+        target = next((n for n in names if n and "Extrude" in n), None)
+        assert target, names
+
+        # ---- suppress: state reads back AND geometry goes away ----
+        suppressed = await adapter.suppress_feature(target, True)
+        assert suppressed.is_success, suppressed.error
+        assert suppressed.data["suppressed"] is True, suppressed.data
+        assert await volume() < with_boss
+
+        # ---- unsuppress: geometry comes back ----
+        unsuppressed = await adapter.suppress_feature(target, False)
+        assert unsuppressed.is_success, unsuppressed.error
+        assert unsuppressed.data["suppressed"] is False, unsuppressed.data
+        assert await volume() == pytest.approx(with_boss, rel=1e-9)
+
+        # ---- delete: unresolvable by name, and the count drops ----
+        deleted = await adapter.delete_feature(target)
+        assert deleted.is_success, deleted.error
+        assert deleted.data["features_after"] < deleted.data["features_before"], (
+            deleted.data
+        )
+
+        after_delete = await adapter.list_features()
+        remaining = [
+            (f.get("name") if isinstance(f, dict) else getattr(f, "name", None))
+            for f in (after_delete.data or [])
+        ]
+        assert target not in remaining, remaining
+
+        # ---- undo: the feature comes back ----
+        undone = await adapter.undo(1)
+        assert undone.is_success, undone.error
+        assert undone.data["tree_changed"] is True, undone.data
+
+        restored = await adapter.list_features()
+        restored_names = [
+            (f.get("name") if isinstance(f, dict) else getattr(f, "name", None))
+            for f in (restored.data or [])
+        ]
+        assert target in restored_names, restored_names
+
+        # ---- a feature that does not exist is an error, not a no-op ----
+        missing = await adapter.delete_feature("NoSuchFeature")
+        assert not missing.is_success
+
+        # ---- nothing to undo must not be dressed up as success ----
+        await adapter.create_part()
+        nothing = await adapter.undo(1)
+        assert nothing.is_success, nothing.error
+        assert nothing.data["tree_changed"] is False, (
+            f"undo on a fresh document reported a tree change: {nothing.data}"
+        )
+    finally:
+        adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))


### PR DESCRIPTION
Adds the three edits an agent needs to walk back a mistake without rebuilding a part from scratch, registered as tools in modeling.py (12 -> 18 tools with the assembly work this branch sits on).

None of the three COM calls can be trusted to report what they did, so none of them are:

- EditSuppress2/EditUnsuppress2 report only through the error channel, so the resulting state is read back from IFeature::IsSuppressed
- EditDelete reports nothing useful, so the feature must fail to resolve by name afterwards
- EditUndo2 is a Sub, and SolidWorks accepts an undo with an empty stack without complaint, so the feature count is compared before and after and the payload reports tree_changed rather than assuming success

Two bugs found by running it against SolidWorks 2025, both invisible to mock tests:

1. EditSuppress2 and EditUnsuppress2 resolve as properties under late binding on this build. Calling them with () performs the edit and *then* raises "'bool' object is not callable" - so the feature really was suppressed while the caller was told the operation failed. The volume changed underneath a reported error. Routed through _get_attr_or_call, which handles both shapes, along with EditDelete and IsSuppressed. A test asserts none of them are called with parentheses again.

2. Walking the tree with FirstFeature/GetNextFeature yields nothing on SW 2025 even with each dispatch flagged for IFeature, and FeatureByPositionReverse returned nothing usable either, so both made the tree look empty rather than raising - which would have made "did the tree change" silently answer False every time. IFeatureManager::GetFeatureCount(True) works and is used instead. It returns None rather than 0 when unreadable, so tree_changed is None - unknown - rather than a false negative.

Verified live by geometry, not return codes. A part with two bosses:

  suppress   -> IsSuppressed True  and volume 22000 -> 16000 mm3
  unsuppress -> IsSuppressed False and volume back to 22000
  delete     -> feature count 21 -> 20, feature unresolvable by name
  undo       -> tree_changed True, the feature is back in the tree
  undo on a fresh document -> tree_changed False, not a fake success
  delete of a name that does not exist -> error, not a silent no-op

The mock mirrors that contract: undo reports tree_changed False when there was nothing to undo, and delete/suppress of an unknown feature is an error rather than a quiet success.

Registered in tools/modeling.py, which the refuse-instead-of-fabricate PR does not touch, so this does not conflict with it.

1916 passed serial and under xdist, coverage 96.89%, ruff unchanged at the 14 findings already on main.