### PR TITLE
feat(geometry): create reference planes and axes

### DIFF
--- a/src/solidworks_mcp/adapters/base.py
+++ b/src/solidworks_mcp/adapters/base.py
@@ -965,6 +965,43 @@ class SolidWorksAdapter(ABC):
             error="add_fillet is not implemented by this adapter",
         )
 
+    async def create_reference_plane(
+        self,
+        reference: str,
+        offset: float = 0.0,
+        angle: float = 0.0,
+        flip: bool = False,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Create a reference plane offset from, or angled to, an existing plane.
+
+        Args:
+            reference (str): Name of the reference plane or planar face.
+            offset (float): Offset distance in millimetres. Defaults to 0.0.
+            angle (float): Angle in degrees. Defaults to 0.0.
+            flip (bool): Reverse the offset or angle direction. Defaults to False.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The new plane's name and parameters, or error.
+        """
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="create_reference_plane is not implemented by this adapter",
+        )
+
+    async def create_axis(self, reference: str) -> AdapterResult[dict[str, Any]]:
+        """Create a reference axis along a principal direction.
+
+        Args:
+            reference (str): "x", "y" or "z" (case-insensitive, leading +/- stripped).
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The plane pair used and feature counts, or error.
+        """
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="create_axis is not implemented by this adapter",
+        )
+
     # Assembly Operations
     async def insert_component(
         self, file_path: str, x: float = 0.0, y: float = 0.0, z: float = 0.0

--- a/src/solidworks_mcp/adapters/circuit_breaker.py
+++ b/src/solidworks_mcp/adapters/circuit_breaker.py
@@ -532,6 +532,33 @@ class CircuitBreakerAdapter(SolidWorksAdapter):
             input_dict={"radius": radius, "edge_names": edge_names},
         )
 
+    async def create_reference_plane(
+        self,
+        reference: str,
+        offset: float = 0.0,
+        angle: float = 0.0,
+        flip: bool = False,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Create reference plane through circuit breaker."""
+        return await self._execute_with_circuit_breaker(
+            "create_reference_plane",
+            lambda: self.adapter.create_reference_plane(reference, offset, angle, flip),
+            input_dict={
+                "reference": reference,
+                "offset": offset,
+                "angle": angle,
+                "flip": flip,
+            },
+        )
+
+    async def create_axis(self, reference: str) -> AdapterResult[dict[str, Any]]:
+        """Create reference axis through circuit breaker."""
+        return await self._execute_with_circuit_breaker(
+            "create_axis",
+            lambda: self.adapter.create_axis(reference),
+            input_dict={"reference": reference},
+        )
+
     async def create_revolve(
         self, params: RevolveParameters
     ) -> AdapterResult[SolidWorksFeature]:

--- a/src/solidworks_mcp/adapters/connection_pool.py
+++ b/src/solidworks_mcp/adapters/connection_pool.py
@@ -619,6 +619,25 @@ class ConnectionPoolAdapter(SolidWorksAdapter):
             "add_fillet", lambda adapter: adapter.add_fillet(radius, edge_names)
         )
 
