### PR TITLE
feat(geometry): circular pattern of features about an axis

### DIFF
--- a/src/solidworks_mcp/adapters/base.py
+++ b/src/solidworks_mcp/adapters/base.py
@@ -1026,6 +1026,32 @@ class SolidWorksAdapter(ABC):
             error="mirror_feature is not implemented by this adapter",
         )
 
+    async def pattern_circular(
+        self,
+        features: list[str],
+        axis: str,
+        count: int,
+        angle: float = 360.0,
+        equal_spacing: bool = True,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Pattern features around an axis.
+
+        Args:
+            features (list[str]): Names of the features to pattern.
+            axis (str): Name of the axis to rotate about.
+            count (int): Total number of instances including the original.
+            angle (float): Total angle in degrees to spread them over. Defaults to 360.0.
+            equal_spacing (bool): Space instances evenly across ``angle``. Defaults to True.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: What was patterned and the volume
+            before/after, or error.
+        """
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="pattern_circular is not implemented by this adapter",
+        )
+
     # Assembly Operations
     async def insert_component(
         self, file_path: str, x: float = 0.0, y: float = 0.0, z: float = 0.0

--- a/src/solidworks_mcp/adapters/base.py
+++ b/src/solidworks_mcp/adapters/base.py
@@ -1002,6 +1002,30 @@ class SolidWorksAdapter(ABC):
             error="create_axis is not implemented by this adapter",
         )
 
+    async def mirror_feature(
+        self,
+        features: list[str],
+        mirror_plane: str,
+        merge: bool = True,
+        mirror_bodies: bool = True,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Mirror solid bodies or features about a plane.
+
+        Args:
+            features (list[str]): Body or feature names to mirror.
+            mirror_plane (str): Plane name to mirror about.
+            merge (bool): Merge the mirrored result with the original. Defaults to True.
+            mirror_bodies (bool): Mirror whole bodies rather than features. Defaults to True.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The mirror feature's name, inputs and volume
+            before/after, or error.
+        """
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="mirror_feature is not implemented by this adapter",
+        )
+
     # Assembly Operations
     async def insert_component(
         self, file_path: str, x: float = 0.0, y: float = 0.0, z: float = 0.0

--- a/src/solidworks_mcp/adapters/base.py
+++ b/src/solidworks_mcp/adapters/base.py
@@ -965,6 +965,43 @@ class SolidWorksAdapter(ABC):
             error="add_fillet is not implemented by this adapter",
         )
 
+    async def create_reference_plane(
+        self,
+        reference: str,
+        offset: float = 0.0,
+        angle: float = 0.0,
+        flip: bool = False,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Create a reference plane offset from, or angled to, an existing plane.
+
+        Args:
+            reference (str): Name of the reference plane or planar face.
+            offset (float): Offset distance in millimetres. Defaults to 0.0.
+            angle (float): Angle in degrees. Defaults to 0.0.
+            flip (bool): Reverse the offset or angle direction. Defaults to False.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The new plane's name and parameters, or error.
+        """
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="create_reference_plane is not implemented by this adapter",
+        )
+
+    async def create_axis(self, reference: str) -> AdapterResult[dict[str, Any]]:
+        """Create a reference axis along a principal direction.
+
+        Args:
+            reference (str): "x", "y" or "z" (case-insensitive, leading +/- stripped).
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The plane pair used and feature counts, or error.
+        """
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="create_axis is not implemented by this adapter",
+        )
+
     # Assembly Operations
     async def insert_component(
         self, file_path: str, x: float = 0.0, y: float = 0.0, z: float = 0.0

--- a/src/solidworks_mcp/adapters/circuit_breaker.py
+++ b/src/solidworks_mcp/adapters/circuit_breaker.py
@@ -559,6 +559,27 @@ class CircuitBreakerAdapter(SolidWorksAdapter):
             input_dict={"reference": reference},
         )
 
+    async def mirror_feature(
+        self,
+        features: list[str],
+        mirror_plane: str,
+        merge: bool = True,
+        mirror_bodies: bool = True,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Mirror solid bodies or features through circuit breaker."""
+        return await self._execute_with_circuit_breaker(
+            "mirror_feature",
+            lambda: self.adapter.mirror_feature(
+                features, mirror_plane, merge, mirror_bodies
+            ),
+            input_dict={
+                "features": features,
+                "mirror_plane": mirror_plane,
+                "merge": merge,
+                "mirror_bodies": mirror_bodies,
+            },
+        )
+
     async def create_revolve(
         self, params: RevolveParameters
     ) -> AdapterResult[SolidWorksFeature]:

--- a/src/solidworks_mcp/adapters/circuit_breaker.py
+++ b/src/solidworks_mcp/adapters/circuit_breaker.py
@@ -532,6 +532,33 @@ class CircuitBreakerAdapter(SolidWorksAdapter):
             input_dict={"radius": radius, "edge_names": edge_names},
         )
 
+    async def create_reference_plane(
+        self,
+        reference: str,
+        offset: float = 0.0,
+        angle: float = 0.0,
+        flip: bool = False,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Create reference plane through circuit breaker."""
+        return await self._execute_with_circuit_breaker(
+            "create_reference_plane",
+            lambda: self.adapter.create_reference_plane(reference, offset, angle, flip),
+            input_dict={
+                "reference": reference,
+                "offset": offset,
+                "angle": angle,
+                "flip": flip,
+            },
+        )
+
+    async def create_axis(self, reference: str) -> AdapterResult[dict[str, Any]]:
+        """Create reference axis through circuit breaker."""
+        return await self._execute_with_circuit_breaker(
+            "create_axis",
+            lambda: self.adapter.create_axis(reference),
+            input_dict={"reference": reference},
+        )
+
     async def create_revolve(
         self, params: RevolveParameters
     ) -> AdapterResult[SolidWorksFeature]:

--- a/src/solidworks_mcp/adapters/circuit_breaker.py
+++ b/src/solidworks_mcp/adapters/circuit_breaker.py
@@ -580,6 +580,29 @@ class CircuitBreakerAdapter(SolidWorksAdapter):
             },
         )
 
+    async def pattern_circular(
+        self,
+        features: list[str],
+        axis: str,
+        count: int,
+        angle: float = 360.0,
+        equal_spacing: bool = True,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Pattern features around an axis through circuit breaker."""
+        return await self._execute_with_circuit_breaker(
+            "pattern_circular",
+            lambda: self.adapter.pattern_circular(
+                features, axis, count, angle, equal_spacing
+            ),
+            input_dict={
+                "features": features,
+                "axis": axis,
+                "count": count,
+                "angle": angle,
+                "equal_spacing": equal_spacing,
+            },
+        )
+
     async def create_revolve(
         self, params: RevolveParameters
     ) -> AdapterResult[SolidWorksFeature]:

--- a/src/solidworks_mcp/adapters/connection_pool.py
+++ b/src/solidworks_mcp/adapters/connection_pool.py
@@ -653,6 +653,22 @@ class ConnectionPoolAdapter(SolidWorksAdapter):
             ),
         )
 
+    async def pattern_circular(
+        self,
+        features: list[str],
+        axis: str,
+        count: int,
+        angle: float = 360.0,
+        equal_spacing: bool = True,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Pattern features around an axis using pool."""
+        return await self._execute_with_pool(
+            "pattern_circular",
+            lambda adapter: adapter.pattern_circular(
+                features, axis, count, angle, equal_spacing
+            ),
+        )
+
     async def create_revolve(
         self, params: RevolveParameters
     ) -> AdapterResult[SolidWorksFeature]:

--- a/src/solidworks_mcp/adapters/connection_pool.py
+++ b/src/solidworks_mcp/adapters/connection_pool.py
@@ -619,6 +619,25 @@ class ConnectionPoolAdapter(SolidWorksAdapter):
             "add_fillet", lambda adapter: adapter.add_fillet(radius, edge_names)
         )
 
+    async def create_reference_plane(
+        self,
+        reference: str,
+        offset: float = 0.0,
+        angle: float = 0.0,
+        flip: bool = False,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Create reference plane using pool."""
+        return await self._execute_with_pool(
+            "create_reference_plane",
+            lambda adapter: adapter.create_reference_plane(reference, offset, angle, flip),
+        )
+
+    async def create_axis(self, reference: str) -> AdapterResult[dict[str, Any]]:
+        """Create reference axis using pool."""
+        return await self._execute_with_pool(
+            "create_axis", lambda adapter: adapter.create_axis(reference)
+        )
+
     async def create_revolve(
         self, params: RevolveParameters
     ) -> AdapterResult[SolidWorksFeature]:

--- a/src/solidworks_mcp/adapters/connection_pool.py
+++ b/src/solidworks_mcp/adapters/connection_pool.py
@@ -638,6 +638,21 @@ class ConnectionPoolAdapter(SolidWorksAdapter):
             "create_axis", lambda adapter: adapter.create_axis(reference)
         )
 
+    async def mirror_feature(
+        self,
+        features: list[str],
+        mirror_plane: str,
+        merge: bool = True,
+        mirror_bodies: bool = True,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Mirror solid bodies or features using pool."""
+        return await self._execute_with_pool(
+            "mirror_feature",
+            lambda adapter: adapter.mirror_feature(
+                features, mirror_plane, merge, mirror_bodies
+            ),
+        )
+
     async def create_revolve(
         self, params: RevolveParameters
     ) -> AdapterResult[SolidWorksFeature]:

--- a/src/solidworks_mcp/adapters/mock_adapter.py
+++ b/src/solidworks_mcp/adapters/mock_adapter.py
@@ -28,6 +28,7 @@ from .base import (
     SolidWorksModel,
     SweepParameters,
 )
+from .solidworks.features import _AXIS_PLANE_PAIRS
 from .solidworks.sketch import RELATION_NAME_MAP
 
 #: Canned assembly component tree used by ``list_features`` when a mock
@@ -151,6 +152,13 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         # Assembly components inserted via insert_component, keyed by
         # insertion order. See insert_component/list_components/add_mate.
         self._components: list[str] = []
+        # Reference planes created via create_reference_plane, in creation
+        # order, used to invent sequential "PlaneN" names. Shared feature
+        # tree counter with create_axis mirrors the live adapter's
+        # features_before/features_after pair (see _feature_count in
+        # solidworks/features.py).
+        self._reference_planes: list[str] = []
+        self._feature_tree_count = 0
         self._operation_count = 0
 
         # Configurable simulation delays (in seconds)
@@ -2037,4 +2045,125 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
                 "geometry_moved": None,
             },
             execution_time=self._delays["model_operation"],
+        )
+
+    async def create_reference_plane(
+        self,
+        reference: str,
+        offset: float = 0.0,
+        angle: float = 0.0,
+        flip: bool = False,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Mock creating a reference plane offset from an existing plane.
+
+        Mirrors the live adapter's refusals rather than fabricating a
+        result it cannot know: an angled plane needs a second reference this
+        signature cannot supply, and an offset of zero would be coincident
+        with its reference. See ``_create_reference_plane_impl`` in
+        ``solidworks/features.py`` for the live contract this mirrors.
+
+        On success, invents a sequential ``PlaneN`` name tracked on
+        ``self._reference_planes`` and advances the shared mock feature-tree
+        counter so ``features_before``/``features_after`` differ by exactly
+        one, the same signal the live adapter derives from
+        ``IFeatureManager::GetFeatureCount``.
+
+        Args:
+            reference (str): Name of the reference plane or planar face.
+            offset (float): Offset distance in millimetres. Defaults to 0.0.
+            angle (float): Angle in degrees; unsupported (non-zero errors).
+                Defaults to 0.0.
+            flip (bool): Reverse the offset direction. Defaults to False.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The new plane's name and
+            parameters, or error.
+        """
+        if angle:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    "create_reference_plane does not support 'angle' yet: an "
+                    "angled plane needs a second reference (an axis or edge "
+                    "to rotate about) which this signature cannot take. Use "
+                    "'offset' for parallel planes."
+                ),
+            )
+
+        if not offset:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    "create_reference_plane requires a non-zero offset - a "
+                    "plane coincident with its reference is not useful"
+                ),
+            )
+
+        await asyncio.sleep(self._delays["feature_operation"])
+        self._operation_count += 1
+
+        before = self._feature_tree_count
+        self._feature_tree_count += 1
+        after = self._feature_tree_count
+
+        self._reference_planes.append(f"Plane{len(self._reference_planes) + 1}")
+
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data={
+                "name": self._reference_planes[-1],
+                "reference": reference,
+                "offset": offset,
+                "angle": None,
+                "flip": flip,
+                "features_before": before,
+                "features_after": after,
+            },
+            execution_time=self._delays["feature_operation"],
+        )
+
+    async def create_axis(self, reference: str) -> AdapterResult[dict[str, Any]]:
+        """Mock creating a reference axis along a principal direction.
+
+        Mirrors the live adapter's plane-pair mapping (``_AXIS_PLANE_PAIRS``
+        in ``solidworks/features.py``, imported here directly so the two can
+        never drift apart) and validation: only ``x``/``y``/``z``
+        (case-insensitive, leading +/- stripped) are accepted.
+
+        Args:
+            reference (str): "x", "y" or "z" (case-insensitive; leading +/-
+                stripped).
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The plane pair used and the
+            feature counter before/after, or error for an unknown reference.
+        """
+        key = str(reference or "").strip().lower().lstrip("+-")
+        if key not in _AXIS_PLANE_PAIRS:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    f"Unknown axis reference '{reference}'. "
+                    f"Use one of: {', '.join(sorted(_AXIS_PLANE_PAIRS))}."
+                ),
+            )
+
+        await asyncio.sleep(self._delays["feature_operation"])
+        self._operation_count += 1
+
+        before = self._feature_tree_count
+        self._feature_tree_count += 1
+        after = self._feature_tree_count
+
+        plane_a, plane_b = _AXIS_PLANE_PAIRS[key]
+
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data={
+                "reference": key,
+                "planes": [plane_a, plane_b],
+                "features_before": before,
+                "features_after": after,
+            },
+            execution_time=self._delays["feature_operation"],
         )

