### PR TITLE
fix: missing math import in reference-plane real-SW test

### DIFF
--- a/tests/test_live_sw_regression.py
+++ b/tests/test_live_sw_regression.py
@@ -32,6 +32,7 @@ Run only these tests locally on Windows with SW::
 from __future__ import annotations
 
 import asyncio
+import math
 import os
 import platform
 import threading


### PR DESCRIPTION
## Summary
- \`test_reference_plane_can_be_sketched_on\` (added in #69) references \`math.pi\` in a \`pytest.approx\` assertion but never imports \`math\` at module scope — caught while running \`dev-test-full\` against live SolidWorks after merging #65-#71.

## Test plan
- [x] Verified against live SolidWorks: \`test_reference_plane_can_be_sketched_on\` passes (real volume check on extruded geometry).