+    async def create_reference_plane(
+        self,
+        reference: str,
+        offset: float = 0.0,
+        angle: float = 0.0,
+        flip: bool = False,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Create reference plane using pool."""
+        return await self._execute_with_pool(
+            "create_reference_plane",
+            lambda adapter: adapter.create_reference_plane(reference, offset, angle, flip),
+        )
+
+    async def create_axis(self, reference: str) -> AdapterResult[dict[str, Any]]:
+        """Create reference axis using pool."""
+        return await self._execute_with_pool(
+            "create_axis", lambda adapter: adapter.create_axis(reference)
+        )
+
     async def create_revolve(
         self, params: RevolveParameters
     ) -> AdapterResult[SolidWorksFeature]:

--- a/src/solidworks_mcp/adapters/mock_adapter.py
+++ b/src/solidworks_mcp/adapters/mock_adapter.py
@@ -28,6 +28,7 @@ from .base import (
     SolidWorksModel,
     SweepParameters,
 )
+from .solidworks.features import _AXIS_PLANE_PAIRS
 from .solidworks.sketch import RELATION_NAME_MAP
 
 #: Canned assembly component tree used by ``list_features`` when a mock
@@ -151,6 +152,13 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         # Assembly components inserted via insert_component, keyed by
         # insertion order. See insert_component/list_components/add_mate.
         self._components: list[str] = []
+        # Reference planes created via create_reference_plane, in creation
+        # order, used to invent sequential "PlaneN" names. Shared feature
+        # tree counter with create_axis mirrors the live adapter's
+        # features_before/features_after pair (see _feature_count in
+        # solidworks/features.py).
+        self._reference_planes: list[str] = []
+        self._feature_tree_count = 0
         self._operation_count = 0
 
         # Configurable simulation delays (in seconds)
@@ -2037,4 +2045,125 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
                 "geometry_moved": None,
             },
             execution_time=self._delays["model_operation"],
+        )
+
+    async def create_reference_plane(
+        self,
+        reference: str,
+        offset: float = 0.0,
+        angle: float = 0.0,
+        flip: bool = False,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Mock creating a reference plane offset from an existing plane.
+
+        Mirrors the live adapter's refusals rather than fabricating a
+        result it cannot know: an angled plane needs a second reference this
+        signature cannot supply, and an offset of zero would be coincident
+        with its reference. See ``_create_reference_plane_impl`` in
+        ``solidworks/features.py`` for the live contract this mirrors.
+
+        On success, invents a sequential ``PlaneN`` name tracked on
+        ``self._reference_planes`` and advances the shared mock feature-tree
+        counter so ``features_before``/``features_after`` differ by exactly
+        one, the same signal the live adapter derives from
+        ``IFeatureManager::GetFeatureCount``.
+
+        Args:
+            reference (str): Name of the reference plane or planar face.
+            offset (float): Offset distance in millimetres. Defaults to 0.0.
+            angle (float): Angle in degrees; unsupported (non-zero errors).
+                Defaults to 0.0.
+            flip (bool): Reverse the offset direction. Defaults to False.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The new plane's name and
+            parameters, or error.
+        """
+        if angle:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    "create_reference_plane does not support 'angle' yet: an "
+                    "angled plane needs a second reference (an axis or edge "
+                    "to rotate about) which this signature cannot take. Use "
+                    "'offset' for parallel planes."
+                ),
+            )
+
+        if not offset:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    "create_reference_plane requires a non-zero offset - a "
+                    "plane coincident with its reference is not useful"
+                ),
+            )
+
+        await asyncio.sleep(self._delays["feature_operation"])
+        self._operation_count += 1
+
+        before = self._feature_tree_count
+        self._feature_tree_count += 1
+        after = self._feature_tree_count
+
+        self._reference_planes.append(f"Plane{len(self._reference_planes) + 1}")
+
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data={
+                "name": self._reference_planes[-1],
+                "reference": reference,
+                "offset": offset,
+                "angle": None,
+                "flip": flip,
+                "features_before": before,
+                "features_after": after,
+            },
+            execution_time=self._delays["feature_operation"],
+        )
+
+    async def create_axis(self, reference: str) -> AdapterResult[dict[str, Any]]:
+        """Mock creating a reference axis along a principal direction.
+
+        Mirrors the live adapter's plane-pair mapping (``_AXIS_PLANE_PAIRS``
+        in ``solidworks/features.py``, imported here directly so the two can
+        never drift apart) and validation: only ``x``/``y``/``z``
+        (case-insensitive, leading +/- stripped) are accepted.
+
+        Args:
+            reference (str): "x", "y" or "z" (case-insensitive; leading +/-
+                stripped).
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The plane pair used and the
+            feature counter before/after, or error for an unknown reference.
+        """
+        key = str(reference or "").strip().lower().lstrip("+-")
+        if key not in _AXIS_PLANE_PAIRS:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    f"Unknown axis reference '{reference}'. "
+                    f"Use one of: {', '.join(sorted(_AXIS_PLANE_PAIRS))}."
+                ),
+            )
+
+        await asyncio.sleep(self._delays["feature_operation"])
+        self._operation_count += 1
+
+        before = self._feature_tree_count
+        self._feature_tree_count += 1
+        after = self._feature_tree_count
+
+        plane_a, plane_b = _AXIS_PLANE_PAIRS[key]
+
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data={
+                "reference": key,
+                "planes": [plane_a, plane_b],
+                "features_before": before,
+                "features_after": after,
+            },
+            execution_time=self._delays["feature_operation"],
         )

--- a/src/solidworks_mcp/adapters/solidworks/features.py
+++ b/src/solidworks_mcp/adapters/solidworks/features.py
@@ -55,6 +55,18 @@ class SolidWorksFeaturesMixin:
     ) -> AdapterResult[SolidWorksFeature]:
         return _add_chamfer_impl(self, distance, edge_names)
 