--- a/src/solidworks_mcp/adapters/mock_adapter.py
+++ b/src/solidworks_mcp/adapters/mock_adapter.py
@@ -159,6 +159,12 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         # solidworks/features.py).
         self._reference_planes: list[str] = []
         self._feature_tree_count = 0
+        # Volume tracked for mirror_feature, in mm^3. Seeded at the
+        # live-measured 1819569.1 mm^3 wing volume from
+        # _mirror_feature_impl in solidworks/features.py, then doubled on
+        # each successful mirror so volume_before/volume_after/volume_ratio
+        # stay self-consistent without a real geometry engine.
+        self._mirror_volume: float = 1819569.1
         self._operation_count = 0
 
         # Configurable simulation delays (in seconds)
@@ -2164,6 +2170,100 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
                 "planes": [plane_a, plane_b],
                 "features_before": before,
                 "features_after": after,
+            },
+            execution_time=self._delays["feature_operation"],
+        )
+
+    #: Built-in planes every SolidWorks part starts with. Combined with
+    #: ``self._reference_planes`` (planes created via create_reference_plane)
+    #: this is the set of plane names ``mirror_feature`` will accept.
+    _BUILTIN_PLANES = frozenset({"Front Plane", "Top Plane", "Right Plane"})
+
+    async def mirror_feature(
+        self,
+        features: list[str],
+        mirror_plane: str,
+        merge: bool = True,
+        mirror_bodies: bool = True,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Mock mirroring solid bodies or features about a plane.
+
+        The mock has no geometry engine, so it cannot measure a real volume
+        change - it mirrors the live adapter's refusals instead of
+        fabricating a result it cannot know. An empty source list or plane
+        name is rejected outright (matching ``_mirror_feature_impl`` in
+        ``solidworks/features.py`` verbatim), and a source or plane name
+        that was never created in this session is rejected the same way
+        ``_select_named_feature`` / ``_select_reference_entity`` would fail
+        to select it there.
+
+        On success, the tracked ``self._mirror_volume`` figure (seeded at
+        the live-measured 1819569.1 mm^3 wing volume) is doubled, matching
+        the ~2.0 ratio a correct mirror produces (measured live: 1.998528
+        for a lofted wing, exactly 2.0 for a boss whose sketch sits on the
+        plane).
+
+        Args:
+            features (list[str]): Body or feature names to mirror.
+            mirror_plane (str): Plane name to mirror about.
+            merge (bool): Merge the mirrored result with the original. Defaults to True.
+            mirror_bodies (bool): Mirror whole bodies rather than features. Defaults to True.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The mirror feature's name, inputs
+            and volume before/after, or error.
+        """
+        names = [n for n in (features or []) if n]
+        if not names:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error="mirror_feature requires at least one body or feature name",
+            )
+        if not mirror_plane:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error="mirror_feature requires a mirror plane name",
+            )
+
+        known_sources = {feature.name for feature in self._features.values()} | set(
+            self._components
+        )
+        for name in names:
+            if name not in known_sources:
+                kind = "body" if mirror_bodies else "feature"
+                return AdapterResult(
+                    status=AdapterResultStatus.ERROR,
+                    error=f"Failed to select {kind} to mirror: {name}",
+                )
+
+        known_planes = self._BUILTIN_PLANES | set(self._reference_planes)
+        if mirror_plane not in known_planes:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=f"Failed to select mirror plane: {mirror_plane}",
+            )
+
+        await asyncio.sleep(self._delays["feature_operation"])
+        self._operation_count += 1
+
+        volume_before = self._mirror_volume
+        volume_after = volume_before * 2
+        self._mirror_volume = volume_after
+
+        self._feature_tree_count += 1
+        feature_name = f"Mirror{self._feature_tree_count}"
+
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data={
+                "name": feature_name,
+                "mirrored": names,
+                "mirror_plane": mirror_plane,
+                "merge": bool(merge),
+                "mirror_bodies": bool(mirror_bodies),
+                "volume_before": volume_before,
+                "volume_after": volume_after,
+                "volume_ratio": round(volume_after / volume_before, 6),
             },
             execution_time=self._delays["feature_operation"],
         )

--- a/src/solidworks_mcp/adapters/mock_adapter.py
+++ b/src/solidworks_mcp/adapters/mock_adapter.py
@@ -158,6 +158,12 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         # features_before/features_after pair (see _feature_count in
         # solidworks/features.py).
         self._reference_planes: list[str] = []
+        # Axes created via create_axis, in creation order, used to invent
+        # sequential "AxisN" names the same way self._reference_planes
+        # invents "PlaneN" names, and to validate the axis name passed to
+        # pattern_circular the same way known_sources validates mirror
+        # sources.
+        self._axes: list[str] = []
         self._feature_tree_count = 0
         # Volume tracked for mirror_feature, in mm^3. Seeded at the
         # live-measured 1819569.1 mm^3 wing volume from
@@ -165,6 +171,13 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
         # each successful mirror so volume_before/volume_after/volume_ratio
         # stay self-consistent without a real geometry engine.
         self._mirror_volume: float = 1819569.1
+        # Volume tracked for pattern_circular, in mm^3. Seeded at the
+        # live-measured 48431.5 mm^3 hub+blade volume from
+        # _pattern_circular_impl in solidworks/features.py, then grown by
+        # _PATTERN_BLADE_VOLUME per extra instance on each successful
+        # pattern so volume_before/volume_after/volume_ratio stay
+        # self-consistent without a real geometry engine.
+        self._pattern_volume: float = 48431.5
         self._operation_count = 0
 
         # Configurable simulation delays (in seconds)
@@ -2163,9 +2176,18 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
 
         plane_a, plane_b = _AXIS_PLANE_PAIRS[key]
 
+        # Invent a sequential "AxisN" name, tracked on self._axes, the same
+        # way create_reference_plane invents "PlaneN" names on
+        # self._reference_planes. InsertAxis2 returns only a bool, so the
+        # live adapter cannot report a name either - but pattern_circular
+        # needs some name to validate the axis argument against, and this
+        # keeps the mock's bookkeeping consistent with the plane convention.
+        self._axes.append(f"Axis{len(self._axes) + 1}")
+
         return AdapterResult(
             status=AdapterResultStatus.SUCCESS,
             data={
+                "name": self._axes[-1],
                 "reference": key,
                 "planes": [plane_a, plane_b],
                 "features_before": before,
@@ -2261,6 +2283,108 @@ class MockSolidWorksAdapter(SolidWorksAdapter):
                 "mirror_plane": mirror_plane,
                 "merge": bool(merge),
                 "mirror_bodies": bool(mirror_bodies),
+                "volume_before": volume_before,
+                "volume_after": volume_after,
+                "volume_ratio": round(volume_after / volume_before, 6),
+            },
+            execution_time=self._delays["feature_operation"],
+        )
+
+    #: Live-measured "volume added per extra circular-pattern instance", in
+    #: mm^3: a hub+blade part measured 48431.5 mm3 for hub + 1 blade, and
+    #: 75916.4 mm3 once patterned to 4 blades (3 extra instances) - see
+    #: ``_pattern_circular_impl`` in ``solidworks/features.py``. Dividing the
+    #: growth by the 3 extra instances gives the per-instance figure used
+    #: below to scale ``self._pattern_volume`` by roughly ``count`` without a
+    #: real geometry engine.
+    _PATTERN_BLADE_VOLUME = (75916.4 - 48431.5) / 3
+
+    async def pattern_circular(
+        self,
+        features: list[str],
+        axis: str,
+        count: int,
+        angle: float = 360.0,
+        equal_spacing: bool = True,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Mock patterning features around an axis.
+
+        The mock has no geometry engine, so it cannot measure a real volume
+        change - it mirrors the live adapter's refusals instead of
+        fabricating a result it cannot know (matching
+        ``_pattern_circular_impl`` in ``solidworks/features.py`` verbatim
+        for the three argument checks below). An axis name that was never
+        created via ``create_axis`` in this session is rejected the same
+        way ``SelectByID2`` would fail to select it there.
+
+        On success, the tracked ``self._pattern_volume`` figure (seeded at
+        the live-measured 48431.5 mm^3 hub+blade volume) grows by
+        ``_PATTERN_BLADE_VOLUME * (count - 1)``, the live-derived
+        per-instance volume, so volume_before/volume_after/volume_ratio
+        stay self-consistent and scale with ``count`` roughly the way
+        adding more blades to the hub would - reproducing the live
+        48431.5 -> 75916.4 mm^3 measurement exactly for ``count=4``.
+
+        Args:
+            features (list[str]): Names of the features to pattern.
+            axis (str): Name of the axis to rotate about.
+            count (int): Total number of instances including the original.
+            angle (float): Total angle in degrees to spread them over. Defaults to 360.0.
+            equal_spacing (bool): Space instances evenly across ``angle``. Defaults to True.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: The pattern's name, inputs and
+            volume before/after, or error.
+        """
+        names = [n for n in (features or []) if n]
+        if not names:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error="pattern_circular requires at least one feature name",
+            )
+        if not axis:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error="pattern_circular requires an axis name to rotate about",
+            )
+        if int(count) < 2:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    f"pattern_circular needs a count of at least 2 (got {count}); "
+                    "a pattern of one is just the original feature"
+                ),
+            )
+
+        known_axes = set(self._axes)
+        if axis not in known_axes:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    f"Failed to select axis '{axis}'. Create one with "
+                    "create_axis first, and pass the name it returns."
+                ),
+            )
+
+        await asyncio.sleep(self._delays["feature_operation"])
+        self._operation_count += 1
+
+        volume_before = self._pattern_volume
+        volume_after = volume_before + self._PATTERN_BLADE_VOLUME * (int(count) - 1)
+        self._pattern_volume = volume_after
+
+        self._feature_tree_count += 1
+        pattern_name = f"CirPattern{self._feature_tree_count}"
+
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data={
+                "name": pattern_name,
+                "patterned": names,
+                "axis": axis,
+                "count": int(count),
+                "angle": float(angle),
+                "equal_spacing": bool(equal_spacing),
                 "volume_before": volume_before,
                 "volume_after": volume_after,
                 "volume_ratio": round(volume_after / volume_before, 6),

--- a/src/solidworks_mcp/adapters/solidworks/features.py
+++ b/src/solidworks_mcp/adapters/solidworks/features.py
@@ -55,6 +55,18 @@ class SolidWorksFeaturesMixin:
     ) -> AdapterResult[SolidWorksFeature]:
         return _add_chamfer_impl(self, distance, edge_names)
 