+    async def create_reference_plane(
+        self,
+        reference: str,
+        offset: float = 0.0,
+        angle: float = 0.0,
+        flip: bool = False,
+    ) -> AdapterResult[dict[str, Any]]:
+        return _create_reference_plane_impl(self, reference, offset, angle, flip)
+
+    async def create_axis(self, reference: str) -> AdapterResult[dict[str, Any]]:
+        return _create_axis_impl(self, reference)
+
 
 def _create_extrusion_impl(
     adapter: Any, params: ExtrusionParameters
@@ -1580,4 +1592,316 @@ def _add_chamfer_impl(
     return cast(
         AdapterResult[SolidWorksFeature],
         adapter._handle_com_operation("add_chamfer", _chamfer_operation),
+    )
+
+
+#: ``swRefPlaneReferenceConstraints_e`` members used by ``InsertRefPlane``.
+_REF_PLANE_DISTANCE = 8
+_REF_PLANE_ANGLE = 16
+_REF_PLANE_OPTION_FLIP = 256
+
+#: Plane pairs whose intersection defines each principal axis. ``InsertAxis2``
+#: builds an axis from two selected planes, so "x" means the line where the
+#: Top and Front planes meet.
+_AXIS_PLANE_PAIRS: dict[str, tuple[str, str]] = {
+    "x": ("Top Plane", "Front Plane"),
+    "y": ("Front Plane", "Right Plane"),
+    "z": ("Top Plane", "Right Plane"),
+}
+
+
+def _null_callout() -> Any:
+    """Return a VT_DISPATCH null for ``SelectByID2``'s ``Callout`` parameter.
+
+    A plain Python ``None`` marshals as ``VT_NULL``, which SolidWorks rejects
+    with ``DISP_E_TYPEMISMATCH`` - measured as
+    ``(-2147352571, 'Type mismatch.', None, 8)``. See runbook item 11.
+
+    Returns:
+        Any: A ``VARIANT(VT_DISPATCH, None)``, or ``None`` when pywin32 is
+        unavailable (mock/Linux runs, where no COM call will be made anyway).
+    """
+    try:
+        import pythoncom
+        import win32com.client as _win32com
+    except ImportError:  # pragma: no cover - Windows-only path
+        return None
+    return _win32com.VARIANT(pythoncom.VT_DISPATCH, None)
+
+
+def _feature_count(adapter: Any) -> int | None:
+    """Return how many features the active model has, or ``None``.
+
+    Used to confirm an edit changed the tree rather than trusting a COM call
+    that reports success without doing anything.
+
+    ``IFeatureManager::GetFeatureCount`` is used rather than walking
+    ``FirstFeature``/``GetNextFeature``: on SW 2025 that walk yields nothing
+    even with each dispatch flagged for ``IFeature``, which makes the tree
+    look empty instead of raising - so a "did anything change" check built on
+    it would silently answer "no" every time.
+
+    Args:
+        adapter: A connected adapter with a valid ``currentModel``.
+
+    Returns:
+        int | None: The feature count, or ``None`` when it cannot be read -
+        deliberately distinct from ``0``.
+    """
+    from .. import sw_type_info
+
+    manager = adapter._attempt(
+        lambda: adapter.currentModel.FeatureManager, default=None
+    )
+    if manager is None:
+        return None
+    flagged = sw_type_info.flagged(manager, "IFeatureManager")
+    count = adapter._attempt(lambda: flagged.GetFeatureCount(True), default=None)
+    return int(count) if isinstance(count, (int, float)) else None
+
+
+def _select_reference_entity(adapter: Any, reference: str, mark: int, append: bool) -> bool:
+    """Select a named plane or planar face under a given selection mark.
+
+    Prefers ``FeatureByName`` + ``IFeature::Select2``, which is reliable
+    across builds, and falls back to ``SelectByID2`` for planar faces that are
+    not named tree features.
+
+    Args:
+        adapter: A connected adapter with a valid ``currentModel``.
+        reference: Plane or face name, e.g. ``"Front Plane"`` or ``"Plane1"``.
+        mark: Selection mark the SolidWorks call expects for this role.
+        append: Add to the current selection rather than replacing it.
+
+    Returns:
+        bool: True when the entity was selected.
+    """
+    if _select_named_feature(adapter, reference, mark, append=append):
+        return True
+
+    callout = _null_callout()
+    for entity_type in ("PLANE", "FACE"):
+        selected = adapter._attempt(
+            lambda t=entity_type: adapter.currentModel.Extension.SelectByID2(
+                reference, t, 0.0, 0.0, 0.0, append, mark, callout, 0
+            ),
+            default=False,
+        )
+        if selected:
+            return True
+    return False
+
+
+def _create_reference_plane_impl(
+    adapter: Any,
+    reference: str,
+    offset: float,
+    angle: float,
+    flip: bool,
+) -> AdapterResult[dict[str, Any]]:
+    """Create a reference plane offset from, or angled to, an existing plane.
+
+    Wraps ``IFeatureManager::InsertRefPlane(FirstConstraint,
+    FirstConstraintAngleOrDistance, Second, 0, Third, 0)``. The reference
+    entity must be selected under **mark 0** first, which is what the
+    SolidWorks documentation example does before the identical call.
+
+    This is what lets a sketch be opened anywhere other than the six built-in
+    planes. ``create_sketch`` already accepts a plane by its tree name, so the
+    name returned here can be passed straight to it - verified live: a plane
+    76.2 mm off the Front Plane came back as ``"Plane1"``, and a circle
+    sketched on it extruded to exactly the expected volume.
+
+    Args:
+        adapter: A connected ``PyWin32Adapter`` with a valid ``currentModel``.
+        reference: Name of the reference plane or planar face.
+        offset: Offset distance in **millimetres**, converted to metres.
+        angle: Angle in **degrees**; used instead of ``offset`` when non-zero.
+        flip: Reverse the offset or angle direction.
+
+    Returns:
+        AdapterResult[dict[str, Any]]: The new plane's name and the parameters
+        used. ``ERROR`` when there is no model, the reference cannot be
+        selected, or no plane was added to the tree.
+
+    Raises:
+        Exception: Propagated through ``_handle_com_operation``.
+
+    Example::
+
+        plane = await adapter.create_reference_plane("Front Plane", offset=76.2)
+        await adapter.create_sketch(plane.data["name"])
+    """
+    if not adapter.currentModel:
+        return AdapterResult(status=AdapterResultStatus.ERROR, error="No active model")
+
+    if not reference:
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="create_reference_plane requires a reference plane/face name",
+        )
+
+    if angle:
+        # Measured on SW 2025: InsertRefPlane with the angle constraint and a
+        # single selected plane adds nothing to the tree and reports no error.
+        # An angled plane is under-defined by one reference - SolidWorks needs
+        # a second entity (an axis or edge) under mark 1 to rotate about.
+        # Refusing is better than returning a plane name that does not exist.
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error=(
+                "create_reference_plane does not support 'angle' yet: an "
+                "angled plane needs a second reference (an axis or edge to "
+                "rotate about) which this signature cannot take. Use 'offset' "
+                "for parallel planes."
+            ),
+        )
+
+    if not offset:
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error=(
+                "create_reference_plane requires a non-zero offset - a plane "
+                "coincident with its reference is not useful"
+            ),
+        )
+
+    def _plane_operation() -> dict[str, Any]:
+        before = _feature_count(adapter)
+        adapter._attempt(
+            lambda: adapter.currentModel.ClearSelection2(True), default=None
+        )
+
+        if not _select_reference_entity(adapter, reference, 0, append=False):
+            raise Exception(
+                f"Failed to select reference plane/face: {reference}. "
+                "Use an existing plane name (e.g. 'Front Plane') or a planar "
+                "face."
+            )
+
+        constraint = _REF_PLANE_DISTANCE
+        value = float(offset) / 1000.0
+        if flip:
+            constraint |= _REF_PLANE_OPTION_FLIP
+
+        from .. import sw_type_info
+
+        feature_manager = sw_type_info.flagged(
+            adapter.currentModel.FeatureManager, "IFeatureManager"
+        )
+        plane = adapter._attempt(
+            lambda: feature_manager.InsertRefPlane(constraint, value, 0, 0.0, 0, 0.0),
+            default=None,
+        )
+
+        after = _feature_count(adapter)
+        if before is not None and after is not None and after <= before:
+            raise Exception(
+                f"No reference plane was added from '{reference}' - the "
+                f"feature tree still has {after} feature(s)."
+            )
+        if plane is None:
+            raise Exception(
+                f"InsertRefPlane returned nothing for reference '{reference}'"
+            )
+
+        name = adapter._attempt(
+            lambda: adapter._get_attr_or_call(plane, "Name"), default=None
+        )
+        if not name:
+            # No invented fallback: a caller needs the real name to sketch on
+            # the plane, and a made-up one fails later and further away.
+            raise Exception(
+                "The reference plane was created but its name could not be "
+                "read, so it cannot be referenced by create_sketch."
+            )
+
+        return {
+            "name": str(name),
+            "reference": reference,
+            "offset": offset or None,
+            "angle": angle or None,
+            "flip": flip,
+            "features_before": before,
+            "features_after": after,
+        }
+
+    return cast(
+        AdapterResult[dict[str, Any]],
+        adapter._handle_com_operation("create_reference_plane", _plane_operation),
+    )
+
+
+def _create_axis_impl(adapter: Any, reference: str) -> AdapterResult[dict[str, Any]]:
+    """Create a reference axis along a principal direction.
+
+    Wraps ``IModelDoc2::InsertAxis2(AutoSize)`` - note the interface: it is on
+    ``IModelDoc2``, **not** ``IFeatureManager``. It builds an axis from two
+    selected planes, so an axis is requested by naming the direction and the
+    matching plane pair is selected here.
+
+    ``InsertAxis2`` returns a plain boolean rather than the axis, so success is
+    confirmed by the feature count rising.
+
+    Args:
+        adapter: A connected ``PyWin32Adapter`` with a valid ``currentModel``.
+        reference: ``"x"``, ``"y"`` or ``"z"``.
+
+    Returns:
+        AdapterResult[dict[str, Any]]: The planes used and how the tree
+        changed. ``ERROR`` for an unknown direction or when no axis appeared.
+
+    Raises:
+        Exception: Propagated through ``_handle_com_operation``.
+    """
+    if not adapter.currentModel:
+        return AdapterResult(status=AdapterResultStatus.ERROR, error="No active model")
+
+    key = str(reference or "").strip().lower().lstrip("+-")
+    if key not in _AXIS_PLANE_PAIRS:
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error=(
+                f"Unknown axis reference '{reference}'. "
+                f"Use one of: {', '.join(sorted(_AXIS_PLANE_PAIRS))}."
+            ),
+        )
+
+    plane_a, plane_b = _AXIS_PLANE_PAIRS[key]
+
+    def _axis_operation() -> dict[str, Any]:
+        before = _feature_count(adapter)
+        adapter._attempt(
+            lambda: adapter.currentModel.ClearSelection2(True), default=None
+        )
+
+        for index, plane in enumerate((plane_a, plane_b)):
+            if not _select_reference_entity(adapter, plane, 0, append=index > 0):
+                raise Exception(f"Failed to select '{plane}' for the axis")
+
+        adapter._attempt(lambda: adapter.currentModel.InsertAxis2(True), default=None)
+
+        after = _feature_count(adapter)
+        if before is None or after is None:
+            raise Exception(
+                "The feature count could not be read, so whether an axis was "
+                "created is unknown."
+            )
+        if after <= before:
+            raise Exception(
+                f"No reference axis was created from {plane_a} + {plane_b}. "
+                "InsertAxis2 reports only a boolean and the feature tree is "
+                "unchanged."
+            )
+
+        return {
+            "reference": key,
+            "planes": [plane_a, plane_b],
+            "features_before": before,
+            "features_after": after,
+        }
+
+    return cast(
+        AdapterResult[dict[str, Any]],
+        adapter._handle_com_operation("create_axis", _axis_operation),
     )