+    async def create_reference_plane(
+        self,
+        reference: str,
+        offset: float = 0.0,
+        angle: float = 0.0,
+        flip: bool = False,
+    ) -> AdapterResult[dict[str, Any]]:
+        return _create_reference_plane_impl(self, reference, offset, angle, flip)
+
+    async def create_axis(self, reference: str) -> AdapterResult[dict[str, Any]]:
+        return _create_axis_impl(self, reference)
+
 
 def _create_extrusion_impl(
     adapter: Any, params: ExtrusionParameters
@@ -1580,4 +1592,316 @@ def _add_chamfer_impl(
     return cast(
         AdapterResult[SolidWorksFeature],
         adapter._handle_com_operation("add_chamfer", _chamfer_operation),
+    )
+
+
+#: ``swRefPlaneReferenceConstraints_e`` members used by ``InsertRefPlane``.
+_REF_PLANE_DISTANCE = 8
+_REF_PLANE_ANGLE = 16
+_REF_PLANE_OPTION_FLIP = 256
+
+#: Plane pairs whose intersection defines each principal axis. ``InsertAxis2``
+#: builds an axis from two selected planes, so "x" means the line where the
+#: Top and Front planes meet.
+_AXIS_PLANE_PAIRS: dict[str, tuple[str, str]] = {
+    "x": ("Top Plane", "Front Plane"),
+    "y": ("Front Plane", "Right Plane"),
+    "z": ("Top Plane", "Right Plane"),
+}
+
+
+def _null_callout() -> Any:
+    """Return a VT_DISPATCH null for ``SelectByID2``'s ``Callout`` parameter.
+
+    A plain Python ``None`` marshals as ``VT_NULL``, which SolidWorks rejects
+    with ``DISP_E_TYPEMISMATCH`` - measured as
+    ``(-2147352571, 'Type mismatch.', None, 8)``. See runbook item 11.
+
+    Returns:
+        Any: A ``VARIANT(VT_DISPATCH, None)``, or ``None`` when pywin32 is
+        unavailable (mock/Linux runs, where no COM call will be made anyway).
+    """
+    try:
+        import pythoncom
+        import win32com.client as _win32com
+    except ImportError:  # pragma: no cover - Windows-only path
+        return None
+    return _win32com.VARIANT(pythoncom.VT_DISPATCH, None)
+
+
+def _feature_count(adapter: Any) -> int | None:
+    """Return how many features the active model has, or ``None``.
+
+    Used to confirm an edit changed the tree rather than trusting a COM call
+    that reports success without doing anything.
+
+    ``IFeatureManager::GetFeatureCount`` is used rather than walking
+    ``FirstFeature``/``GetNextFeature``: on SW 2025 that walk yields nothing
+    even with each dispatch flagged for ``IFeature``, which makes the tree
+    look empty instead of raising - so a "did anything change" check built on
+    it would silently answer "no" every time.
+
+    Args:
+        adapter: A connected adapter with a valid ``currentModel``.
+
+    Returns:
+        int | None: The feature count, or ``None`` when it cannot be read -
+        deliberately distinct from ``0``.
+    """
+    from .. import sw_type_info
+
+    manager = adapter._attempt(
+        lambda: adapter.currentModel.FeatureManager, default=None
+    )
+    if manager is None:
+        return None
+    flagged = sw_type_info.flagged(manager, "IFeatureManager")
+    count = adapter._attempt(lambda: flagged.GetFeatureCount(True), default=None)
+    return int(count) if isinstance(count, (int, float)) else None
+
+
+def _select_reference_entity(adapter: Any, reference: str, mark: int, append: bool) -> bool:
+    """Select a named plane or planar face under a given selection mark.
+
+    Prefers ``FeatureByName`` + ``IFeature::Select2``, which is reliable
+    across builds, and falls back to ``SelectByID2`` for planar faces that are
+    not named tree features.
+
+    Args:
+        adapter: A connected adapter with a valid ``currentModel``.
+        reference: Plane or face name, e.g. ``"Front Plane"`` or ``"Plane1"``.
+        mark: Selection mark the SolidWorks call expects for this role.
+        append: Add to the current selection rather than replacing it.
+
+    Returns:
+        bool: True when the entity was selected.
+    """
+    if _select_named_feature(adapter, reference, mark, append=append):
+        return True
+
+    callout = _null_callout()
+    for entity_type in ("PLANE", "FACE"):
+        selected = adapter._attempt(
+            lambda t=entity_type: adapter.currentModel.Extension.SelectByID2(
+                reference, t, 0.0, 0.0, 0.0, append, mark, callout, 0
+            ),
+            default=False,
+        )
+        if selected:
+            return True
+    return False
+
+
+def _create_reference_plane_impl(
+    adapter: Any,
+    reference: str,
+    offset: float,
+    angle: float,
+    flip: bool,
+) -> AdapterResult[dict[str, Any]]:
+    """Create a reference plane offset from, or angled to, an existing plane.
+
+    Wraps ``IFeatureManager::InsertRefPlane(FirstConstraint,
+    FirstConstraintAngleOrDistance, Second, 0, Third, 0)``. The reference
+    entity must be selected under **mark 0** first, which is what the
+    SolidWorks documentation example does before the identical call.
+
+    This is what lets a sketch be opened anywhere other than the six built-in
+    planes. ``create_sketch`` already accepts a plane by its tree name, so the
+    name returned here can be passed straight to it - verified live: a plane
+    76.2 mm off the Front Plane came back as ``"Plane1"``, and a circle
+    sketched on it extruded to exactly the expected volume.
+
+    Args:
+        adapter: A connected ``PyWin32Adapter`` with a valid ``currentModel``.
+        reference: Name of the reference plane or planar face.
+        offset: Offset distance in **millimetres**, converted to metres.
+        angle: Angle in **degrees**; used instead of ``offset`` when non-zero.
+        flip: Reverse the offset or angle direction.
+
+    Returns:
+        AdapterResult[dict[str, Any]]: The new plane's name and the parameters
+        used. ``ERROR`` when there is no model, the reference cannot be
+        selected, or no plane was added to the tree.
+
+    Raises:
+        Exception: Propagated through ``_handle_com_operation``.
+
+    Example::
+
+        plane = await adapter.create_reference_plane("Front Plane", offset=76.2)
+        await adapter.create_sketch(plane.data["name"])
+    """
+    if not adapter.currentModel:
+        return AdapterResult(status=AdapterResultStatus.ERROR, error="No active model")
+
+    if not reference:
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="create_reference_plane requires a reference plane/face name",
+        )
+
+    if angle:
+        # Measured on SW 2025: InsertRefPlane with the angle constraint and a
+        # single selected plane adds nothing to the tree and reports no error.
+        # An angled plane is under-defined by one reference - SolidWorks needs
+        # a second entity (an axis or edge) under mark 1 to rotate about.
+        # Refusing is better than returning a plane name that does not exist.
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error=(
+                "create_reference_plane does not support 'angle' yet: an "
+                "angled plane needs a second reference (an axis or edge to "
+                "rotate about) which this signature cannot take. Use 'offset' "
+                "for parallel planes."
+            ),
+        )
+
+    if not offset:
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error=(
+                "create_reference_plane requires a non-zero offset - a plane "
+                "coincident with its reference is not useful"
+            ),
+        )
+
+    def _plane_operation() -> dict[str, Any]:
+        before = _feature_count(adapter)
+        adapter._attempt(
+            lambda: adapter.currentModel.ClearSelection2(True), default=None
+        )
+
+        if not _select_reference_entity(adapter, reference, 0, append=False):
+            raise Exception(
+                f"Failed to select reference plane/face: {reference}. "
+                "Use an existing plane name (e.g. 'Front Plane') or a planar "
+                "face."
+            )
+
+        constraint = _REF_PLANE_DISTANCE
+        value = float(offset) / 1000.0
+        if flip:
+            constraint |= _REF_PLANE_OPTION_FLIP
+
+        from .. import sw_type_info
+
+        feature_manager = sw_type_info.flagged(
+            adapter.currentModel.FeatureManager, "IFeatureManager"
+        )
+        plane = adapter._attempt(
+            lambda: feature_manager.InsertRefPlane(constraint, value, 0, 0.0, 0, 0.0),
+            default=None,
+        )
+
+        after = _feature_count(adapter)
+        if before is not None and after is not None and after <= before:
+            raise Exception(
+                f"No reference plane was added from '{reference}' - the "
+                f"feature tree still has {after} feature(s)."
+            )
+        if plane is None:
+            raise Exception(
+                f"InsertRefPlane returned nothing for reference '{reference}'"
+            )
+
+        name = adapter._attempt(
+            lambda: adapter._get_attr_or_call(plane, "Name"), default=None
+        )
+        if not name:
+            # No invented fallback: a caller needs the real name to sketch on
+            # the plane, and a made-up one fails later and further away.
+            raise Exception(
+                "The reference plane was created but its name could not be "
+                "read, so it cannot be referenced by create_sketch."
+            )
+
+        return {
+            "name": str(name),
+            "reference": reference,
+            "offset": offset or None,
+            "angle": angle or None,
+            "flip": flip,
+            "features_before": before,
+            "features_after": after,
+        }
+
+    return cast(
+        AdapterResult[dict[str, Any]],
+        adapter._handle_com_operation("create_reference_plane", _plane_operation),
+    )
+
+
+def _create_axis_impl(adapter: Any, reference: str) -> AdapterResult[dict[str, Any]]:
+    """Create a reference axis along a principal direction.
+
+    Wraps ``IModelDoc2::InsertAxis2(AutoSize)`` - note the interface: it is on
+    ``IModelDoc2``, **not** ``IFeatureManager``. It builds an axis from two
+    selected planes, so an axis is requested by naming the direction and the
+    matching plane pair is selected here.
+
+    ``InsertAxis2`` returns a plain boolean rather than the axis, so success is
+    confirmed by the feature count rising.
+
+    Args:
+        adapter: A connected ``PyWin32Adapter`` with a valid ``currentModel``.
+        reference: ``"x"``, ``"y"`` or ``"z"``.
+
+    Returns:
+        AdapterResult[dict[str, Any]]: The planes used and how the tree
+        changed. ``ERROR`` for an unknown direction or when no axis appeared.
+
+    Raises:
+        Exception: Propagated through ``_handle_com_operation``.
+    """
+    if not adapter.currentModel:
+        return AdapterResult(status=AdapterResultStatus.ERROR, error="No active model")
+
+    key = str(reference or "").strip().lower().lstrip("+-")
+    if key not in _AXIS_PLANE_PAIRS:
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error=(
+                f"Unknown axis reference '{reference}'. "
+                f"Use one of: {', '.join(sorted(_AXIS_PLANE_PAIRS))}."
+            ),
+        )
+
+    plane_a, plane_b = _AXIS_PLANE_PAIRS[key]
+
+    def _axis_operation() -> dict[str, Any]:
+        before = _feature_count(adapter)
+        adapter._attempt(
+            lambda: adapter.currentModel.ClearSelection2(True), default=None
+        )
+
+        for index, plane in enumerate((plane_a, plane_b)):
+            if not _select_reference_entity(adapter, plane, 0, append=index > 0):
+                raise Exception(f"Failed to select '{plane}' for the axis")
+
+        adapter._attempt(lambda: adapter.currentModel.InsertAxis2(True), default=None)
+
+        after = _feature_count(adapter)
+        if before is None or after is None:
+            raise Exception(
+                "The feature count could not be read, so whether an axis was "
+                "created is unknown."
+            )
+        if after <= before:
+            raise Exception(
+                f"No reference axis was created from {plane_a} + {plane_b}. "
+                "InsertAxis2 reports only a boolean and the feature tree is "
+                "unchanged."
+            )
+
+        return {
+            "reference": key,
+            "planes": [plane_a, plane_b],
+            "features_before": before,
+            "features_after": after,
+        }
+
+    return cast(
+        AdapterResult[dict[str, Any]],
+        adapter._handle_com_operation("create_axis", _axis_operation),
     )

--- a/src/solidworks_mcp/adapters/solidworks/features.py
+++ b/src/solidworks_mcp/adapters/solidworks/features.py
@@ -67,6 +67,90 @@ class SolidWorksFeaturesMixin:
     async def create_axis(self, reference: str) -> AdapterResult[dict[str, Any]]:
         return _create_axis_impl(self, reference)
 
+    async def pattern_circular(
+        self,
+        features: list[str],
+        axis: str,
+        count: int,
+        angle: float = 360.0,
+        equal_spacing: bool = True,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Pattern features around an axis.
+
+        ``FeatureCircularPattern5`` returns a Feature object whether or not it
+        produced anything, so the model volume is measured before and after
+        here - in the async layer, using ``get_mass_properties``, which is the
+        read path that works. Reading volume inline inside the COM closure
+        returns ``None`` while a selection is active.
+
+        Note that instances landing off the parent body are silently dropped
+        by SolidWorks, so the volume rises by less than ``count - 1`` times the
+        seed. That is correct behaviour, not a failure - only *no* growth at
+        all means the pattern did nothing.
+
+        Args:
+            features: Names of the features to pattern.
+            axis: Name of the axis to rotate about, e.g. ``"Axis1"`` from
+                ``create_axis``.
+            count: Total number of instances including the original.
+            angle: Total angle in degrees to spread them over. Defaults to a
+                full 360.
+            equal_spacing: Space instances evenly across ``angle``.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: What was patterned and the volume
+            before and after. ``ERROR`` when nothing could be selected or the
+            volume did not grow.
+        """
+        adapter = self._adapter(self)
+        if not adapter.currentModel:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR, error="No active model"
+            )
+
+        before = await self.get_mass_properties()
+        volume_before = (
+            before.data.volume if before.is_success and before.data else None
+        )
+
+        result = _pattern_circular_impl(self, features, axis, count, angle, equal_spacing)
+        if not result.is_success:
+            return result
+
+        after = await self.get_mass_properties()
+        volume_after = after.data.volume if after.is_success and after.data else None
+
+        if volume_before is None or volume_after is None:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    "The pattern call returned a feature but the volume could "
+                    "not be read before and after, so whether any instances "
+                    "were created is unknown."
+                ),
+            )
+        if volume_after <= volume_before * 1.0001:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    f"The circular pattern produced no geometry (volume "
+                    f"{volume_before:.1f} -> {volume_after:.1f} mm3). "
+                    f"SolidWorks returned a feature but patterned nothing. "
+                    f"Check that '{axis}' is a real axis in the tree and that "
+                    f"the instances land on the parent body."
+                ),
+            )
+
+        data = dict(result.data or {})
+        data["volume_before"] = volume_before
+        data["volume_after"] = volume_after
+        data["volume_ratio"] = round(volume_after / volume_before, 6)
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data=data,
+            execution_time=result.execution_time,
+        )
+
     async def mirror_feature(
         self,
         features: list[str],
@@ -2119,4 +2203,153 @@ def _mirror_feature_impl(
     return cast(
         AdapterResult[dict[str, Any]],
         adapter._handle_com_operation("mirror_feature", _mirror_operation),
+    )
+
+
+#: Selection marks ``FeatureCircularPattern5`` expects, per the SolidWorks API
+#: reference: the direction axis is mark 1 and the features to pattern are
+#: mark 4. These differ from the mirror marks - reusing those silently
+#: produces a feature that patterns nothing.
+_PATTERN_MARK_AXIS = 1
+_PATTERN_MARK_FEATURES = 4
+
+
+def _pattern_circular_impl(
+    adapter: Any,
+    features: list[str],
+    axis: str,
+    count: int,
+    angle: float,
+    equal_spacing: bool,
+) -> AdapterResult[dict[str, Any]]:
+    """Select the axis and features, then call FeatureCircularPattern5.
+
+    This build exposes FeatureCircularPattern through ...5; v5 is used, with
+    the 14 arguments it declares. ``DName`` is a direction *name string*, so
+    the axis is both selected under mark 1 and named in the call.
+
+    Whether anything was produced is checked by the caller, which can read
+    volume through ``get_mass_properties``.
+
+    Args:
+        adapter: A connected ``PyWin32Adapter`` with a valid ``currentModel``.
+        features: Feature names to pattern.
+        axis: Axis name to rotate about.
+        count: Total instances including the original.
+        angle: Total spread in degrees.
+        equal_spacing: Space instances evenly across ``angle``.
+
+    Returns:
+        AdapterResult[dict[str, Any]]: The pattern's name and inputs.
+
+    Raises:
+        Exception: Propagated through ``_handle_com_operation``.
+    """
+    if not adapter.currentModel:
+        return AdapterResult(status=AdapterResultStatus.ERROR, error="No active model")
+
+    names = [n for n in (features or []) if n]
+    if not names:
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="pattern_circular requires at least one feature name",
+        )
+    if not axis:
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="pattern_circular requires an axis name to rotate about",
+        )
+    if int(count) < 2:
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error=(
+                f"pattern_circular needs a count of at least 2 (got {count}); "
+                "a pattern of one is just the original feature"
+            ),
+        )
+
+    def _pattern_operation() -> dict[str, Any]:
+        import math
+
+        adapter._attempt(
+            lambda: adapter.currentModel.ClearSelection2(True), default=None
+        )
+        callout = _null_callout()
+
+        axis_selected = bool(
+            adapter._attempt(
+                lambda: adapter.currentModel.Extension.SelectByID2(
+                    axis, "AXIS", 0.0, 0.0, 0.0, False, _PATTERN_MARK_AXIS, callout, 0
+                ),
+                default=False,
+            )
+        )
+        if not axis_selected:
+            raise Exception(
+                f"Failed to select axis '{axis}'. Create one with create_axis "
+                "first, and pass the name it returns."
+            )
+
+        for name in names:
+            selected = bool(
+                adapter._attempt(
+                    lambda n=name: adapter.currentModel.Extension.SelectByID2(
+                        n, "BODYFEATURE", 0.0, 0.0, 0.0, True,
+                        _PATTERN_MARK_FEATURES, callout, 0,
+                    ),
+                    default=False,
+                )
+            )
+            if not selected:
+                selected = _select_named_feature(
+                    adapter, name, _PATTERN_MARK_FEATURES, append=True
+                )
+            if not selected:
+                raise Exception(f"Failed to select feature to pattern: {name}")
+
+        from .. import sw_type_info
+
+        feature_manager = sw_type_info.flagged(
+            adapter.currentModel.FeatureManager, "IFeatureManager"
+        )
+        feature = adapter._attempt(
+            lambda: feature_manager.FeatureCircularPattern5(
+                int(count),                      # Number
+                math.radians(float(angle)),      # Spacing (radians)
+                False,                           # FlipDirection
+                axis,                            # DName
+                False,                           # GeometryPattern
+                bool(equal_spacing),             # EqualSpacing
+                False,                           # VaryInstance
+                False,                           # SyncSubAssemblies
+                False,                           # BDir2
+                False,                           # BSymmetric
+                0,                               # Number2
+                0.0,                             # Spacing2
+                "",                              # DName2
+                False,                           # EqualSpacing2
+            ),
+            default=None,
+        )
+        if feature is None:
+            raise Exception(
+                f"FeatureCircularPattern5 returned nothing (features={names}, "
+                f"axis={axis})"
+            )
+
+        pattern_name = adapter._attempt(
+            lambda: adapter._get_attr_or_call(feature, "Name"), default=None
+        )
+        return {
+            "name": str(pattern_name) if pattern_name else None,
+            "patterned": names,
+            "axis": axis,
+            "count": int(count),
+            "angle": float(angle),
+            "equal_spacing": bool(equal_spacing),
+        }
+
+    return cast(
+        AdapterResult[dict[str, Any]],
+        adapter._handle_com_operation("pattern_circular", _pattern_operation),
     )

--- a/src/solidworks_mcp/adapters/solidworks/features.py
+++ b/src/solidworks_mcp/adapters/solidworks/features.py
@@ -67,6 +67,92 @@ class SolidWorksFeaturesMixin:
     async def create_axis(self, reference: str) -> AdapterResult[dict[str, Any]]:
         return _create_axis_impl(self, reference)
 
+    async def mirror_feature(
+        self,
+        features: list[str],
+        mirror_plane: str,
+        merge: bool = True,
+        mirror_bodies: bool = True,
+    ) -> AdapterResult[dict[str, Any]]:
+        """Mirror solid bodies or features about a plane.
+
+        ``InsertMirrorFeature`` returns a Feature object even when it mirrored
+        nothing, so the model's volume is measured before and after and the
+        call is reported as failed if the volume did not grow. That check runs
+        here rather than inside the COM closure because ``get_mass_properties``
+        is the read path known to work - reading ``CreateMassProperty().Volume``
+        inline returns ``None`` when a plane is still in the selection set,
+        which silently disables the check.
+
+        Args:
+            features: Names of the bodies (or features) to mirror. For a body
+                mirror these are the names as they appear under Solid Bodies,
+                which for a lofted wing is the loft's own name.
+            mirror_plane: Plane to mirror about, e.g. ``"Right Plane"``.
+            merge: Merge the mirrored result with the original.
+            mirror_bodies: Mirror whole solid bodies rather than features.
+                Defaults to ``True``, which is what works for anything built
+                from a loft or sweep: SolidWorks only resolves a *feature*
+                mirror when the feature's own sketch sits on the mirror plane,
+                so a wing lofted between stations offset from the centreline
+                cannot be feature-mirrored. Measured on SW 2025: body mirroring
+                a 1819569 mm^3 wing about the Right Plane gave 3636460 mm^3.
+
+        Returns:
+            AdapterResult[dict[str, Any]]: What was mirrored, and the volume
+            before and after. ``ERROR`` when nothing was selected, the call
+            failed, or the volume did not grow.
+        """
+        adapter = self._adapter(self)
+        if not adapter.currentModel:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR, error="No active model"
+            )
+
+        before = await self.get_mass_properties()
+        volume_before = before.data.volume if before.is_success and before.data else None
+
+        result = _mirror_feature_impl(
+            self, features, mirror_plane, merge, mirror_bodies
+        )
+        if not result.is_success:
+            return result
+
+        after = await self.get_mass_properties()
+        volume_after = after.data.volume if after.is_success and after.data else None
+
+        if volume_before is None or volume_after is None:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    "The mirror call returned a feature but the volume could "
+                    "not be read before and after, so whether any geometry was "
+                    "produced is unknown."
+                ),
+            )
+        if volume_after <= volume_before * 1.001:
+            return AdapterResult(
+                status=AdapterResultStatus.ERROR,
+                error=(
+                    f"The mirror produced no new geometry (volume "
+                    f"{volume_before:.1f} -> {volume_after:.1f} mm3). "
+                    "SolidWorks returned a feature but mirrored nothing. With "
+                    "mirror_bodies=False this happens whenever the feature's "
+                    "own sketch does not sit on the mirror plane; try "
+                    "mirror_bodies=True to mirror the solid body instead."
+                ),
+            )
+
+        data = dict(result.data or {})
+        data["volume_before"] = volume_before
+        data["volume_after"] = volume_after
+        data["volume_ratio"] = round(volume_after / volume_before, 6)
+        return AdapterResult(
+            status=AdapterResultStatus.SUCCESS,
+            data=data,
+            execution_time=result.execution_time,
+        )
+
 
 def _create_extrusion_impl(
     adapter: Any, params: ExtrusionParameters
@@ -1904,4 +1990,133 @@ def _create_axis_impl(adapter: Any, reference: str) -> AdapterResult[dict[str, A
     return cast(
         AdapterResult[dict[str, Any]],
         adapter._handle_com_operation("create_axis", _axis_operation),
+    )
+
+
+#: Selection marks ``InsertMirrorFeature`` expects, per the SolidWorks API
+#: reference: features 1, faces 128, bodies 256, and the mirror plane 2.
+#: Wrong marks and the call reports a feature while mirroring nothing.
+_MIRROR_MARK_FEATURES = 1
+_MIRROR_MARK_BODIES = 256
+_MIRROR_MARK_PLANE = 2
+
+
+def _mirror_feature_impl(
+    adapter: Any,
+    features: list[str],
+    mirror_plane: str,
+    merge: bool,
+    mirror_bodies: bool,
+) -> AdapterResult[dict[str, Any]]:
+    """Select the sources and the plane, then call InsertMirrorFeature.
+
+    Wraps ``IFeatureManager::InsertMirrorFeature(BMirrorBody,
+    BGeometryPattern, BMerge, BKnit)``. There is no ``...2`` overload of this
+    call. Everything it acts on must be pre-selected under the right mark, so
+    the marks are the whole game - see ``_MIRROR_MARK_*``.
+
+    Whether the mirror actually produced geometry is checked by the caller,
+    which can read volume through ``get_mass_properties``.
+
+    Args:
+        adapter: A connected ``PyWin32Adapter`` with a valid ``currentModel``.
+        features: Body or feature names to mirror.
+        mirror_plane: Plane name to mirror about.
+        merge: Merge the result with the original.
+        mirror_bodies: Select and mirror whole bodies rather than features.
+
+    Returns:
+        AdapterResult[dict[str, Any]]: The mirror feature's name and inputs.
+
+    Raises:
+        Exception: Propagated through ``_handle_com_operation``.
+    """
+    if not adapter.currentModel:
+        return AdapterResult(status=AdapterResultStatus.ERROR, error="No active model")
+
+    names = [n for n in (features or []) if n]
+    if not names:
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="mirror_feature requires at least one body or feature name",
+        )
+    if not mirror_plane:
+        return AdapterResult(
+            status=AdapterResultStatus.ERROR,
+            error="mirror_feature requires a mirror plane name",
+        )
+
+    source_mark = _MIRROR_MARK_BODIES if mirror_bodies else _MIRROR_MARK_FEATURES
+    entity_type = "SOLIDBODY" if mirror_bodies else None
+
+    def _mirror_operation() -> dict[str, Any]:
+        adapter._attempt(
+            lambda: adapter.currentModel.ClearSelection2(True), default=None
+        )
+        callout = _null_callout()
+
+        for index, name in enumerate(names):
+            append = index > 0
+            selected = False
+            if entity_type is not None:
+                selected = bool(
+                    adapter._attempt(
+                        lambda n=name, a=append: (
+                            adapter.currentModel.Extension.SelectByID2(
+                                n, entity_type, 0.0, 0.0, 0.0, a, source_mark,
+                                callout, 0,
+                            )
+                        ),
+                        default=False,
+                    )
+                )
+            if not selected:
+                selected = _select_named_feature(
+                    adapter, name, source_mark, append=append
+                )
+            if not selected:
+                kind = "body" if mirror_bodies else "feature"
+                raise Exception(f"Failed to select {kind} to mirror: {name}")
+
+        if not _select_reference_entity(
+            adapter, mirror_plane, _MIRROR_MARK_PLANE, append=True
+        ):
+            raise Exception(f"Failed to select mirror plane: {mirror_plane}")
+
+        from .. import sw_type_info
+
+        feature_manager = sw_type_info.flagged(
+            adapter.currentModel.FeatureManager, "IFeatureManager"
+        )
+        feature = adapter._attempt(
+            lambda: feature_manager.InsertMirrorFeature(
+                bool(mirror_bodies),  # BMirrorBody
+                False,  # BGeometryPattern - solve the whole feature
+                bool(merge),  # BMerge
+                False,  # BKnit
+            ),
+            default=None,
+        )
+        if feature is None:
+            raise Exception(
+                f"InsertMirrorFeature returned nothing (sources={names}, "
+                f"plane={mirror_plane})"
+            )
+
+        name = adapter._attempt(
+            lambda: adapter._get_attr_or_call(feature, "Name"), default=None
+        )
+        return {
+            # No invented fallback: an unreadable name is reported as None
+            # rather than as the literal "Mirror", which would not resolve.
+            "name": str(name) if name else None,
+            "mirrored": names,
+            "mirror_plane": mirror_plane,
+            "merge": bool(merge),
+            "mirror_bodies": bool(mirror_bodies),
+        }
+
+    return cast(
+        AdapterResult[dict[str, Any]],
+        adapter._handle_com_operation("mirror_feature", _mirror_operation),
     )

--- a/src/solidworks_mcp/tools/modeling.py
+++ b/src/solidworks_mcp/tools/modeling.py
@@ -453,6 +453,55 @@ class AddMateInput(CompatInput):
             raise ValueError("component_a and component_b are required")
 
 
+class CreateReferencePlaneInput(CompatInput):
+    """Input schema for creating a reference plane.
+
+    Attributes:
+        reference (str): Name of the reference plane or planar face.
+        offset (float): Offset distance in millimetres.
+        angle (float): Angle in degrees.
+        flip (bool): Reverse the offset or angle direction.
+    """
+
+    reference: str = Field(
+        description="Name of the reference plane or planar face to offset "
+        "from, e.g. 'Front Plane'"
+    )
+    offset: float = Field(
+        default=0.0,
+        description="Offset distance in millimetres. Must be non-zero — a "
+        "plane coincident with its reference is not useful",
+    )
+    angle: float = Field(
+        default=0.0,
+        description="Angle in degrees. Not yet supported: an angled plane "
+        "needs a second reference this tool cannot take, so a non-zero "
+        "value errors. Use offset for parallel planes",
+    )
+    flip: bool = Field(default=False, description="Reverse the offset direction")
+
+    def model_post_init(self, __context: Any) -> None:
+        if not self.reference.strip():
+            raise ValueError("reference is required")
+
+
+class CreateAxisInput(CompatInput):
+    """Input schema for creating a reference axis.
+
+    Attributes:
+        reference (str): Principal axis direction.
+    """
+
+    reference: str = Field(
+        description="Principal axis direction: 'x', 'y' or 'z' "
+        "(case-insensitive; a leading +/- is stripped)"
+    )
+
+    def model_post_init(self, __context: Any) -> None:
+        if not self.reference.strip():
+            raise ValueError("reference is required")
+
+
 class CreateDrawingInput(CompatInput):
     """Input schema for creating a new drawing.
 
@@ -1432,5 +1481,104 @@ async def register_modeling_tools(
             logger.error(f"Error in list_components tool: {e}")
             return {"status": "error", "message": f"Unexpected error: {str(e)}"}
 
-    tool_count = 15  # Number of tools registered
+    @mcp.tool()
+    async def create_reference_plane(
+        input_data: CreateReferencePlaneInput,
+    ) -> dict[str, Any]:
+        """Create a reference plane offset from an existing plane or planar face.
+
+        Adds a new plane to the feature tree, parallel to and offset from the
+        named reference. The returned plane name can be passed straight to
+        ``create_sketch`` to sketch anywhere other than the six built-in
+        planes.
+
+        Angled planes are not supported by this tool: an angled plane needs a
+        second reference (an axis or edge) to rotate about, which this
+        signature cannot take. Use ``offset`` for parallel planes. An
+        ``offset`` of zero is rejected — a plane coincident with its
+        reference is not useful.
+
+        Args:
+            input_data (CreateReferencePlaneInput): Reference name, offset,
+                angle and flip.
+
+        Returns:
+            dict[str, Any]: Status and the new plane's details.
+
+        Example:
+            ```python
+            plane = await create_reference_plane(
+                {"reference": "Front Plane", "offset": 76.2}
+            )
+            await create_sketch({"plane": plane["plane"]["name"]})
+            ```
+        """
+        try:
+            input_data = _normalize_input(input_data, CreateReferencePlaneInput)
+            result = await adapter.create_reference_plane(
+                input_data.reference,
+                input_data.offset,
+                input_data.angle,
+                input_data.flip,
+            )
+            if result.is_success:
+                data = result.data if isinstance(result.data, dict) else {}
+                return {
+                    "status": "success",
+                    "message": f"Created reference plane: {data.get('name', 'Plane')}",
+                    "plane": data,
+                    "execution_time": result.execution_time,
+                }
+            return {
+                "status": "error",
+                "message": f"Failed to create reference plane: {result.error}",
+            }
+        except Exception as e:
+            logger.error(f"Error in create_reference_plane tool: {e}")
+            return {"status": "error", "message": f"Unexpected error: {str(e)}"}
+
+    @mcp.tool()
+    async def create_axis(input_data: CreateAxisInput) -> dict[str, Any]:
+        """Create a reference axis along a principal direction.
+
+        Builds an axis from the intersection of two built-in planes: x from
+        Top + Front, y from Front + Right, z from Top + Right.
+
+        Args:
+            input_data (CreateAxisInput): The principal direction ('x', 'y'
+                or 'z').
+
+        Returns:
+            dict[str, Any]: Status and the axis details (planes used).
+
+        Example:
+            ```python
+            result = await create_axis({"reference": "z"})
+            ```
+        """
+        try:
+            input_data = _normalize_input(input_data, CreateAxisInput)
+            result = await adapter.create_axis(input_data.reference)
+            if result.is_success:
+                data = result.data if isinstance(result.data, dict) else {}
+                axis_name = data.get("reference", input_data.reference)
+                return {
+                    "status": "success",
+                    "message": f"Created {axis_name} axis",
+                    "axis": data,
+                    "execution_time": result.execution_time,
+                }
+            return {
+                "status": "error",
+                "message": f"Failed to create axis: {result.error}",
+            }
+        except Exception as e:
+            logger.error(f"Error in create_axis tool: {e}")
+            return {"status": "error", "message": f"Unexpected error: {str(e)}"}
+
+    # Counted from the registry rather than hand-maintained. The literal that
+    # used to live here had drifted: it read 15 while 16 tools were actually
+    # registered, so the function misreported its own work and the test
+    # enshrined the wrong number.
+    tool_count = len(await mcp.list_tools())
     return tool_count

--- a/src/solidworks_mcp/tools/modeling.py
+++ b/src/solidworks_mcp/tools/modeling.py
@@ -540,6 +540,48 @@ class MirrorFeatureInput(CompatInput):
             raise ValueError("mirror_plane is required")
 
 
+class PatternCircularInput(CompatInput):
+    """Input schema for patterning features around an axis.
+
+    Attributes:
+        features (list[str]): Names of the features to pattern.
+        axis (str): Name of the axis to rotate about.
+        count (int): Total number of instances including the original.
+        angle (float): Total angle in degrees to spread instances over.
+        equal_spacing (bool): Space instances evenly across angle.
+    """
+
+    features: list[str] = Field(
+        default_factory=list,
+        description="Names of the features to pattern. At least one required.",
+    )
+    axis: str = Field(
+        description="Name of the axis to rotate about, e.g. 'Axis1' as "
+        "created by create_axis"
+    )
+    count: int = Field(
+        description="Total number of instances including the original. "
+        "Must be at least 2 - a pattern of one is just the original feature"
+    )
+    angle: float = Field(
+        default=360.0,
+        description="Total angle in degrees to spread the instances over. "
+        "Defaults to a full 360",
+    )
+    equal_spacing: bool = Field(
+        default=True,
+        description="Space instances evenly across 'angle'",
+    )
+
+    def model_post_init(self, __context: Any) -> None:
+        if not self.features:
+            raise ValueError("features must contain at least one name")
+        if not self.axis.strip():
+            raise ValueError("axis is required")
+        if self.count < 2:
+            raise ValueError("count must be at least 2")
+
+
 class CreateDrawingInput(CompatInput):
     """Input schema for creating a new drawing.
 
@@ -1662,6 +1704,57 @@ async def register_modeling_tools(
             }
         except Exception as e:
             logger.error(f"Error in mirror_feature tool: {e}")
+            return {"status": "error", "message": f"Unexpected error: {str(e)}"}
+
+    @mcp.tool()
+    async def pattern_circular(input_data: PatternCircularInput) -> dict[str, Any]:
+        """Pattern features around an axis.
+
+        Selects the named axis and features, then creates a circular
+        pattern. The pattern is verified by comparing model volume before
+        and after: SolidWorks can report a feature even when it patterned
+        nothing, so a volume that did not grow is reported as an error
+        rather than a false success.
+
+        Args:
+            input_data (PatternCircularInput): Feature names, axis, count,
+                angle, and equal_spacing.
+
+        Returns:
+            dict[str, Any]: Status and the pattern's details, including
+            volume before/after and the resulting ratio.
+
+        Example:
+            ```python
+            result = await pattern_circular(
+                {"features": ["Boss-Extrude1"], "axis": "Axis1", "count": 4}
+            )
+            ```
+        """
+        try:
+            input_data = _normalize_input(input_data, PatternCircularInput)
+            result = await adapter.pattern_circular(
+                input_data.features,
+                input_data.axis,
+                input_data.count,
+                input_data.angle,
+                input_data.equal_spacing,
+            )
+            if result.is_success:
+                data = result.data if isinstance(result.data, dict) else {}
+                return {
+                    "status": "success",
+                    "message": f"Patterned {', '.join(input_data.features)} "
+                    f"around {input_data.axis} ({input_data.count} instances)",
+                    "pattern": data,
+                    "execution_time": result.execution_time,
+                }
+            return {
+                "status": "error",
+                "message": f"Failed to pattern feature: {result.error}",
+            }
+        except Exception as e:
+            logger.error(f"Error in pattern_circular tool: {e}")
             return {"status": "error", "message": f"Unexpected error: {str(e)}"}
 
     # Counted from the registry rather than hand-maintained. The literal that

--- a/src/solidworks_mcp/tools/modeling.py
+++ b/src/solidworks_mcp/tools/modeling.py
@@ -502,6 +502,44 @@ class CreateAxisInput(CompatInput):
             raise ValueError("reference is required")
 
 
+class MirrorFeatureInput(CompatInput):
+    """Input schema for mirroring solid bodies or features.
+
+    Attributes:
+        features (list[str]): Body or feature names to mirror.
+        mirror_plane (str): Plane name to mirror about.
+        merge (bool): Merge the mirrored result with the original.
+        mirror_bodies (bool): Mirror whole bodies rather than features.
+    """
+
+    features: list[str] = Field(
+        default_factory=list,
+        description="Body or feature names to mirror. At least one required. "
+        "For a body mirror these are the names as they appear under Solid "
+        "Bodies, which for a lofted wing is the loft's own name",
+    )
+    mirror_plane: str = Field(
+        description="Plane name to mirror about, e.g. 'Right Plane'"
+    )
+    merge: bool = Field(
+        default=True,
+        description="Merge the mirrored result with the original body",
+    )
+    mirror_bodies: bool = Field(
+        default=True,
+        description="Mirror whole solid bodies rather than individual "
+        "features. Defaults to True, which is what works for anything "
+        "built from a loft or sweep - a feature mirror only resolves when "
+        "the feature's own sketch sits on the mirror plane",
+    )
+
+    def model_post_init(self, __context: Any) -> None:
+        if not self.features:
+            raise ValueError("features must contain at least one name")
+        if not self.mirror_plane.strip():
+            raise ValueError("mirror_plane is required")
+
+
 class CreateDrawingInput(CompatInput):
     """Input schema for creating a new drawing.
 
@@ -1574,6 +1612,56 @@ async def register_modeling_tools(
             }
         except Exception as e:
             logger.error(f"Error in create_axis tool: {e}")
+            return {"status": "error", "message": f"Unexpected error: {str(e)}"}
+
+    @mcp.tool()
+    async def mirror_feature(input_data: MirrorFeatureInput) -> dict[str, Any]:
+        """Mirror solid bodies or features about a plane.
+
+        Selects the named sources and the mirror plane, then mirrors them.
+        The mirror is verified by comparing model volume before and after:
+        SolidWorks can report a feature even when it mirrored nothing, so a
+        volume that did not grow is reported as an error rather than a
+        false success.
+
+        Args:
+            input_data (MirrorFeatureInput): Source names, mirror plane, and
+                merge/mirror_bodies flags.
+
+        Returns:
+            dict[str, Any]: Status and the mirror feature's details,
+            including volume before/after and the resulting ratio.
+
+        Example:
+            ```python
+            result = await mirror_feature(
+                {"features": ["Loft1"], "mirror_plane": "Right Plane"}
+            )
+            ```
+        """
+        try:
+            input_data = _normalize_input(input_data, MirrorFeatureInput)
+            result = await adapter.mirror_feature(
+                input_data.features,
+                input_data.mirror_plane,
+                input_data.merge,
+                input_data.mirror_bodies,
+            )
+            if result.is_success:
+                data = result.data if isinstance(result.data, dict) else {}
+                return {
+                    "status": "success",
+                    "message": f"Mirrored {', '.join(input_data.features)} "
+                    f"about {input_data.mirror_plane}",
+                    "mirror": data,
+                    "execution_time": result.execution_time,
+                }
+            return {
+                "status": "error",
+                "message": f"Failed to mirror feature: {result.error}",
+            }
+        except Exception as e:
+            logger.error(f"Error in mirror_feature tool: {e}")
             return {"status": "error", "message": f"Unexpected error: {str(e)}"}
 
     # Counted from the registry rather than hand-maintained. The literal that

--- a/tests/solidworks_mcp/adapters/test_mirror_capability.py
+++ b/tests/solidworks_mcp/adapters/test_mirror_capability.py
@@ -1,0 +1,265 @@
+"""Contract tests for the ``mirror_feature`` capability on the adapter surface.
+
+``mirror_feature`` exists on the base adapter, the mock, the circuit breaker
+and the connection pool. A method missing from either wrapper silently
+degrades to the base "not implemented" default at runtime, and mock mode
+cannot catch it - the mock is not wrapped - so the wiring is asserted
+directly here.
+
+Modeled on ``test_reference_geometry_capability.py``, scoped to the single
+capability implemented on ``SolidWorksFeaturesMixin`` in
+``src/solidworks_mcp/adapters/solidworks/features.py``
+(``_mirror_feature_impl`` / ``SolidWorksFeaturesMixin.mirror_feature``).
+"""
+
+import inspect
+
+import pytest
+
+from solidworks_mcp.adapters.base import ExtrusionParameters, SolidWorksAdapter
+from solidworks_mcp.adapters.circuit_breaker import CircuitBreakerAdapter
+from solidworks_mcp.adapters.connection_pool import ConnectionPoolAdapter
+from solidworks_mcp.adapters.mock_adapter import MockSolidWorksAdapter
+
+CAPABILITY = "mirror_feature"
+
+WRAPPERS = [
+    SolidWorksAdapter,
+    MockSolidWorksAdapter,
+    CircuitBreakerAdapter,
+    ConnectionPoolAdapter,
+]
+
+
+@pytest.mark.parametrize("cls", WRAPPERS, ids=lambda c: c.__name__)
+def test_capability_exists_on_every_layer(cls: type) -> None:
+    """A capability missing from a wrapper degrades silently at runtime."""
+    method = getattr(cls, CAPABILITY, None)
+    assert method is not None, f"{cls.__name__} is missing {CAPABILITY}"
+    assert inspect.iscoroutinefunction(method), (
+        f"{cls.__name__}.{CAPABILITY} must be async"
+    )
+
+
+def test_real_adapter_resolves_to_the_features_mixin() -> None:
+    """PyWin32Adapter must reach the COM implementation, not the base stub.
+
+    ``mirror_feature`` is only reachable if it is defined *inside*
+    ``SolidWorksFeaturesMixin``. Written at module scope in ``features.py``
+    it would still import cleanly, still pass every mock test, and still
+    satisfy the layer checks above - but ``PyWin32Adapter`` would then
+    resolve the name to ``SolidWorksAdapter``'s "not implemented" default
+    and the real COM code would never be called.
+    """
+    pytest.importorskip("win32com", reason="pywin32 is Windows-only")
+    from solidworks_mcp.adapters.pywin32_adapter import PyWin32Adapter
+
+    owner = next(
+        (
+            klass.__name__
+            for klass in PyWin32Adapter.__mro__
+            if CAPABILITY in vars(klass)
+        ),
+        None,
+    )
+    assert owner == "SolidWorksFeaturesMixin", (
+        f"PyWin32Adapter.{CAPABILITY} resolves to {owner}, not the COM mixin. "
+        "The implementation is unreachable and every call silently returns the "
+        "base adapter's 'not implemented' error."
+    )
+
+
+def test_wrappers_do_not_silently_fall_through_to_base() -> None:
+    """The breaker and pool must define their own pass-through, not inherit."""
+    for cls in (CircuitBreakerAdapter, ConnectionPoolAdapter):
+        assert CAPABILITY in vars(cls), (
+            f"{cls.__name__} inherits {CAPABILITY} from the base adapter, so "
+            "calls to it return 'not implemented' instead of reaching the real "
+            "adapter"
+        )
+
+
+@pytest.mark.asyncio
+async def test_base_defaults_report_missing_capability() -> None:
+    """The base adapter's default names the missing capability, not a fabrication."""
+
+    class _BareAdapter(SolidWorksAdapter):
+        """Minimal concrete adapter that leaves mirror_feature unimplemented."""
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            return None
+
+        def is_connected(self) -> bool:
+            return False
+
+        async def health_check(self):
+            return None
+
+        async def open_model(self, file_path):
+            return None
+
+        async def close_model(self, save=False):
+            return None
+
+        async def get_model_info(self):
+            return None
+
+        async def list_features(self, include_suppressed=False, max_assembly_depth=2):
+            return None
+
+        async def list_configurations(self):
+            return None
+
+        async def create_part(self, name=None, units=None):
+            return None
+
+        async def create_assembly(self, name=None):
+            return None
+
+        async def create_drawing(self, name=None):
+            return None
+
+        async def create_extrusion(self, params):
+            return None
+
+        async def create_revolve(self, params):
+            return None
+
+        async def create_sweep(self, params):
+            return None
+
+        async def create_loft(self, params):
+            return None
+
+        async def create_sketch(self, plane):
+            return None
+
+        async def add_line(self, x1, y1, x2, y2):
+            return None
+
+        async def add_circle(self, center_x, center_y, radius):
+            return None
+
+        async def add_rectangle(self, x1, y1, x2, y2):
+            return None
+
+        async def exit_sketch(self):
+            return None
+
+        async def get_mass_properties(self):
+            return None
+
+        async def export_image(self, payload):
+            return None
+
+        async def export_file(self, file_path, format_type):
+            return None
+
+        async def get_dimension(self, name):
+            return None
+
+        async def set_dimension(self, name, value):
+            return None
+
+    adapter = _BareAdapter()
+
+    result = await adapter.mirror_feature(["Body1"], "Right Plane")
+    assert not result.is_success
+    assert "mirror_feature" in (result.error or "")
+
+
+# --- Mock refusals: must mirror the live adapter, never fabricate a result ---
+
+
+@pytest.mark.asyncio
+async def test_mock_mirror_feature_rejects_empty_features() -> None:
+    """An empty source list is refused with the live adapter's exact message."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.mirror_feature([], "Right Plane")
+    assert not result.is_success
+    assert "at least one body or feature name" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_mock_mirror_feature_rejects_empty_mirror_plane() -> None:
+    """An empty mirror plane name is refused with the live adapter's exact message."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.mirror_feature(["Boss-Extrude1"], "")
+    assert not result.is_success
+    assert "requires a mirror plane name" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_mock_mirror_feature_rejects_unknown_source_name() -> None:
+    """A source name that was never created in this session cannot be selected."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.mirror_feature(["NoSuchBody"], "Right Plane")
+    assert not result.is_success
+    assert "NoSuchBody" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_mock_mirror_feature_rejects_unknown_mirror_plane() -> None:
+    """A plane name that is neither built-in nor created cannot be selected."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+    await adapter.create_part()
+    feature = await adapter.create_extrusion(ExtrusionParameters(depth=10.0))
+    assert feature.is_success
+
+    result = await adapter.mirror_feature([feature.data.name], "Diagonal Plane")
+    assert not result.is_success
+    assert "Diagonal Plane" in (result.error or "")
+
+
+# --- Mock success shape ---
+
+
+@pytest.mark.asyncio
+async def test_mock_mirror_feature_success_volume_ratio() -> None:
+    """Success doubles the tracked volume figure, giving a ratio well above 1.5."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+    await adapter.create_part()
+    feature = await adapter.create_extrusion(ExtrusionParameters(depth=10.0))
+    assert feature.is_success
+    source_name = feature.data.name
+
+    result = await adapter.mirror_feature([source_name], "Right Plane")
+    assert result.is_success
+    assert result.data["mirrored"] == [source_name]
+    assert result.data["mirror_plane"] == "Right Plane"
+    assert result.data["volume_ratio"] > 1.5
+    assert result.data["volume_after"] > result.data["volume_before"]
+
+
+# --- Guard test: wrong selection marks silently mirror nothing ---
+
+
+def test_mirror_selection_marks_match_the_solidworks_api() -> None:
+    """These are the SolidWorks-documented selection marks for InsertMirrorFeature.
+
+    Per the API reference: features are mark 1, faces are mark 128, bodies
+    are mark 256, and the mirror plane is mark 2. Wrong marks make the call
+    report a feature while mirroring nothing - a bug no other test here
+    would catch, since the live COM code is off-limits for modification and
+    the mock does not execute this path at all.
+    """
+    from solidworks_mcp.adapters.solidworks.features import (
+        _MIRROR_MARK_BODIES,
+        _MIRROR_MARK_FEATURES,
+        _MIRROR_MARK_PLANE,
+    )
+
+    assert _MIRROR_MARK_FEATURES == 1
+    assert _MIRROR_MARK_BODIES == 256
+    assert _MIRROR_MARK_PLANE == 2

--- a/tests/solidworks_mcp/adapters/test_pattern_capability.py
+++ b/tests/solidworks_mcp/adapters/test_pattern_capability.py
@@ -1,0 +1,274 @@
+"""Contract tests for the ``pattern_circular`` capability on the adapter surface.
+
+``pattern_circular`` exists on the base adapter, the mock, the circuit
+breaker and the connection pool. A method missing from either wrapper
+silently degrades to the base "not implemented" default at runtime, and
+mock mode cannot catch it - the mock is not wrapped - so the wiring is
+asserted directly here.
+
+Modeled on ``test_mirror_capability.py``, scoped to the single capability
+implemented on ``SolidWorksFeaturesMixin`` in
+``src/solidworks_mcp/adapters/solidworks/features.py``
+(``_pattern_circular_impl`` / ``SolidWorksFeaturesMixin.pattern_circular``).
+"""
+
+import inspect
+
+import pytest
+
+from solidworks_mcp.adapters.base import ExtrusionParameters, SolidWorksAdapter
+from solidworks_mcp.adapters.circuit_breaker import CircuitBreakerAdapter
+from solidworks_mcp.adapters.connection_pool import ConnectionPoolAdapter
+from solidworks_mcp.adapters.mock_adapter import MockSolidWorksAdapter
+
+CAPABILITY = "pattern_circular"
+
+WRAPPERS = [
+    SolidWorksAdapter,
+    MockSolidWorksAdapter,
+    CircuitBreakerAdapter,
+    ConnectionPoolAdapter,
+]
+
+
+@pytest.mark.parametrize("cls", WRAPPERS, ids=lambda c: c.__name__)
+def test_capability_exists_on_every_layer(cls: type) -> None:
+    """A capability missing from a wrapper degrades silently at runtime."""
+    method = getattr(cls, CAPABILITY, None)
+    assert method is not None, f"{cls.__name__} is missing {CAPABILITY}"
+    assert inspect.iscoroutinefunction(method), (
+        f"{cls.__name__}.{CAPABILITY} must be async"
+    )
+
+
+def test_real_adapter_resolves_to_the_features_mixin() -> None:
+    """PyWin32Adapter must reach the COM implementation, not the base stub.
+
+    ``pattern_circular`` is only reachable if it is defined *inside*
+    ``SolidWorksFeaturesMixin``. Written at module scope in ``features.py``
+    it would still import cleanly, still pass every mock test, and still
+    satisfy the layer checks above - but ``PyWin32Adapter`` would then
+    resolve the name to ``SolidWorksAdapter``'s "not implemented" default
+    and the real COM code would never be called.
+    """
+    pytest.importorskip("win32com", reason="pywin32 is Windows-only")
+    from solidworks_mcp.adapters.pywin32_adapter import PyWin32Adapter
+
+    owner = next(
+        (
+            klass.__name__
+            for klass in PyWin32Adapter.__mro__
+            if CAPABILITY in vars(klass)
+        ),
+        None,
+    )
+    assert owner == "SolidWorksFeaturesMixin", (
+        f"PyWin32Adapter.{CAPABILITY} resolves to {owner}, not the COM mixin. "
+        "The implementation is unreachable and every call silently returns the "
+        "base adapter's 'not implemented' error."
+    )
+
+
+def test_wrappers_do_not_silently_fall_through_to_base() -> None:
+    """The breaker and pool must define their own pass-through, not inherit."""
+    for cls in (CircuitBreakerAdapter, ConnectionPoolAdapter):
+        assert CAPABILITY in vars(cls), (
+            f"{cls.__name__} inherits {CAPABILITY} from the base adapter, so "
+            "calls to it return 'not implemented' instead of reaching the real "
+            "adapter"
+        )
+
+
+@pytest.mark.asyncio
+async def test_base_defaults_report_missing_capability() -> None:
+    """The base adapter's default names the missing capability, not a fabrication."""
+
+    class _BareAdapter(SolidWorksAdapter):
+        """Minimal concrete adapter that leaves pattern_circular unimplemented."""
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            return None
+
+        def is_connected(self) -> bool:
+            return False
+
+        async def health_check(self):
+            return None
+
+        async def open_model(self, file_path):
+            return None
+
+        async def close_model(self, save=False):
+            return None
+
+        async def get_model_info(self):
+            return None
+
+        async def list_features(self, include_suppressed=False, max_assembly_depth=2):
+            return None
+
+        async def list_configurations(self):
+            return None
+
+        async def create_part(self, name=None, units=None):
+            return None
+
+        async def create_assembly(self, name=None):
+            return None
+
+        async def create_drawing(self, name=None):
+            return None
+
+        async def create_extrusion(self, params):
+            return None
+
+        async def create_revolve(self, params):
+            return None
+
+        async def create_sweep(self, params):
+            return None
+
+        async def create_loft(self, params):
+            return None
+
+        async def create_sketch(self, plane):
+            return None
+
+        async def add_line(self, x1, y1, x2, y2):
+            return None
+
+        async def add_circle(self, center_x, center_y, radius):
+            return None
+
+        async def add_rectangle(self, x1, y1, x2, y2):
+            return None
+
+        async def exit_sketch(self):
+            return None
+
+        async def get_mass_properties(self):
+            return None
+
+        async def export_image(self, payload):
+            return None
+
+        async def export_file(self, file_path, format_type):
+            return None
+
+        async def get_dimension(self, name):
+            return None
+
+        async def set_dimension(self, name, value):
+            return None
+
+    adapter = _BareAdapter()
+
+    result = await adapter.pattern_circular(["Boss-Extrude1"], "Axis1", 4)
+    assert not result.is_success
+    assert "pattern_circular" in (result.error or "")
+
+
+# --- Mock refusals: must mirror the live adapter, never fabricate a result ---
+
+
+@pytest.mark.asyncio
+async def test_mock_pattern_circular_rejects_empty_features() -> None:
+    """An empty feature list is refused with the live adapter's exact message."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.pattern_circular([], "Axis1", 4)
+    assert not result.is_success
+    assert "at least one feature name" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_mock_pattern_circular_rejects_empty_axis() -> None:
+    """An empty axis name is refused with the live adapter's exact message."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.pattern_circular(["Boss-Extrude1"], "", 4)
+    assert not result.is_success
+    assert "requires an axis name to rotate about" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_mock_pattern_circular_rejects_count_below_two() -> None:
+    """A count under 2 is refused with the live adapter's exact message."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.pattern_circular(["Boss-Extrude1"], "Axis1", 1)
+    assert not result.is_success
+    assert "needs a count of at least 2" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_mock_pattern_circular_rejects_unknown_axis() -> None:
+    """An axis name that was never created in this session cannot be selected."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+    await adapter.create_part()
+    feature = await adapter.create_extrusion(ExtrusionParameters(depth=10.0))
+    assert feature.is_success
+
+    result = await adapter.pattern_circular([feature.data.name], "Axis99", 4)
+    assert not result.is_success
+    assert "Axis99" in (result.error or "")
+
+
+# --- Mock success shape ---
+
+
+@pytest.mark.asyncio
+async def test_mock_pattern_circular_success_volume_ratio() -> None:
+    """Success grows the tracked volume figure, giving a ratio well above 1.5.
+
+    Reproduces the live measurement exactly: a hub+blade part at 48431.5
+    mm^3, patterned to 4 blades (3 extra instances), gave 75916.4 mm^3 -
+    ratio 1.5677.
+    """
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+    await adapter.create_part()
+    feature = await adapter.create_extrusion(ExtrusionParameters(depth=10.0))
+    assert feature.is_success
+    source_name = feature.data.name
+
+    axis = await adapter.create_axis("z")
+    assert axis.is_success
+    axis_name = axis.data["name"]
+
+    result = await adapter.pattern_circular([source_name], axis_name, 4)
+    assert result.is_success
+    assert result.data["patterned"] == [source_name]
+    assert result.data["axis"] == axis_name
+    assert result.data["count"] == 4
+    assert result.data["volume_ratio"] > 1.5
+    assert result.data["volume_after"] > result.data["volume_before"]
+
+
+# --- Guard test: wrong selection marks silently pattern nothing ---
+
+
+def test_pattern_selection_marks_match_the_solidworks_api() -> None:
+    """These are the SolidWorks-documented selection marks for FeatureCircularPattern5.
+
+    Per the API reference: the direction axis is mark 1 and the features to
+    pattern are mark 4. These differ from the mirror marks (features 1,
+    plane 2) - reusing those makes the call report a feature while
+    patterning nothing, a bug no other test here would catch, since the
+    live COM code is off-limits for modification and the mock does not
+    execute this path at all.
+    """
+    from solidworks_mcp.adapters.solidworks.features import (
+        _PATTERN_MARK_AXIS,
+        _PATTERN_MARK_FEATURES,
+    )
+
+    assert _PATTERN_MARK_AXIS == 1
+    assert _PATTERN_MARK_FEATURES == 4

--- a/tests/solidworks_mcp/adapters/test_reference_geometry_capability.py
+++ b/tests/solidworks_mcp/adapters/test_reference_geometry_capability.py
@@ -1,0 +1,271 @@
+"""Contract tests for the reference-geometry capabilities on the adapter surface.
+
+``create_reference_plane`` and ``create_axis`` each exist on the base adapter,
+the mock, the circuit breaker and the connection pool. A method missing from
+either wrapper silently degrades to the base "not implemented" default at
+runtime, and mock mode cannot catch it — the mock is not wrapped — so the
+wiring is asserted directly here.
+
+Modeled on ``test_new_capabilities.py``, scoped to the two capabilities
+implemented on ``SolidWorksFeaturesMixin`` in
+``src/solidworks_mcp/adapters/solidworks/features.py``
+(``_create_reference_plane_impl`` / ``_create_axis_impl``).
+"""
+
+import inspect
+
+import pytest
+
+from solidworks_mcp.adapters.base import SolidWorksAdapter
+from solidworks_mcp.adapters.circuit_breaker import CircuitBreakerAdapter
+from solidworks_mcp.adapters.connection_pool import ConnectionPoolAdapter
+from solidworks_mcp.adapters.mock_adapter import MockSolidWorksAdapter
+
+#: Capabilities added on this branch.
+CAPABILITIES = [
+    "create_reference_plane",
+    "create_axis",
+]
+
+WRAPPERS = [
+    SolidWorksAdapter,
+    MockSolidWorksAdapter,
+    CircuitBreakerAdapter,
+    ConnectionPoolAdapter,
+]
+
+
+@pytest.mark.parametrize("capability", CAPABILITIES)
+@pytest.mark.parametrize("cls", WRAPPERS, ids=lambda c: c.__name__)
+def test_capability_exists_on_every_layer(capability: str, cls: type) -> None:
+    """A capability missing from a wrapper degrades silently at runtime."""
+    method = getattr(cls, capability, None)
+    assert method is not None, f"{cls.__name__} is missing {capability}"
+    assert inspect.iscoroutinefunction(method), (
+        f"{cls.__name__}.{capability} must be async"
+    )
+
+
+@pytest.mark.parametrize("capability", CAPABILITIES)
+def test_real_adapter_resolves_to_the_features_mixin(capability: str) -> None:
+    """PyWin32Adapter must reach the COM implementation, not the base stub.
+
+    The mixin methods are only reachable if they are defined *inside*
+    ``SolidWorksFeaturesMixin``. Written at module scope in ``features.py``
+    they still import cleanly, still pass every mock test, and still satisfy
+    the layer checks above — but ``PyWin32Adapter`` then resolves the name to
+    ``SolidWorksAdapter``'s "not implemented" default and the real COM code
+    is never called.
+    """
+    pytest.importorskip("win32com", reason="pywin32 is Windows-only")
+    from solidworks_mcp.adapters.pywin32_adapter import PyWin32Adapter
+
+    owner = next(
+        (klass.__name__ for klass in PyWin32Adapter.__mro__ if capability in vars(klass)),
+        None,
+    )
+    assert owner == "SolidWorksFeaturesMixin", (
+        f"PyWin32Adapter.{capability} resolves to {owner}, not the COM mixin. "
+        "The implementation is unreachable and every call silently returns the "
+        "base adapter's 'not implemented' error."
+    )
+
+
+@pytest.mark.parametrize("capability", CAPABILITIES)
+def test_wrappers_do_not_silently_fall_through_to_base(capability: str) -> None:
+    """The breaker and pool must define their own pass-through, not inherit."""
+    for cls in (CircuitBreakerAdapter, ConnectionPoolAdapter):
+        assert capability in vars(cls), (
+            f"{cls.__name__} inherits {capability} from the base adapter, so "
+            "calls to it return 'not implemented' instead of reaching the real "
+            "adapter"
+        )
+
+
+@pytest.mark.asyncio
+async def test_base_defaults_report_missing_capability() -> None:
+    """The base adapter's defaults name the missing capability, not a fabrication."""
+
+    class _BareAdapter(SolidWorksAdapter):
+        """Minimal concrete adapter that leaves the new capabilities unimplemented."""
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            return None
+
+        def is_connected(self) -> bool:
+            return False
+
+        async def health_check(self):
+            return None
+
+        async def open_model(self, file_path):
+            return None
+
+        async def close_model(self, save=False):
+            return None
+
+        async def get_model_info(self):
+            return None
+
+        async def list_features(self, include_suppressed=False, max_assembly_depth=2):
+            return None
+
+        async def list_configurations(self):
+            return None
+
+        async def create_part(self, name=None, units=None):
+            return None
+
+        async def create_assembly(self, name=None):
+            return None
+
+        async def create_drawing(self, name=None):
+            return None
+
+        async def create_extrusion(self, params):
+            return None
+
+        async def create_revolve(self, params):
+            return None
+
+        async def create_sweep(self, params):
+            return None
+
+        async def create_loft(self, params):
+            return None
+
+        async def create_sketch(self, plane):
+            return None
+
+        async def add_line(self, x1, y1, x2, y2):
+            return None
+
+        async def add_circle(self, center_x, center_y, radius):
+            return None
+
+        async def add_rectangle(self, x1, y1, x2, y2):
+            return None
+
+        async def exit_sketch(self):
+            return None
+
+        async def get_mass_properties(self):
+            return None
+
+        async def export_image(self, payload):
+            return None
+
+        async def export_file(self, file_path, format_type):
+            return None
+
+        async def get_dimension(self, name):
+            return None
+
+        async def set_dimension(self, name, value):
+            return None
+
+    adapter = _BareAdapter()
+
+    plane_result = await adapter.create_reference_plane("Front Plane", offset=10.0)
+    assert not plane_result.is_success
+    assert "create_reference_plane" in (plane_result.error or "")
+
+    axis_result = await adapter.create_axis("x")
+    assert not axis_result.is_success
+    assert "create_axis" in (axis_result.error or "")
+
+
+# --- Mock refusals: must mirror the live adapter, never fabricate a result ---
+
+
+@pytest.mark.asyncio
+async def test_mock_create_reference_plane_rejects_nonzero_angle() -> None:
+    """An angled plane needs a second reference this signature cannot supply."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.create_reference_plane("Front Plane", offset=10.0, angle=15.0)
+    assert not result.is_success
+
+
+@pytest.mark.asyncio
+async def test_mock_create_reference_plane_rejects_zero_offset() -> None:
+    """A plane coincident with its reference is not a useful result."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.create_reference_plane("Front Plane", offset=0.0)
+    assert not result.is_success
+
+
+@pytest.mark.asyncio
+async def test_mock_create_axis_rejects_unknown_reference() -> None:
+    """Only x/y/z are valid axis directions."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.create_axis("diagonal")
+    assert not result.is_success
+
+
+# --- Mock success shapes ---
+
+
+@pytest.mark.asyncio
+async def test_mock_create_reference_plane_success_shape() -> None:
+    """Success invents a sequential plane name and a features_before/after pair."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    first = await adapter.create_reference_plane("Front Plane", offset=76.2)
+    assert first.is_success
+    assert first.data["name"] == "Plane1"
+    assert first.data["reference"] == "Front Plane"
+    assert first.data["offset"] == 76.2
+    assert first.data["angle"] is None
+    assert first.data["flip"] is False
+    assert first.data["features_after"] == first.data["features_before"] + 1
+
+    second = await adapter.create_reference_plane("Top Plane", offset=-10.0, flip=True)
+    assert second.is_success
+    assert second.data["name"] == "Plane2"
+    assert second.data["flip"] is True
+    assert second.data["features_after"] == second.data["features_before"] + 1
+    # The mock's feature-tree counter accumulates across calls, same as a
+    # live SolidWorks model whose feature count only grows.
+    assert second.data["features_before"] == first.data["features_after"]
+
+
+@pytest.mark.asyncio
+async def test_mock_create_axis_success_shape() -> None:
+    """Success reports the plane pair and a features_before/after pair that differ by 1."""
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    result = await adapter.create_axis("+X")
+    assert result.is_success
+    assert result.data["reference"] == "x"
+    assert result.data["planes"] == ["Top Plane", "Front Plane"]
+    assert result.data["features_after"] == result.data["features_before"] + 1
+
+
+@pytest.mark.asyncio
+async def test_mock_create_axis_plane_pairs_match_the_com_layer() -> None:
+    """The mock's plane pairs must match the COM layer's ``_AXIS_PLANE_PAIRS``.
+
+    The two are the same object (imported directly, not copied), so this
+    also guards against a future refactor accidentally duplicating and
+    diverging the mapping.
+    """
+    from solidworks_mcp.adapters.solidworks.features import _AXIS_PLANE_PAIRS
+
+    adapter = MockSolidWorksAdapter({})
+    await adapter.connect()
+
+    for direction, (plane_a, plane_b) in _AXIS_PLANE_PAIRS.items():
+        result = await adapter.create_axis(direction)
+        assert result.is_success
+        assert result.data["planes"] == [plane_a, plane_b]

--- a/tests/solidworks_mcp/tools/test_modeling.py
+++ b/tests/solidworks_mcp/tools/test_modeling.py
@@ -34,7 +34,13 @@ class TestModelingTools:
         tool_count = await register_modeling_tools(
             mcp_server, mock_adapter, mock_config
         )
-        assert tool_count == 15
+        # Asserted against the registry rather than a literal, so the count
+        # cannot drift out of step with what was actually registered again.
+        names = {tool.name for tool in await mcp_server.list_tools()}
+        assert tool_count == len(names), (
+            f"register_modeling_tools reported {tool_count} tools but "
+            f"registered {len(names)}"
+        )
         # The Phase 1 sweep/loft tools must be registered alongside the rest.
         names = {tool.name for tool in await mcp_server.list_tools()}
         assert {"create_sweep", "create_loft"} <= names

--- a/tests/test_live_sw_regression.py
+++ b/tests/test_live_sw_regression.py
@@ -2489,3 +2489,78 @@ async def test_mirror_refuses_bad_input(connected_adapter):
         assert "NoSuchBody" in (unknown.error or "")
     finally:
         adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))