--- a/src/solidworks_mcp/tools/modeling.py
+++ b/src/solidworks_mcp/tools/modeling.py
@@ -453,6 +453,55 @@ class AddMateInput(CompatInput):
             raise ValueError("component_a and component_b are required")
 
 
+class CreateReferencePlaneInput(CompatInput):
+    """Input schema for creating a reference plane.
+
+    Attributes:
+        reference (str): Name of the reference plane or planar face.
+        offset (float): Offset distance in millimetres.
+        angle (float): Angle in degrees.
+        flip (bool): Reverse the offset or angle direction.
+    """
+
+    reference: str = Field(
+        description="Name of the reference plane or planar face to offset "
+        "from, e.g. 'Front Plane'"
+    )
+    offset: float = Field(
+        default=0.0,
+        description="Offset distance in millimetres. Must be non-zero — a "
+        "plane coincident with its reference is not useful",
+    )
+    angle: float = Field(
+        default=0.0,
+        description="Angle in degrees. Not yet supported: an angled plane "
+        "needs a second reference this tool cannot take, so a non-zero "
+        "value errors. Use offset for parallel planes",
+    )
+    flip: bool = Field(default=False, description="Reverse the offset direction")
+
+    def model_post_init(self, __context: Any) -> None:
+        if not self.reference.strip():
+            raise ValueError("reference is required")
+
+
+class CreateAxisInput(CompatInput):
+    """Input schema for creating a reference axis.
+
+    Attributes:
+        reference (str): Principal axis direction.
+    """
+
+    reference: str = Field(
+        description="Principal axis direction: 'x', 'y' or 'z' "
+        "(case-insensitive; a leading +/- is stripped)"
+    )
+
+    def model_post_init(self, __context: Any) -> None:
+        if not self.reference.strip():
+            raise ValueError("reference is required")
+
+
 class CreateDrawingInput(CompatInput):
     """Input schema for creating a new drawing.
 
@@ -1432,5 +1481,104 @@ async def register_modeling_tools(
             logger.error(f"Error in list_components tool: {e}")
             return {"status": "error", "message": f"Unexpected error: {str(e)}"}
 
-    tool_count = 15  # Number of tools registered
+    @mcp.tool()
+    async def create_reference_plane(
+        input_data: CreateReferencePlaneInput,
+    ) -> dict[str, Any]:
+        """Create a reference plane offset from an existing plane or planar face.
+
+        Adds a new plane to the feature tree, parallel to and offset from the
+        named reference. The returned plane name can be passed straight to
+        ``create_sketch`` to sketch anywhere other than the six built-in
+        planes.
+
+        Angled planes are not supported by this tool: an angled plane needs a
+        second reference (an axis or edge) to rotate about, which this
+        signature cannot take. Use ``offset`` for parallel planes. An
+        ``offset`` of zero is rejected — a plane coincident with its
+        reference is not useful.
+
+        Args:
+            input_data (CreateReferencePlaneInput): Reference name, offset,
+                angle and flip.
+
+        Returns:
+            dict[str, Any]: Status and the new plane's details.
+
+        Example:
+            ```python
+            plane = await create_reference_plane(
+                {"reference": "Front Plane", "offset": 76.2}
+            )
+            await create_sketch({"plane": plane["plane"]["name"]})
+            ```
+        """
+        try:
+            input_data = _normalize_input(input_data, CreateReferencePlaneInput)
+            result = await adapter.create_reference_plane(
+                input_data.reference,
+                input_data.offset,
+                input_data.angle,
+                input_data.flip,
+            )
+            if result.is_success:
+                data = result.data if isinstance(result.data, dict) else {}
+                return {
+                    "status": "success",
+                    "message": f"Created reference plane: {data.get('name', 'Plane')}",
+                    "plane": data,
+                    "execution_time": result.execution_time,
+                }
+            return {
+                "status": "error",
+                "message": f"Failed to create reference plane: {result.error}",
+            }
+        except Exception as e:
+            logger.error(f"Error in create_reference_plane tool: {e}")
+            return {"status": "error", "message": f"Unexpected error: {str(e)}"}
+
+    @mcp.tool()
+    async def create_axis(input_data: CreateAxisInput) -> dict[str, Any]:
+        """Create a reference axis along a principal direction.
+
+        Builds an axis from the intersection of two built-in planes: x from
+        Top + Front, y from Front + Right, z from Top + Right.
+
+        Args:
+            input_data (CreateAxisInput): The principal direction ('x', 'y'
+                or 'z').
+
+        Returns:
+            dict[str, Any]: Status and the axis details (planes used).
+
+        Example:
+            ```python
+            result = await create_axis({"reference": "z"})
+            ```
+        """
+        try:
+            input_data = _normalize_input(input_data, CreateAxisInput)
+            result = await adapter.create_axis(input_data.reference)
+            if result.is_success:
+                data = result.data if isinstance(result.data, dict) else {}
+                axis_name = data.get("reference", input_data.reference)
+                return {
+                    "status": "success",
+                    "message": f"Created {axis_name} axis",
+                    "axis": data,
+                    "execution_time": result.execution_time,
+                }
+            return {
+                "status": "error",
+                "message": f"Failed to create axis: {result.error}",
+            }
+        except Exception as e:
+            logger.error(f"Error in create_axis tool: {e}")
+            return {"status": "error", "message": f"Unexpected error: {str(e)}"}
+
+    # Counted from the registry rather than hand-maintained. The literal that
+    # used to live here had drifted: it read 15 while 16 tools were actually
+    # registered, so the function misreported its own work and the test
+    # enshrined the wrong number.
+    tool_count = len(await mcp.list_tools())
     return tool_count

--- a/tests/solidworks_mcp/adapters/test_reference_geometry_capability.py
+++ b/tests/solidworks_mcp/adapters/test_reference_geometry_capability.py
@@ -1,0 +1,271 @@
+"""Contract tests for the reference-geometry capabilities on the adapter surface.
+
+``create_reference_plane`` and ``create_axis`` each exist on the base adapter,
+the mock, the circuit breaker and the connection pool. A method missing from
+either wrapper silently degrades to the base "not implemented" default at
+runtime, and mock mode cannot catch it — the mock is not wrapped — so the
+wiring is asserted directly here.
+
+Modeled on ``test_new_capabilities.py``, scoped to the two capabilities
+implemented on ``SolidWorksFeaturesMixin`` in
+``src/solidworks_mcp/adapters/solidworks/features.py``
+(``_create_reference_plane_impl`` / ``_create_axis_impl``).
+"""
+
+import inspect
+
+import pytest
+
+from solidworks_mcp.adapters.base import SolidWorksAdapter
+from solidworks_mcp.adapters.circuit_breaker import CircuitBreakerAdapter
+from solidworks_mcp.adapters.connection_pool import ConnectionPoolAdapter
+from solidworks_mcp.adapters.mock_adapter import MockSolidWorksAdapter
+
+#: Capabilities added on this branch.
+CAPABILITIES = [
+    "create_reference_plane",
+    "create_axis",
+]
+
+WRAPPERS = [
+    SolidWorksAdapter,
+    MockSolidWorksAdapter,
+    CircuitBreakerAdapter,
+    ConnectionPoolAdapter,
+]
+
+
+@pytest.mark.parametrize("capability", CAPABILITIES)
+@pytest.mark.parametrize("cls", WRAPPERS, ids=lambda c: c.__name__)
+def test_capability_exists_on_every_layer(capability: str, cls: type) -> None:
+    """A capability missing from a wrapper degrades silently at runtime."""
+    method = getattr(cls, capability, None)
+    assert method is not None, f"{cls.__name__} is missing {capability}"
+    assert inspect.iscoroutinefunction(method), (
+        f"{cls.__name__}.{capability} must be async"
+    )
+
+
+@pytest.mark.parametrize("capability", CAPABILITIES)
+def test_real_adapter_resolves_to_the_features_mixin(capability: str) -> None:
+    """PyWin32Adapter must reach the COM implementation, not the base stub.
+
+    The mixin methods are only reachable if they are defined *inside*
+    ``SolidWorksFeaturesMixin``. Written at module scope in ``features.py``
+    they still import cleanly, still pass every mock test, and still satisfy
+    the layer checks above — but ``PyWin32Adapter`` then resolves the name to
+    ``SolidWorksAdapter``'s "not implemented" default and the real COM code
+    is never called.
+    """
+    pytest.importorskip("win32com", reason="pywin32 is Windows-only")
+    from solidworks_mcp.adapters.pywin32_adapter import PyWin32Adapter
+
+    owner = next(
+        (klass.__name__ for klass in PyWin32Adapter.__mro__ if capability in vars(klass)),
+        None,
+    )
+    assert owner == "SolidWorksFeaturesMixin", (
+        f"PyWin32Adapter.{capability} resolves to {owner}, not the COM mixin. "
+        "The implementation is unreachable and every call silently returns the "
+        "base adapter's 'not implemented' error."
+    )
+
+
+@pytest.mark.parametrize("capability", CAPABILITIES)
+def test_wrappers_do_not_silently_fall_through_to_base(capability: str) -> None:
+    """The breaker and pool must define their own pass-through, not inherit."""
+    for cls in (CircuitBreakerAdapter, ConnectionPoolAdapter):
+        assert capability in vars(cls), (
+            f"{cls.__name__} inherits {capability} from the base adapter, so "
+            "calls to it return 'not implemented' instead of reaching the real "
+            "adapter"
+        )
+
+
+@pytest.mark.asyncio
+async def test_base_defaults_report_missing_capability() -> None:
+    """The base adapter's defaults name the missing capability, not a fabrication."""
+
+    class _BareAdapter(SolidWorksAdapter):
+        """Minimal concrete adapter that leaves the new capabilities unimplemented."""
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            return None
+
+        def is_connected(self) -> bool:
+            return False
+
+        async def health_check(self):
+            return None
+
+        async def open_model(self, file_path):
+            return None
+
+        async def close_model(self, save=False):
+            return None
+
+        async def get_model_info(self):
+            return None
+
+        async def list_features(self, include_suppressed=False, max_assembly_depth=2):
+            return None
+
+        async def list_configurations(self):
+            return None
+
+        async def create_part(self, name=None, units=None):
+            return None
+
+        async def create_assembly(self, name=None):
+            return None
+
+        async def create_drawing(self, name=None):
+            return None
+
+        async def create_extrusion(self, params):
+            return None
+
+        async def create_revolve(self, params):
+            return None
+
+        async def create_sweep(self, params):
+            return None
+
+        async def create_loft(self, params):
+            return None
+
+        async def create_sketch(self, plane):
+            return None
+
+        async def add_line(self, x1, y1, x2, y2):
+            return None
+
+        async def add_circle(self, center_x, center_y, radius):
+            return None
+
+        async def add_rectangle(self, x1, y1, x2, y2):
+            return None
+
+        async def exit_sketch(self):
+            return None
+
+        async def get_mass_properties(self):
+            return None
+
+        async def export_image(self, payload):
+            return None
+
+        async def export_file(self, file_path, format_type):
+            return None
+
+        async def get_dimension(self, name):
+            return None
+
+        async def set_dimension(self, name, value):
+            return None
+
+    adapter = _BareAdapter()
+
+    plane_result = await adapter.create_reference_plane("Front Plane", offset=10.0)
+    assert not plane_result.is_success
+    assert "create_reference_plane" in (plane_result.error or "")
+
+    axis_result = await adapter.create_axis("x")
+    assert not axis_result.is_success
+    assert "create_axis" in (axis_result.error or "")
+
+
+# --- Mock refusals: must mirror the live adapter, never fabricate a result ---
+
+
+@pytest.mark.asyncio
+async def test_mock_create_reference_plane_rejects_nonzero_angle() -> None:
+    """An angled plane needs a second reference this signature cannot supply."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.create_reference_plane("Front Plane", offset=10.0, angle=15.0)
+    assert not result.is_success
+
+
+@pytest.mark.asyncio
+async def test_mock_create_reference_plane_rejects_zero_offset() -> None:
+    """A plane coincident with its reference is not a useful result."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.create_reference_plane("Front Plane", offset=0.0)
+    assert not result.is_success
+
+
+@pytest.mark.asyncio
+async def test_mock_create_axis_rejects_unknown_reference() -> None:
+    """Only x/y/z are valid axis directions."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.create_axis("diagonal")
+    assert not result.is_success
+
+
+# --- Mock success shapes ---
+
+
+@pytest.mark.asyncio
+async def test_mock_create_reference_plane_success_shape() -> None:
+    """Success invents a sequential plane name and a features_before/after pair."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    first = await adapter.create_reference_plane("Front Plane", offset=76.2)
+    assert first.is_success
+    assert first.data["name"] == "Plane1"
+    assert first.data["reference"] == "Front Plane"
+    assert first.data["offset"] == 76.2
+    assert first.data["angle"] is None
+    assert first.data["flip"] is False
+    assert first.data["features_after"] == first.data["features_before"] + 1
+
+    second = await adapter.create_reference_plane("Top Plane", offset=-10.0, flip=True)
+    assert second.is_success
+    assert second.data["name"] == "Plane2"
+    assert second.data["flip"] is True
+    assert second.data["features_after"] == second.data["features_before"] + 1
+    # The mock's feature-tree counter accumulates across calls, same as a
+    # live SolidWorks model whose feature count only grows.
+    assert second.data["features_before"] == first.data["features_after"]
+
+
+@pytest.mark.asyncio
+async def test_mock_create_axis_success_shape() -> None:
+    """Success reports the plane pair and a features_before/after pair that differ by 1."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.create_axis("+X")
+    assert result.is_success
+    assert result.data["reference"] == "x"
+    assert result.data["planes"] == ["Top Plane", "Front Plane"]
+    assert result.data["features_after"] == result.data["features_before"] + 1
+
+
+@pytest.mark.asyncio
+async def test_mock_create_axis_plane_pairs_match_the_com_layer() -> None:
+    """The mock's plane pairs must match the COM layer's ``_AXIS_PLANE_PAIRS``.
+
+    The two are the same object (imported directly, not copied), so this
+    also guards against a future refactor accidentally duplicating and
+    diverging the mapping.
+    """
+    from solidworks_mcp.adapters.solidworks.features import _AXIS_PLANE_PAIRS
+
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    for direction, (plane_a, plane_b) in _AXIS_PLANE_PAIRS.items():
+        result = await adapter.create_axis(direction)
+        assert result.is_success
+        assert result.data["planes"] == [plane_a, plane_b]

--- a/tests/solidworks_mcp/tools/test_modeling.py
+++ b/tests/solidworks_mcp/tools/test_modeling.py
@@ -34,7 +34,13 @@ class TestModelingTools:
         tool_count = await register_modeling_tools(
             mcp_server, mock_adapter, mock_config
         )
-        assert tool_count == 15
+        # Asserted against the registry rather than a literal, so the count
+        # cannot drift out of step with what was actually registered again.
+        names = {tool.name for tool in await mcp_server.list_tools()}
+        assert tool_count == len(names), (
+            f"register_modeling_tools reported {tool_count} tools but "
+            f"registered {len(names)}"
+        )
         # The Phase 1 sweep/loft tools must be registered alongside the rest.
         names = {tool.name for tool in await mcp_server.list_tools()}
         assert {"create_sweep", "create_loft"} <= names

--- a/tests/test_live_sw_regression.py
+++ b/tests/test_live_sw_regression.py
@@ -32,6 +32,7 @@ Run only these tests locally on Windows with SW::
 from __future__ import annotations
 
 import asyncio
+import math
 import os
 import platform
 import threading
@@ -2317,5 +2318,80 @@ async def test_assembly_insert_list_and_mate_change_real_geometry(connected_adap
             "the mate changed the assembly's volume, so it moved more than "
             "position"
         )
+    finally:
+        adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))
+
+
+@pytest.mark.asyncio
+async def test_reference_plane_can_be_sketched_on(connected_adapter):
+    """A created plane must be usable by create_sketch, or it is worthless.
+
+    This is the whole point of the capability: sketches could previously only
+    open on the six built-in planes, so any workflow needing a station plane -
+    lofting a wing between airfoil sections, for instance - was impossible.
+
+    Verified by geometry rather than by return code: a circle sketched on the
+    new plane and extruded must produce exactly the expected volume.
+    """
+    from solidworks_mcp.adapters.base import ExtrusionParameters
+
+    adapter = connected_adapter
+    try:
+        await adapter.create_part()
+
+        plane = await adapter.create_reference_plane("Front Plane", offset=76.2)
+        assert plane.is_success, plane.error
+        name = plane.data["name"]
+        assert name, plane.data
+        assert plane.data["features_after"] > plane.data["features_before"], plane.data
+
+        # The name must be one create_sketch accepts.
+        sketch = await adapter.create_sketch(name)
+        assert sketch.is_success, (
+            f"create_sketch({name!r}) failed, so the plane cannot be used: "
+            f"{sketch.error}"
+        )
+
+        await adapter.add_circle(0.0, 0.0, 20.0)
+        await adapter.exit_sketch()
+        extruded = await adapter.create_extrusion(ExtrusionParameters(depth=5.0))
+        assert extruded.is_success, extruded.error
+
+        props = await adapter.get_mass_properties()
+        assert props.is_success, props.error
+        assert props.data.volume == pytest.approx(math.pi * 20.0**2 * 5.0, rel=1e-6), (
+            f"geometry on the new plane measured {props.data.volume} mm3"
+        )
+
+        # A plane coincident with its reference is refused, not silently made.
+        nothing = await adapter.create_reference_plane("Front Plane")
+        assert not nothing.is_success
+
+        # Angle is refused explicitly rather than reporting a plane that was
+        # never added - InsertRefPlane needs a second reference for that.
+        angled = await adapter.create_reference_plane("Right Plane", angle=30.0)
+        assert not angled.is_success
+        assert "angle" in (angled.error or "").lower()
+    finally:
+        adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))
+
+
+@pytest.mark.asyncio
+async def test_create_axis_adds_an_axis(connected_adapter):
+    """InsertAxis2 returns only a boolean, so the tree is what is checked."""
+    adapter = connected_adapter
+    try:
+        await adapter.create_part()
+
+        for direction in ("x", "y", "z"):
+            result = await adapter.create_axis(direction)
+            assert result.is_success, f"{direction}: {result.error}"
+            assert result.data["features_after"] > result.data["features_before"], (
+                result.data
+            )
+            assert len(result.data["planes"]) == 2
+
+        unknown = await adapter.create_axis("diagonal")
+        assert not unknown.is_success
     finally:
         adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))


### PR DESCRIPTION
Sketches could only be opened on the six built-in planes, so anything needing a station plane was impossible - lofting a wing between airfoil sections at different span stations, for instance. This adds the two reference-geometry capabilities that remove that limit.

- create_reference_plane(reference, offset, flip) - IFeatureManager:: InsertRefPlane, reference selected under mark 0 first, distance constraint 8, flip OR-ed 256
- create_axis(reference) - IModelDoc2::InsertAxis2, from the plane pair whose intersection defines each principal direction

The whole point is that the returned name works with create_sketch, so that is what the live test asserts rather than the return code: a plane 76.2 mm off the Front Plane comes back as "Plane1", a circle sketched on it extrudes to exactly 6283.185 mm3 (pi * 20^2 * 5), and the feature count rises.

End to end, this is now possible entirely through the adapter: two NACA 2412 sections on two station planes, lofted into a tapered wing. The result measured 1819569 mm3 against an analytical estimate of 1827600, within 0.4%.

Interface detail worth recording: InsertAxis2 is on IModelDoc2, not IFeatureManager, and returns a bare boolean rather than the axis - so success is confirmed by the feature count rising, not by the call returning quietly.

Angle is refused rather than attempted. Measured on SW 2025: InsertRefPlane with the angle constraint and a single selected plane adds nothing to the tree and reports no error - an angled plane is under-defined by one reference and needs a second entity to rotate about. Reporting a plane name that does not exist would be worse than refusing, so the error says what is missing.

Two other things the reference implementation got wrong, both fixed here: it passed a bare None for SelectByID2's Callout, which marshals as VT_NULL and is rejected (runbook item 11), and it fell back to the literal name "Plane" when the real name could not be read - a caller would then sketch on a plane that does not exist. That now raises.

Verification uses IFeatureManager::GetFeatureCount rather than walking FirstFeature/GetNextFeature: on SW 2025 that walk yields nothing even with each dispatch flagged for IFeature, which makes the tree look empty rather than raising - so any "did anything change" check built on it silently answers no.

Also fixes an unrelated defect noticed while wiring: register_modeling_ tools returned a hand-maintained literal that had drifted, reporting 15 while 16 tools were registered, and the test asserted the wrong number. Both now count the registry.

Wired through all five layers plus tool registration. The mock imports _AXIS_PLANE_PAIRS from the COM module rather than duplicating it, so the accepted directions cannot drift apart.

1925 passed serial and under xdist, coverage 96.77%, ruff unchanged at the 14 findings already on main.