+
+
+@pytest.mark.asyncio
+async def test_circular_pattern_builds_a_propeller(connected_adapter):
+    """A pattern must add instances, proven by volume arithmetic.
+
+    ``FeatureCircularPattern5`` returns a Feature object whether or not it
+    produced anything. The geometry here is chosen so every instance lands on
+    the hub, which makes the sum exact: patterning one blade to four must add
+    precisely three blades' worth of material.
+    """
+    from solidworks_mcp.adapters.base import ExtrusionParameters
+
+    adapter = connected_adapter
+    try:
+        await adapter.create_part()
+        await adapter.create_sketch("Top")
+        await adapter.add_circle(0.0, 0.0, 25.0)
+        await adapter.exit_sketch()
+        await adapter.create_extrusion(ExtrusionParameters(depth=20.0))
+        hub = await adapter.get_mass_properties()
+        assert hub.is_success, hub.error
+
+        await adapter.create_sketch("Top")
+        await adapter.add_rectangle(20.0, -8.0, 120.0, 8.0)
+        await adapter.exit_sketch()
+        blade = await adapter.create_extrusion(ExtrusionParameters(depth=6.0))
+        assert blade.is_success, blade.error
+        blade_name = getattr(blade.data, "name", None) or "Boss-Extrude2"
+
+        one = await adapter.get_mass_properties()
+        seed = one.data.volume - hub.data.volume
+        assert seed > 0, (one.data.volume, hub.data.volume)
+
+        axis = await adapter.create_axis("y")
+        assert axis.is_success, axis.error
+        listed = await adapter.list_features()
+        names = [
+            (f.get("name") if isinstance(f, dict) else getattr(f, "name", None))
+            for f in (listed.data or [])
+        ]
+        axis_name = next((n for n in names if n and n.startswith("Axis")), "Axis1")
+
+        patterned = await adapter.pattern_circular([blade_name], axis_name, count=4)
+        assert patterned.is_success, patterned.error
+
+        added = patterned.data["volume_after"] - patterned.data["volume_before"]
+        assert added / seed == pytest.approx(3.0, rel=0.02), (
+            f"expected three extra blades, got {added / seed:.2f}: "
+            f"{patterned.data}"
+        )
+    finally:
+        adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))
+
+
+@pytest.mark.asyncio
+async def test_circular_pattern_refuses_bad_input(connected_adapter):
+    """Empty inputs, a count of one, and an unknown axis are all errors."""
+    adapter = connected_adapter
+    try:
+        await adapter.create_part()
+
+        assert not (await adapter.pattern_circular([], "Axis1", 4)).is_success
+        assert not (await adapter.pattern_circular(["Boss-Extrude1"], "", 4)).is_success
+        assert not (
+            await adapter.pattern_circular(["Boss-Extrude1"], "Axis1", 1)
+        ).is_success
+
+        unknown = await adapter.pattern_circular(
+            ["Boss-Extrude1"], "NoSuchAxis", 4
+        )
+        assert not unknown.is_success
+        assert "NoSuchAxis" in (unknown.error or "")
+    finally:
+        adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))

--- a/tests/test_live_sw_regression.py
+++ b/tests/test_live_sw_regression.py
@@ -32,6 +32,7 @@ Run only these tests locally on Windows with SW::
 from __future__ import annotations
 
 import asyncio
+import math
 import os
 import platform
 import threading
@@ -2317,5 +2318,80 @@ async def test_assembly_insert_list_and_mate_change_real_geometry(connected_adap
             "the mate changed the assembly's volume, so it moved more than "
             "position"
         )
+    finally:
+        adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))
+
+
+@pytest.mark.asyncio
+async def test_reference_plane_can_be_sketched_on(connected_adapter):
+    """A created plane must be usable by create_sketch, or it is worthless.
+
+    This is the whole point of the capability: sketches could previously only
+    open on the six built-in planes, so any workflow needing a station plane -
+    lofting a wing between airfoil sections, for instance - was impossible.
+
+    Verified by geometry rather than by return code: a circle sketched on the
+    new plane and extruded must produce exactly the expected volume.
+    """
+    from solidworks_mcp.adapters.base import ExtrusionParameters
+
+    adapter = connected_adapter
+    try:
+        await adapter.create_part()
+
+        plane = await adapter.create_reference_plane("Front Plane", offset=76.2)
+        assert plane.is_success, plane.error
+        name = plane.data["name"]
+        assert name, plane.data
+        assert plane.data["features_after"] > plane.data["features_before"], plane.data
+
+        # The name must be one create_sketch accepts.
+        sketch = await adapter.create_sketch(name)
+        assert sketch.is_success, (
+            f"create_sketch({name!r}) failed, so the plane cannot be used: "
+            f"{sketch.error}"
+        )
+
+        await adapter.add_circle(0.0, 0.0, 20.0)
+        await adapter.exit_sketch()
+        extruded = await adapter.create_extrusion(ExtrusionParameters(depth=5.0))
+        assert extruded.is_success, extruded.error
+
+        props = await adapter.get_mass_properties()
+        assert props.is_success, props.error
+        assert props.data.volume == pytest.approx(math.pi * 20.0**2 * 5.0, rel=1e-6), (
+            f"geometry on the new plane measured {props.data.volume} mm3"
+        )
+
+        # A plane coincident with its reference is refused, not silently made.
+        nothing = await adapter.create_reference_plane("Front Plane")
+        assert not nothing.is_success
+
+        # Angle is refused explicitly rather than reporting a plane that was
+        # never added - InsertRefPlane needs a second reference for that.
+        angled = await adapter.create_reference_plane("Right Plane", angle=30.0)
+        assert not angled.is_success
+        assert "angle" in (angled.error or "").lower()
+    finally:
+        adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))
+
+
+@pytest.mark.asyncio
+async def test_create_axis_adds_an_axis(connected_adapter):
+    """InsertAxis2 returns only a boolean, so the tree is what is checked."""
+    adapter = connected_adapter
+    try:
+        await adapter.create_part()
+
+        for direction in ("x", "y", "z"):
+            result = await adapter.create_axis(direction)
+            assert result.is_success, f"{direction}: {result.error}"
+            assert result.data["features_after"] > result.data["features_before"], (
+                result.data
+            )
+            assert len(result.data["planes"]) == 2
+
+        unknown = await adapter.create_axis("diagonal")
+        assert not unknown.is_success
     finally:
         adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))

--- a/tests/test_live_sw_regression.py
+++ b/tests/test_live_sw_regression.py
@@ -2395,3 +2395,97 @@ async def test_create_axis_adds_an_axis(connected_adapter):
         assert not unknown.is_success
     finally:
         adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))
+
+
+@pytest.mark.asyncio
+async def test_mirror_body_doubles_a_lofted_wing(connected_adapter):
+    """Mirroring must be proven by volume, not by the returned feature.
+
+    ``InsertMirrorFeature`` hands back a Feature object even when it mirrored
+    nothing, so the only real evidence is that the solid got bigger. A wing
+    lofted between stations offset from the centreline cannot be
+    *feature*-mirrored - SolidWorks resolves that only when the feature's own
+    sketch sits on the mirror plane - so this mirrors the body.
+    """
+    from solidworks_mcp.adapters.base import LoftParameters
+
+    adapter = connected_adapter
+    try:
+        await adapter.create_part()
+
+        profiles = []
+        for offset, radius in ((0.0, 40.0), (300.0, 20.0)):
+            plane = "Right Plane"
+            if offset:
+                made = await adapter.create_reference_plane("Right Plane", offset=offset)
+                assert made.is_success, made.error
+                plane = made.data["name"]
+            sketch = await adapter.create_sketch(plane)
+            assert sketch.is_success, sketch.error
+            await adapter.add_circle(0.0, 0.0, radius)
+            await adapter.exit_sketch()
+            profiles.append(sketch.data)
+
+        loft = await adapter.create_loft(LoftParameters(profiles=profiles))
+        assert loft.is_success, loft.error
+        body = getattr(loft.data, "name", None) or "Loft1"
+
+        one = await adapter.get_mass_properties()
+        assert one.is_success, one.error
+        assert one.data.volume > 0
+
+        mirrored = await adapter.mirror_feature([body], "Right Plane")
+        assert mirrored.is_success, mirrored.error
+        assert mirrored.data["volume_ratio"] == pytest.approx(2.0, rel=0.02), (
+            f"mirror did not double the solid: {mirrored.data}"
+        )
+        assert mirrored.data["mirror_bodies"] is True
+    finally:
+        adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))
+
+
+@pytest.mark.asyncio
+async def test_mirror_feature_when_the_sketch_is_on_the_plane(connected_adapter):
+    """The feature-mirror path, on the geometry where SolidWorks allows it."""
+    from solidworks_mcp.adapters.base import ExtrusionParameters
+
+    adapter = connected_adapter
+    try:
+        await adapter.create_part()
+        await adapter.create_sketch("Right Plane")
+        await adapter.add_rectangle(10.0, 0.0, 40.0, 30.0)
+        await adapter.exit_sketch()
+        boss = await adapter.create_extrusion(ExtrusionParameters(depth=20.0))
+        assert boss.is_success, boss.error
+        name = getattr(boss.data, "name", None) or "Boss-Extrude1"
+
+        mirrored = await adapter.mirror_feature(
+            [name], "Right Plane", mirror_bodies=False
+        )
+        assert mirrored.is_success, mirrored.error
+        assert mirrored.data["volume_ratio"] == pytest.approx(2.0, rel=0.02), (
+            mirrored.data
+        )
+        assert mirrored.data["mirror_bodies"] is False
+    finally:
+        adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))
+
+
+@pytest.mark.asyncio
+async def test_mirror_refuses_bad_input(connected_adapter):
+    """Empty inputs and unknown sources are errors, not silent no-ops."""
+    adapter = connected_adapter
+    try:
+        await adapter.create_part()
+
+        no_sources = await adapter.mirror_feature([], "Right Plane")
+        assert not no_sources.is_success
+
+        no_plane = await adapter.mirror_feature(["Boss-Extrude1"], "")
+        assert not no_plane.is_success
+
+        unknown = await adapter.mirror_feature(["NoSuchBody"], "Right Plane")
+        assert not unknown.is_success
+        assert "NoSuchBody" in (unknown.error or "")
+    finally:
+        adapter._attempt(lambda: adapter.swApp.CloseAllDocuments(True))


### PR DESCRIPTION
## What

| Tool | What it does |
|---|---|
| `pattern_circular(...)` | Pattern features about an axis — `IFeatureManager::FeatureCircularPattern5` |

Stacked on #70 (`feat/mirror-feature`), which is itself stacked on #69 (`feat/reference-geometry`) — merge order is #69, then #70, then this branch.

Propeller blades, radial engine cylinders, bolt circles — anything repeated around an axis. Pairs with the reference-geometry work: `create_axis` supplies the rotation reference this tool patterns around.

## Selection marks differ from mirror's

The axis goes under mark 1, the features to pattern under mark 4 — mirror uses features under 1 and the plane under 2. Reusing mirror's marks makes SolidWorks return a `Feature` object having patterned nothing, silently. A test pins both constants for that reason.

## FeatureCircularPattern5, not v4

This build exposes `FeatureCircularPattern` overloads v1 through v5, so v5 is used, with the 14 arguments it declares. The reference implementation reached for v4. `DName` takes a direction *name string* rather than a selection reference, so the axis is both selected under mark 1 and passed by name in the same call.

## Live proof

A hub with one blade, patterned to four:

```
one blade    48431.5 mm3
four blades  75916.4 mm3
growth       exactly 3.00 extra blades
```

Geometry was chosen so every instance lands on the parent body and the growth is exact, not approximate.

## Partial patterns are normal, not a failure

Instances that land off the parent body are dropped silently by SolidWorks — no error, no partial-count report, the volume simply doesn't include them. So a pattern that grows by fewer than count-1 blade-equivalents is normal, not broken. Only zero growth at all means nothing happened. The docstring says this plainly, since a caller comparing against count-1 would otherwise read a legitimate partial pattern as a bug.

## pattern_linear is deliberately not included

`FeatureLinearPattern5` returns a `CDispatch` and produces no geometry. Measured every combination available:

```
CtrlByNum1=True,  GeometryPattern=True   -> volume unchanged, 201696.5 mm3
CtrlByNum1=False, GeometryPattern=True   -> volume unchanged, 201696.5 mm3
v2 overload                              -> rejects the argument count
```

201696.5 mm³ every time, with the direction axis and seed feature both confirmed selected beforehand — so the inputs were right and the call still did nothing. Shipping a capability that's never been observed to work is the failure this branch avoids; `pattern_linear` waits until the cause is known.

## Test results

- 1951 passed
- Coverage 95.43%
- `ruff check src tests` unchanged at the 14 findings already on `main`
- CI green on the fork

## Why this shows three commits

The two extra commits are #69's and #70's, not duplicates. Merge those first
and this diff collapses to the pattern change alone. All three branches touch
the same six files, which is why they stack rather than standing alone.
