### PR TITLE
test: 100% coverage for features.py/io.py + tool-layer tests for 7 new PRs

### DIFF
--- a/dev-commands.ps1
+++ b/dev-commands.ps1
@@ -123,6 +123,7 @@ function dev-help {
     Write-Host "  dev-install-ui      Install/repair UI extras in .venv only"
     Write-Host "  dev-test            Run test suite with coverage (excludes solidworks_only)"
     Write-Host "  dev-test-full       Run full suite including real SolidWorks integration tests"
+    Write-Host "  dev-test-combined   Mock (parallel) + real-SW (serial) as 2 runs, merged into one true coverage report"
     Write-Host "  dev-lint            Format + lint code (ruff format + ruff check)"
     Write-Host "  dev-format          Format code only (ruff format)"
     Write-Host "  dev-build           Build package for distribution"
@@ -181,10 +182,13 @@ function dev-test {
     # Keep generated integration artifacts from previous runs from accumulating.
     Invoke-IntegrationCleanup
 
+    # -n 4, not "auto": this machine has 24 logical CPUs but only ~10GB free
+    # RAM once VSCode + SolidWorks are running - "auto" spawns a worker per
+    # CPU, each loading the full package + deps, and OOMs the machine.
     Invoke-Pytest @(
         "tests/",
         "-m", "not solidworks_only and not smoke",
-        "-n", "auto",
+        "-n", "4",
         "--cov=src/solidworks_mcp",
         "--cov-report=term-missing",
         "--cov-report=html:htmlcov",
@@ -223,6 +227,74 @@ function dev-test-full {
         Write-Host "Full tests passed!" -ForegroundColor Green
     } else {
         Write-Host "Full tests failed." -ForegroundColor Red
+    }
+}
+
+function dev-test-combined {
+    # dev-test-full runs everything serially in one ~30-50min pytest session
+    # (-n 1 for the whole tree, since real COM needs single-threaded). This
+    # runs the mock suite in parallel and the real-SolidWorks suite serially
+    # as two SEPARATE pytest sessions, each writing to its own coverage data
+    # file, then combines them with `coverage combine` into one true report -
+    # the union of what mock tests AND real-SolidWorks tests each cover.
+    #
+    # Why this matters: a line only reachable via real COM (e.g. a defensive
+    # "SolidWorks returned nothing" raise inside add_mate) will always show
+    # as "missing" in a mock-only report, even once test_live_sw_regression.py
+    # genuinely exercises it. Chasing that gap with more mock tests either
+    # means skipping it (leaving a misleading "uncovered" line) or writing a
+    # redundant fake-COM test for something already proven live. Combined
+    # coverage answers "is this covered by ANY test" instead, so new tests
+    # only get written for lines neither suite actually reaches.
+    Write-Host "Running combined coverage: mock suite (parallel) + real SolidWorks suite (serial), merged into one true report..." -ForegroundColor Cyan
+    $env:PY_KEY_VALUE_DISABLE_BEARTYPE = "true"
+
+    Remove-Item -Path .coverage.mock, .coverage.real, .coverage.combined -Force -ErrorAction SilentlyContinue
+
+    # -n 4, not "auto": this machine has 24 logical CPUs but only ~10GB free
+    # RAM once VSCode + SolidWorks are running, and "auto" spawns a worker
+    # per CPU - each loading the full package + deps. Already learned the
+    # hard way once this session (see TODO_SESSION.md's 2026-08-14 entry) -
+    # "auto" OOM'd the machine again when this command first ran.
+    Write-Host "Phase 1/3: mock suite (parallel, -n 4)..." -ForegroundColor Cyan
+    $env:COVERAGE_FILE = ".coverage.mock"
+    Invoke-Pytest @(
+        "tests/",
+        "-m", "not solidworks_only",
+        "-n", "4",
+        "--cov=src/solidworks_mcp",
+        "--cov-report=",
+        "--cov-fail-under=0",
+        "-q"
+    )
+    $mockExit = $LASTEXITCODE
+
+    Write-Host "Phase 2/3: real SolidWorks suite (serial, -n 1 - requires SolidWorks running)..." -ForegroundColor Cyan
+    $env:SOLIDWORKS_MCP_RUN_REAL_INTEGRATION = "true"
+    $env:COVERAGE_FILE = ".coverage.real"
+    Invoke-Pytest @(
+        "tests/",
+        "-m", "solidworks_only",
+        "-n", "1",
+        "--cov=src/solidworks_mcp",
+        "--cov-report=",
+        "--cov-fail-under=0",
+        "-q"
+    )
+    $realExit = $LASTEXITCODE
+    Remove-Item Env:\COVERAGE_FILE -ErrorAction SilentlyContinue
+
+    Write-Host "Phase 3/3: combining coverage data..." -ForegroundColor Cyan
+    Invoke-Venv -Args @("-m", "coverage", "combine", "--data-file=.coverage.combined", "--keep", ".coverage.mock", ".coverage.real")
+    Invoke-Venv -Args @("-m", "coverage", "html", "--data-file=.coverage.combined", "-d", "htmlcov")
+    Invoke-Venv -Args @("-m", "coverage", "xml", "--data-file=.coverage.combined", "-o", "coverage.xml")
+    Invoke-Venv -Args @("-m", "coverage", "report", "--data-file=.coverage.combined", "-m", "--fail-under=99")
+    $reportExit = $LASTEXITCODE
+
+    if ($mockExit -eq 0 -and $realExit -eq 0 -and $reportExit -eq 0) {
+        Write-Host "Combined suite passed! True combined coverage written to htmlcov/index.html" -ForegroundColor Green
+    } else {
+        Write-Host "Combined suite failed (mock exit=$mockExit, real exit=$realExit, coverage gate exit=$reportExit)." -ForegroundColor Red
     }
 }
 

--- a/src/solidworks_mcp/adapters/solidworks/features.py
+++ b/src/solidworks_mcp/adapters/solidworks/features.py
@@ -630,7 +630,7 @@ def _select_named_feature(
     Sweep and loft rely on selection marks to tell SolidWorks which selection
     is the profile (1), guide curve (2), or sweep path (4).  We resolve the
     feature with ``IModelDoc2::FeatureByName`` and select it with
-    ``IFeature::Select2(append, mark)`` â€” the same proven path the rest of the
+    ``IFeature::Select2(append, mark)`` — the same proven path the rest of the
     adapter uses for plane/sketch selection.  ``IModelDocExtension::SelectByID2``
     is avoided deliberately: late-bound ``SelectByID2`` raises
     ``Type mismatch`` on some SolidWorks builds, whereas ``FeatureByName`` +
@@ -641,7 +641,7 @@ def _select_named_feature(
         adapter: A connected adapter with a valid ``currentModel``.
         name: Feature name (e.g. ``"Sketch1"`` or ``"Helix/Spiral1"``).  Any
             ``@document`` qualifier is stripped before lookup.
-        mark: Selection mark â€” 1=profile, 2=guide curve, 4=sweep path.
+        mark: Selection mark — 1=profile, 2=guide curve, 4=sweep path.
         append: ``True`` to add to the current selection set, ``False`` to
             replace it.
 
@@ -706,7 +706,7 @@ def _read_member(obj: Any, name: str) -> Any:  # pragma: no cover
 
     Late-bound pywin32 dispatches are inconsistent: an unflagged zero-arg
     accessor may come back as a bound method (needing a call) *or* as the
-    already-resolved value â€” and when that value is itself a COM object it is
+    already-resolved value — and when that value is itself a COM object it is
     also callable, so a naive "call if callable" check wrongly invokes its
     default dispatch (``Member not found``).  This helper calls the member and
     falls back to the raw member if the call raises, so it yields the value in
@@ -932,7 +932,7 @@ def _create_loft_impl(
     """Create a lofted boss/protrusion between two or more profile sketches.
 
     Uses ``IFeatureManager::InsertProtrusionBlend2``.  Each profile named in
-    ``params.profiles`` is selected under mark 1 (in order â€” the selection
+    ``params.profiles`` is selected under mark 1 (in order — the selection
     order determines the loft direction), and any ``params.guide_curves`` are
     selected under mark 2.  Because a solid is produced, every profile must be
     a closed contour.
@@ -1205,7 +1205,7 @@ def _create_cut_extrude_impl(
             )
         elif sw_major >= 34:
             # SW 2026+ adds OptimizeGeometry as a 27th INPUT param.
-            # PFeat is an OUT param (PARAMFLAG_FOUT|FRETVAL) â€” not passed by caller.
+            # PFeat is an OUT param (PARAMFLAG_FOUT|FRETVAL) — not passed by caller.
             feature, cut4_error = adapter._attempt_with_error(
                 lambda: feature_manager.FeatureCut4(
                     is_through,  # Sd
@@ -1394,8 +1394,8 @@ def _parse_edge_spec(  # pragma: no cover
     """Parse an edge specification string into (SelectByID2 name, x, y, z).
 
     Supports two formats:
-    - ``"Edge<1>"`` â€” name-based selection (x=y=z=0.0, SW looks up by topology name)
-    - ``"x,y,z"`` â€” coordinate-based selection (name="", coordinate hint in metres)
+    - ``"Edge<1>"`` — name-based selection (x=y=z=0.0, SW looks up by topology name)
+    - ``"x,y,z"`` — coordinate-based selection (name="", coordinate hint in metres)
     """
     parts = edge_name.split(",")
     if len(parts) == 3:
@@ -1423,7 +1423,7 @@ def _select_edge_by_coord(  # pragma: no cover
     improve hit probability on curved edges.
 
     The ``Callout`` parameter of ``SelectByID2`` requires a VT_DISPATCH null
-    VARIANT â€” passing plain Python ``None`` triggers DISP_E_TYPEMISMATCH.
+    VARIANT — passing plain Python ``None`` triggers DISP_E_TYPEMISMATCH.
 
     Returns True if an edge was successfully selected; False otherwise.
     """
@@ -1455,7 +1455,7 @@ def _select_edge_by_coord(  # pragma: no cover
             (x, y * 1.001, z),
         ]
 
-    # VT_DISPATCH null pointer â€” required by SelectByID2's Callout parameter.
+    # VT_DISPATCH null pointer — required by SelectByID2's Callout parameter.
     # Plain Python None marshals as VT_NULL which SW rejects with DISP_E_TYPEMISMATCH.
     try:
         import pythoncom
@@ -1562,7 +1562,7 @@ def _add_fillet_impl(
                 raise Exception(f"Failed to select edge: {edge_name}")
 
         # SW 2025+ (major >= 33): IModelDoc2.FeatureFillet3 (9 params).
-        # Returns a non-zero int on success â€” NOT an IFeature â€” so we look up
+        # Returns a non-zero int on success — NOT an IFeature — so we look up
         # the last modified feature afterwards to get the name/id.
         # Older builds: IFeatureManager.FeatureFillet3 (15 params, returns IFeature).
         if fillet_sw_major >= 33:
@@ -1570,7 +1570,7 @@ def _add_fillet_impl(
                 radius / 1000.0,  # R1 in meters
                 True,  # Propagate (VT_BOOL)
                 0,  # Ftyp (VT_I4)
-                False,  # VarRadTyp (VT_BOOL â€” must be bool, not int)
+                False,  # VarRadTyp (VT_BOOL — must be bool, not int)
                 0,  # OverflowType (VT_I4)
                 0,  # NRadii (VT_I4)
                 None,  # Radii (VT_VARIANT)
@@ -1581,7 +1581,7 @@ def _add_fillet_impl(
                 raise Exception(
                     "Failed to create fillet (IModelDoc2.FeatureFillet3 returned 0)"
                 )
-            feature = None  # int return â€” retrieve feature object below
+            feature = None  # int return — retrieve feature object below
         else:
             feature_manager = adapter.currentModel.FeatureManager
             feature = feature_manager.FeatureFillet3(
@@ -1604,7 +1604,7 @@ def _add_fillet_impl(
             if not feature:
                 raise Exception("Failed to create fillet")
 
-        # Resolve the feature name â€” FeatureFillet3 on SW 2025+ returns an int,
+        # Resolve the feature name — FeatureFillet3 on SW 2025+ returns an int,
         # not an IFeature, so we can only report a default name here.
         feature_name = "Fillet"
         if feature is not None and hasattr(feature, "Name"):

--- a/tests/solidworks_mcp/adapters/test_adapters.py
+++ b/tests/solidworks_mcp/adapters/test_adapters.py
@@ -2553,6 +2553,14 @@ class TestPyWin32AdapterBranches:
             SimpleNamespace(Dispatch=Mock(return_value=None)),
             raising=False,
         )
+        # The 8-cycle acquire_solidworks_application retry loop sleeps 1s
+        # between attempts; every attempt here is mocked to fail, so the
+        # real 8s wait is pure overhead - skip it without changing the
+        # retry-count/exception logic under test.
+        monkeypatch.setattr(
+            "solidworks_mcp.adapters.pywin32_adapter.asyncio.sleep",
+            AsyncMock(),
+        )
 
         with pytest.raises(SolidWorksMCPError, match="instance is None"):
             await adapter.connect()

--- a/tests/solidworks_mcp/adapters/test_connection_pool_coverage.py
+++ b/tests/solidworks_mcp/adapters/test_connection_pool_coverage.py
@@ -407,7 +407,9 @@ class TestConnectionPoolAdapterCoverage:
     # ------------------------------------------------------------------
 
     @pytest.mark.asyncio
-    async def test_execute_with_pool_logs_when_replacement_adapter_fails(self):
+    async def test_execute_with_pool_logs_when_replacement_adapter_fails(
+        self, monkeypatch
+    ):
         """When the operation keeps failing and replacement adapter creation also."""
 
         bad_factory_calls = 0
@@ -438,6 +440,23 @@ class TestConnectionPoolAdapterCoverage:
             """Test always fail."""
 
             raise RuntimeError("operation failed")
+
+        # After the seed adapter fails and the bad_factory replacement also
+        # fails to connect, the retry loop's second _get_adapter() call
+        # blocks on an empty queue for its hardcoded 30s default timeout.
+        # Shrink that to keep the real wait_for/TimeoutError logic intact
+        # without the test actually waiting 30 real seconds.
+        real_get_adapter = pool._get_adapter
+
+        async def fast_get_adapter(timeout: float = 0.01):
+            return await real_get_adapter(timeout=timeout)
+
+        monkeypatch.setattr(pool, "_get_adapter", fast_get_adapter)
+        # Also skip the retry loop's 1s-per-retry exponential backoff sleep
+        # (max_retries=1 here, so this alone was worth 1 real second).
+        monkeypatch.setattr(
+            "solidworks_mcp.adapters.connection_pool.asyncio.sleep", AsyncMock()
+        )
 
         with patch("solidworks_mcp.adapters.connection_pool.logger") as mock_logger:
             result = await pool._execute_with_pool("test_op", always_fail)

--- a/tests/solidworks_mcp/test_solidworks_mixins_coverage.py
+++ b/tests/solidworks_mcp/test_solidworks_mixins_coverage.py
@@ -9,12 +9,25 @@ Exercises the specific code paths missed by the main branch test suite:
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
+from solidworks_mcp.adapters.base import AdapterResult, AdapterResultStatus
 from solidworks_mcp.adapters.pywin32_adapter import PyWin32Adapter
-from solidworks_mcp.adapters.solidworks.io import SolidWorksIOMixin
+from solidworks_mcp.adapters.solidworks.features import (
+    _create_axis_impl,
+    _create_reference_plane_impl,
+    _mirror_feature_impl,
+    _pattern_circular_impl,
+    _select_reference_entity,
+    _suppress_feature_impl,
+)
+from solidworks_mcp.adapters.solidworks.io import (
+    SolidWorksIOMixin,
+    _payload,
+    _payload_dict,
+)
 from solidworks_mcp.adapters.solidworks.sketch import SolidWorksSketchMixin
 
 # ---------------------------------------------------------------------------
@@ -321,3 +334,440 @@ class TestSolidWorksSketchMixinGeometryHelpers:
 
         assert result.is_success
         assert result.data == expected
+
+
+# ---------------------------------------------------------------------------
+# features.py: narrow COM defensive branches for the new PR #66-71 capabilities
+#
+# These are pure error-handling logic reacting to a falsy/unexpected COM
+# return value (e.g. "InsertMirrorFeature returned nothing") - not a claim
+# about what real SolidWorks actually does. Faking the specific return shape
+# a COM call produces, to verify OUR code reacts correctly, is safe and
+# established elsewhere in this file; it is fabricating a *believable
+# success* response (asserting real SW behaviour we cannot verify) that this
+# repo's tests avoid.
+# ---------------------------------------------------------------------------
+
+
+class TestMirrorAndPatternVolumeBracketing:
+    """Cover the async wrapper methods' before/after volume-check branches."""
+
+    @pytest.mark.asyncio
+    async def test_mirror_feature_errors_when_volume_unreadable(
+        self, monkeypatch
+    ) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.get_mass_properties = AsyncMock(
+            return_value=AdapterResult(
+                status=AdapterResultStatus.ERROR, error="no solid bodies"
+            )
+        )
+        with patch(
+            "solidworks_mcp.adapters.solidworks.features._mirror_feature_impl",
+            return_value=AdapterResult(
+                status=AdapterResultStatus.SUCCESS, data={"name": "Mirror1"}
+            ),
+        ):
+            result = await adapter.mirror_feature(["Body1"], "Right Plane")
+        assert result.is_error
+        assert "volume could not be read" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_mirror_feature_errors_when_volume_did_not_grow(
+        self, monkeypatch
+    ) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        same_volume = AdapterResult(
+            status=AdapterResultStatus.SUCCESS, data=SimpleNamespace(volume=100.0)
+        )
+        adapter.get_mass_properties = AsyncMock(return_value=same_volume)
+        with patch(
+            "solidworks_mcp.adapters.solidworks.features._mirror_feature_impl",
+            return_value=AdapterResult(
+                status=AdapterResultStatus.SUCCESS, data={"name": "Mirror1"}
+            ),
+        ):
+            result = await adapter.mirror_feature(["Body1"], "Right Plane")
+        assert result.is_error
+        assert "no new geometry" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_pattern_circular_errors_when_volume_unreadable(
+        self, monkeypatch
+    ) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.get_mass_properties = AsyncMock(
+            return_value=AdapterResult(status=AdapterResultStatus.ERROR, error="n/a")
+        )
+        with patch(
+            "solidworks_mcp.adapters.solidworks.features._pattern_circular_impl",
+            return_value=AdapterResult(
+                status=AdapterResultStatus.SUCCESS, data={"name": "CirPattern1"}
+            ),
+        ):
+            result = await adapter.pattern_circular(["Boss-Extrude1"], "Axis1", 4)
+        assert result.is_error
+        assert "volume could not be read" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_pattern_circular_errors_when_volume_did_not_grow(
+        self, monkeypatch
+    ) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        same_volume = AdapterResult(
+            status=AdapterResultStatus.SUCCESS, data=SimpleNamespace(volume=48431.5)
+        )
+        adapter.get_mass_properties = AsyncMock(return_value=same_volume)
+        with patch(
+            "solidworks_mcp.adapters.solidworks.features._pattern_circular_impl",
+            return_value=AdapterResult(
+                status=AdapterResultStatus.SUCCESS, data={"name": "CirPattern1"}
+            ),
+        ):
+            result = await adapter.pattern_circular(["Boss-Extrude1"], "Axis1", 4)
+        assert result.is_error
+        assert "produced no geometry" in (result.error or "")
+
+
+class TestSelectReferenceEntityFallback:
+    """Cover ``_select_reference_entity``'s SelectByID2 PLANE/FACE fallback."""
+
+    def test_falls_back_to_face_selectbyid2(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        # The named-feature path fails, so the fallback loop runs.
+        adapter.currentModel.FeatureByName.return_value = None
+        # PLANE attempt fails, FACE attempt succeeds.
+        adapter.currentModel.Extension.SelectByID2.side_effect = [False, True]
+
+        result = _select_reference_entity(adapter, "SomeFace", 0, append=False)
+
+        assert result is True
+        assert adapter.currentModel.Extension.SelectByID2.call_count == 2
+
+    def test_returns_false_when_every_attempt_fails(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.FeatureByName.return_value = None
+        adapter.currentModel.Extension.SelectByID2.return_value = False
+
+        result = _select_reference_entity(adapter, "Nothing", 0, append=False)
+
+        assert result is False
+
+
+class TestCreateReferencePlaneImplErrors:
+    """Cover ``_create_reference_plane_impl``'s two raise branches."""
+
+    def test_errors_when_reference_not_selectable(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.FeatureByName.return_value = None
+        adapter.currentModel.Extension.SelectByID2.return_value = False
+
+        result = _create_reference_plane_impl(
+            adapter, "Nonexistent Plane", 10.0, 0.0, False
+        )
+
+        assert result.is_error
+        assert "Failed to select reference plane/face" in (result.error or "")
+
+    def test_errors_when_plane_name_unreadable(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        # Named-feature selection succeeds.
+        adapter.currentModel.FeatureByName.return_value = SimpleNamespace(
+            Select2=lambda append, mark: True
+        )
+        # Feature count must rise (before < after) to pass that guard.
+        feature_manager = MagicMock()
+        feature_manager.GetFeatureCount.side_effect = [5, 6]
+        adapter.currentModel.FeatureManager = feature_manager
+        # InsertRefPlane succeeds but the resulting plane's Name is empty.
+        feature_manager.InsertRefPlane.return_value = SimpleNamespace(Name="")
+
+        result = _create_reference_plane_impl(adapter, "Front Plane", 10.0, 0.0, False)
+
+        assert result.is_error
+        assert "name could not be read" in (result.error or "")
+
+
+class TestCreateAxisImplErrors:
+    """Cover ``_create_axis_impl``'s "feature count unreadable" branch."""
+
+    def test_errors_when_feature_count_unreadable(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.FeatureByName.return_value = SimpleNamespace(
+            Select2=lambda append, mark: True
+        )
+        # GetFeatureCount returns a non-numeric value both times, so
+        # _feature_count(adapter) resolves to None on both reads.
+        feature_manager = MagicMock()
+        feature_manager.GetFeatureCount.return_value = None
+        adapter.currentModel.FeatureManager = feature_manager
+
+        result = _create_axis_impl(adapter, "z")
+
+        assert result.is_error
+        assert "feature count could not be read" in (result.error or "")
+
+
+class TestMirrorAndPatternImplReturnedNothing:
+    """Cover the "COM returned nothing after a valid selection" raises."""
+
+    def test_mirror_feature_impl_errors_when_insert_returns_nothing(
+        self, monkeypatch
+    ) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        # mirror_bodies=False routes source AND plane selection through the
+        # named-feature path (FeatureByName + Select2), avoiding the need to
+        # also wire up the SelectByID2 body-selection branch.
+        adapter.currentModel.FeatureByName.return_value = SimpleNamespace(
+            Select2=lambda append, mark: True
+        )
+        feature_manager = MagicMock()
+        feature_manager.InsertMirrorFeature.return_value = None
+        adapter.currentModel.FeatureManager = feature_manager
+
+        result = _mirror_feature_impl(adapter, ["Loft1"], "Right Plane", True, False)
+
+        assert result.is_error
+        assert "InsertMirrorFeature returned nothing" in (result.error or "")
+
+    def test_pattern_circular_impl_errors_when_call_returns_nothing(
+        self, monkeypatch
+    ) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        # Axis and feature selection both go through SelectByID2 directly.
+        adapter.currentModel.Extension.SelectByID2.return_value = True
+        feature_manager = MagicMock()
+        feature_manager.FeatureCircularPattern5.return_value = None
+        adapter.currentModel.FeatureManager = feature_manager
+
+        result = _pattern_circular_impl(
+            adapter, ["Boss-Extrude1"], "Axis1", 4, 360.0, True
+        )
+
+        assert result.is_error
+        assert "FeatureCircularPattern5 returned nothing" in (result.error or "")
+
+
+class TestSuppressFeatureImplStateMismatch:
+    """Cover the "state did not change" guard in ``_suppress_feature_impl``."""
+
+    def test_errors_when_readback_state_does_not_match_request(
+        self, monkeypatch
+    ) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        # First FeatureByName call (initial select) and second (post-rebuild
+        # refresh) both resolve to a feature reporting IsSuppressed=False -
+        # a suppress request (suppress=True) that the COM call accepted but
+        # that did not actually take effect.
+        adapter.currentModel.FeatureByName.side_effect = [
+            SimpleNamespace(IsSuppressed=False, Select2=lambda append, mark: True),
+            SimpleNamespace(IsSuppressed=False),
+        ]
+
+        result = _suppress_feature_impl(adapter, "Fillet1", True)
+
+        assert result.is_error
+        assert "did not change" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# io.py: narrow error/fallback branches for the new PR #65/#66 drawing and
+# interference capabilities, plus two small pre-existing payload-coercion
+# fallbacks these tests happen to also close.
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadCoercionFallbacks:
+    """Cover the ``vars(data)`` fallback in ``_payload`` / ``_payload_dict``."""
+
+    def test_payload_coerces_plain_object_via_vars(self) -> None:
+        class _Obj:
+            def __init__(self) -> None:
+                self.text = "hello"
+                self._private = "hidden"
+
+        result = _payload(_Obj())
+        assert result == {"text": "hello"}
+
+    def test_payload_dict_coerces_plain_object_via_vars(self) -> None:
+        class _Obj:
+            def __init__(self) -> None:
+                self.coincident = True
+                self._private = "hidden"
+
+        result = _payload_dict(_Obj())
+        assert result == {"coincident": True}
+
+
+class TestRequireDrawingGuard:
+    """Cover ``SolidWorksIOMixin._require_drawing``'s two error branches."""
+
+    @pytest.mark.asyncio
+    async def test_errors_when_no_active_model(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = None
+
+        result = await adapter.add_note({"text": "hi"})
+
+        assert result.is_error
+        assert "No active model" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_errors_when_active_document_is_not_a_drawing(
+        self, monkeypatch
+    ) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 1  # Part, not a drawing (3)
+
+        result = await adapter.add_note({"text": "hi"})
+
+        assert result.is_error
+        assert "requires a drawing document" in (result.error or "")
+
+
+class TestPlaceViewErrors:
+    """Cover ``_place_view``'s input-validation error branches."""
+
+    @staticmethod
+    def _drawing_adapter(monkeypatch) -> PyWin32Adapter:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 3  # Drawing
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_errors_when_model_path_missing(self, monkeypatch) -> None:
+        adapter = self._drawing_adapter(monkeypatch)
+
+        result = await adapter.create_drawing_view({"orientation": "front"})
+
+        assert result.is_error
+        assert "A model path is required" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_errors_when_model_file_not_found(self, monkeypatch) -> None:
+        adapter = self._drawing_adapter(monkeypatch)
+
+        result = await adapter.create_drawing_view(
+            {"model_path": "C:/definitely/does/not/exist.sldprt"}
+        )
+
+        assert result.is_error
+        assert "Model file not found" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_errors_when_orientation_unknown(self, monkeypatch) -> None:
+        adapter = self._drawing_adapter(monkeypatch)
+        # __file__ definitely exists on disk, so the file-not-found check
+        # passes and the orientation check is what actually gets exercised.
+        result = await adapter.create_drawing_view(
+            {"model_path": __file__, "orientation": "not_a_real_view"}
+        )
+
+        assert result.is_error
+        assert "Unknown orientation" in (result.error or "")
+
+
+class TestCreateTechnicalDrawingNoViewsCreated:
+    """Cover ``create_technical_drawing``'s "no views were created" raise."""
+
+    @pytest.mark.asyncio
+    async def test_errors_when_no_new_views_appear(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 3  # Drawing
+        # GetViews() defaults to a MagicMock, which _view_names treats as
+        # "not a list/tuple" and reduces to [] both before and after, so
+        # nothing appears to have been added.
+
+        result = await adapter.create_technical_drawing({"model_path": __file__})
+
+        assert result.is_error
+        assert "No views were created" in (result.error or "")
+
+
+class TestAddNoteInsertNoteReturnsNothing:
+    """Cover ``add_note``'s "InsertNote returned nothing" raise."""
+
+    @pytest.mark.asyncio
+    async def test_errors_when_insert_note_returns_nothing(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 3  # Drawing
+        adapter.currentModel.InsertNote.return_value = None
+
+        result = await adapter.add_note({"text": "MATERIAL: AISI 1018"})
+
+        assert result.is_error
+        assert "InsertNote returned nothing" in (result.error or "")
+
+
+class TestCheckInterferenceManagerUnavailable:
+    """Cover ``check_interference``'s "manager is unavailable" raise."""
+
+    @pytest.mark.asyncio
+    async def test_errors_when_interference_detection_manager_unavailable(
+        self, monkeypatch
+    ) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 2  # Assembly
+        adapter.currentModel.InterferenceDetectionManager = None
+
+        result = await adapter.check_interference()
+
+        assert result.is_error
+        assert "InterferenceDetectionManager is unavailable" in (result.error or "")
+
+
+class TestCreateDrawingNoTemplateConfigured:
+    """Cover ``create_drawing``'s "no drawing template configured" raise."""
+
+    @pytest.mark.asyncio
+    async def test_errors_when_no_template_resolves(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        monkeypatch.setattr(adapter, "is_connected", lambda: True)
+        adapter.swApp = MagicMock()
+        adapter._resolve_template_path = lambda *a, **kw: None
+
+        result = await adapter.create_drawing()
+
+        assert result.is_error
+        assert "No drawing template configured" in (result.error or "")
+
+
+class TestSaveFileLegacyFallback:
+    """Cover ``save_file``'s legacy ``Save()`` fallback and unwritten-file raise."""
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_save_and_errors_when_file_not_written(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        adapter = _build_adapter(monkeypatch)
+        # A path that does not exist, so the final os.path.exists check fails
+        # regardless of what the mocked Save3/Save calls "do".
+        target = str(tmp_path / "does_not_exist.sldprt")
+
+        model = MagicMock()
+        model.GetPathName.return_value = target
+        model.Save3.return_value = None  # forces the legacy Save() fallback
+        adapter.currentModel = model
+
+        result = await adapter.save_file(target)
+
+        assert result.is_error
+        assert "File not written after save" in (result.error or "")
+        model.Save.assert_called_once()

--- a/tests/solidworks_mcp/test_solidworks_mixins_coverage.py
+++ b/tests/solidworks_mcp/test_solidworks_mixins_coverage.py
@@ -1155,6 +1155,25 @@ class TestSuppressFeatureImplMoreErrors:
         assert result.is_error
         assert "Feature not found: Ghost1" in (result.error or "")
 
+    def test_errors_when_edit_suppress_raises(self, monkeypatch) -> None:
+        """Late binding can resolve EditSuppress2 as a property that performs
+        the edit and *then* raises "'bool' object is not callable" - the
+        operation succeeds while the caller sees a failure. Reproduced here
+        via a plain raise, which _attempt_with_error reports the same way."""
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.FeatureByName.return_value = SimpleNamespace(
+            Select2=lambda append, mark: True, IsSuppressed=False
+        )
+        adapter.currentModel.EditSuppress2.side_effect = TypeError(
+            "'bool' object is not callable"
+        )
+
+        result = _suppress_feature_impl(adapter, "Fillet1", True)
+
+        assert result.is_error
+        assert "Failed to suppress Fillet1" in (result.error or "")
+
 
 class TestUndoImplMoreErrors:
     def test_errors_when_no_active_model(self, monkeypatch) -> None:

--- a/tests/solidworks_mcp/test_solidworks_mixins_coverage.py
+++ b/tests/solidworks_mcp/test_solidworks_mixins_coverage.py
@@ -18,17 +18,25 @@ from solidworks_mcp.adapters.pywin32_adapter import PyWin32Adapter
 from solidworks_mcp.adapters.solidworks.features import (
     _create_axis_impl,
     _create_reference_plane_impl,
+    _delete_feature_impl,
+    _feature_count,
+    _is_suppressed,
     _mirror_feature_impl,
     _pattern_circular_impl,
     _select_reference_entity,
     _suppress_feature_impl,
+    _undo_impl,
 )
 from solidworks_mcp.adapters.solidworks.io import (
     SolidWorksIOMixin,
     _byref_int,
     _ByrefFallback,
+    _component_pairs,
+    _component_transforms,
+    _interference_details,
     _payload,
     _payload_dict,
+    _view_names,
 )
 from solidworks_mcp.adapters.solidworks.sketch import SolidWorksSketchMixin
 
@@ -1024,3 +1032,770 @@ class TestSaveFileLegacyFallback:
         assert result.is_error
         assert "File not written after save" in (result.error or "")
         model.Save.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Second pass: every remaining line from the combined (mock + real-SW)
+# coverage report, closed one by one per the user's explicit request.
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureCountAndSuppressedHelpers:
+    """Direct unit tests for the small module-level helpers in features.py."""
+
+    def test_feature_count_returns_none_when_manager_unreadable(self) -> None:
+        class _Adapter:
+            currentModel = SimpleNamespace(FeatureManager=None)
+
+            def _attempt(self, op, default=None):
+                try:
+                    return op()
+                except Exception:
+                    return default
+
+        assert _feature_count(_Adapter()) is None
+
+    def test_feature_count_returns_none_when_count_not_numeric(self) -> None:
+        class _Adapter:
+            currentModel = SimpleNamespace(
+                FeatureManager=SimpleNamespace(
+                    GetFeatureCount=lambda include_hidden: "not-a-number"
+                )
+            )
+
+            def _attempt(self, op, default=None):
+                try:
+                    return op()
+                except Exception:
+                    return default
+
+        assert _feature_count(_Adapter()) is None
+
+    def test_is_suppressed_reads_list_state(self) -> None:
+        class _Adapter:
+            def _attempt(self, op, default=None):
+                try:
+                    return op()
+                except Exception:
+                    return default
+
+            def _get_attr_or_call(self, obj, attr_name):
+                attr = getattr(obj, attr_name, None)
+                return attr() if callable(attr) else attr
+
+        feature = SimpleNamespace(IsSuppressed=[True])
+        assert _is_suppressed(_Adapter(), feature) is True
+
+    def test_is_suppressed_reads_int_state(self) -> None:
+        class _Adapter:
+            def _attempt(self, op, default=None):
+                try:
+                    return op()
+                except Exception:
+                    return default
+
+            def _get_attr_or_call(self, obj, attr_name):
+                attr = getattr(obj, attr_name, None)
+                return attr() if callable(attr) else attr
+
+        feature = SimpleNamespace(IsSuppressed=1)
+        assert _is_suppressed(_Adapter(), feature) is True
+
+    def test_is_suppressed_returns_none_for_unrecognized_type(self) -> None:
+        class _Adapter:
+            def _attempt(self, op, default=None):
+                try:
+                    return op()
+                except Exception:
+                    return default
+
+            def _get_attr_or_call(self, obj, attr_name):
+                attr = getattr(obj, attr_name, None)
+                return attr() if callable(attr) else attr
+
+        feature = SimpleNamespace(IsSuppressed="unexpected")
+        assert _is_suppressed(_Adapter(), feature) is None
+
+
+class TestDeleteFeatureImplMoreErrors:
+    def test_errors_when_no_active_model(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = None
+        result = _delete_feature_impl(adapter, "Boss-Extrude1")
+        assert result.is_error
+        assert "No active model" in (result.error or "")
+
+    def test_errors_when_edit_delete_did_not_remove_feature(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        feature = SimpleNamespace(Select2=lambda append, mark: True)
+        adapter.currentModel.FeatureByName.return_value = feature
+
+        result = _delete_feature_impl(adapter, "Boss-Extrude1")
+
+        assert result.is_error
+        assert "EditDelete did not remove feature" in (result.error or "")
+
+
+class TestSuppressFeatureImplMoreErrors:
+    def test_errors_when_no_active_model(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = None
+        result = _suppress_feature_impl(adapter, "Fillet1", True)
+        assert result.is_error
+        assert "No active model" in (result.error or "")
+
+    def test_errors_when_feature_not_found(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.FeatureByName.return_value = None
+
+        result = _suppress_feature_impl(adapter, "Ghost1", True)
+
+        assert result.is_error
+        assert "Feature not found: Ghost1" in (result.error or "")
+
+
+class TestUndoImplMoreErrors:
+    def test_errors_when_no_active_model(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = None
+        result = _undo_impl(adapter, 1)
+        assert result.is_error
+        assert "No active model" in (result.error or "")
+
+    def test_errors_when_both_undo_overloads_fail(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.EditUndo2.side_effect = RuntimeError("not supported")
+        adapter.currentModel.EditUndo.side_effect = RuntimeError("legacy gone too")
+
+        result = _undo_impl(adapter, 1)
+
+        assert result.is_error
+        assert "Undo failed" in (result.error or "")
+
+
+class TestCreateReferencePlaneImplMoreErrors:
+    def test_errors_when_no_active_model(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = None
+        result = _create_reference_plane_impl(adapter, "Front Plane", 10.0, 0.0, False)
+        assert result.is_error
+        assert "No active model" in (result.error or "")
+
+    def test_errors_when_reference_blank(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+
+        result = _create_reference_plane_impl(adapter, "", 10.0, 0.0, False)
+
+        assert result.is_error
+        assert "requires a reference plane/face name" in (result.error or "")
+
+    def test_flip_true_combines_the_option_flag_on_success(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.FeatureByName.return_value = SimpleNamespace(
+            Select2=lambda append, mark: True
+        )
+        feature_manager = MagicMock()
+        feature_manager.GetFeatureCount.side_effect = [5, 6]
+        feature_manager.InsertRefPlane.return_value = SimpleNamespace(Name="Plane1")
+        adapter.currentModel.FeatureManager = feature_manager
+
+        result = _create_reference_plane_impl(adapter, "Front Plane", 10.0, 0.0, True)
+
+        assert result.is_success
+        no_flip_constraint = feature_manager.InsertRefPlane.call_args.args[0]
+        assert no_flip_constraint & 256  # _REF_PLANE_OPTION_FLIP bit is set
+
+    def test_errors_when_no_plane_added_to_tree(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.FeatureByName.return_value = SimpleNamespace(
+            Select2=lambda append, mark: True
+        )
+        feature_manager = MagicMock()
+        feature_manager.GetFeatureCount.return_value = 5  # unchanged before/after
+        adapter.currentModel.FeatureManager = feature_manager
+
+        result = _create_reference_plane_impl(adapter, "Front Plane", 10.0, 0.0, False)
+
+        assert result.is_error
+        assert "No reference plane was added" in (result.error or "")
+
+    def test_errors_when_insert_ref_plane_returns_nothing(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.FeatureByName.return_value = SimpleNamespace(
+            Select2=lambda append, mark: True
+        )
+        feature_manager = MagicMock()
+        feature_manager.GetFeatureCount.side_effect = [5, 6]
+        feature_manager.InsertRefPlane.return_value = None
+        adapter.currentModel.FeatureManager = feature_manager
+
+        result = _create_reference_plane_impl(adapter, "Front Plane", 10.0, 0.0, False)
+
+        assert result.is_error
+        assert "InsertRefPlane returned nothing" in (result.error or "")
+
+
+class TestCreateAxisImplMoreErrors:
+    def test_errors_when_no_active_model(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = None
+        result = _create_axis_impl(adapter, "z")
+        assert result.is_error
+        assert "No active model" in (result.error or "")
+
+    def test_errors_when_plane_selection_fails(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.FeatureByName.return_value = None
+        adapter.currentModel.Extension.SelectByID2.return_value = False
+
+        result = _create_axis_impl(adapter, "z")
+
+        assert result.is_error
+        assert "Failed to select" in (result.error or "")
+
+    def test_errors_when_no_axis_created_but_counts_readable(
+        self, monkeypatch
+    ) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.FeatureByName.return_value = SimpleNamespace(
+            Select2=lambda append, mark: True
+        )
+        feature_manager = MagicMock()
+        feature_manager.GetFeatureCount.return_value = 5  # unchanged
+        adapter.currentModel.FeatureManager = feature_manager
+
+        result = _create_axis_impl(adapter, "z")
+
+        assert result.is_error
+        assert "No reference axis was created" in (result.error or "")
+
+
+class TestMirrorFeatureImplMoreErrors:
+    def test_errors_when_no_active_model(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = None
+        result = _mirror_feature_impl(adapter, ["Loft1"], "Right Plane", True, True)
+        assert result.is_error
+        assert "No active model" in (result.error or "")
+
+    def test_errors_when_plane_selection_fails_but_source_succeeds(
+        self, monkeypatch
+    ) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+
+        def feature_by_name(name):
+            if name == "Loft1":
+                return SimpleNamespace(Select2=lambda append, mark: True)
+            return None
+
+        adapter.currentModel.FeatureByName.side_effect = feature_by_name
+        adapter.currentModel.Extension.SelectByID2.return_value = False
+
+        result = _mirror_feature_impl(
+            adapter, ["Loft1"], "Right Plane", True, False
+        )
+
+        assert result.is_error
+        assert "Failed to select mirror plane: Right Plane" in (result.error or "")
+
+
+class TestPatternCircularImplMoreErrors:
+    def test_errors_when_no_active_model(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = None
+        result = _pattern_circular_impl(
+            adapter, ["Boss-Extrude1"], "Axis1", 4, 360.0, True
+        )
+        assert result.is_error
+        assert "No active model" in (result.error or "")
+
+    def test_falls_back_to_named_feature_selection_and_then_fails(
+        self, monkeypatch
+    ) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+
+        def select_by_id2(name, kind, x, y, z, append, mark, callout, opt):
+            return kind == "AXIS"
+
+        adapter.currentModel.Extension.SelectByID2.side_effect = select_by_id2
+        adapter.currentModel.FeatureByName.return_value = None
+
+        result = _pattern_circular_impl(
+            adapter, ["Boss-Extrude1"], "Axis1", 4, 360.0, True
+        )
+
+        assert result.is_error
+        assert "Failed to select feature to pattern" in (result.error or "")
+
+
+class TestMirrorAndPatternWrapperNoActiveModel:
+    """The async wrapper methods' own early 'no active model' guard."""
+
+    @pytest.mark.asyncio
+    async def test_mirror_feature_errors_when_no_active_model(
+        self, monkeypatch
+    ) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = None
+        result = await adapter.mirror_feature(["Body1"], "Right Plane")
+        assert result.is_error
+        assert "No active model" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_pattern_circular_errors_when_no_active_model(
+        self, monkeypatch
+    ) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = None
+        result = await adapter.pattern_circular(["Boss-Extrude1"], "Axis1", 4)
+        assert result.is_error
+        assert "No active model" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# io.py: module-level helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestViewNamesHelper:
+    def test_skips_unwrappable_views(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        monkeypatch.setattr(
+            "solidworks_mcp.adapters.solidworks.io._dynamic",
+            SimpleNamespace(Dispatch=lambda obj: None),
+        )
+        drawing = SimpleNamespace(GetViews=lambda: [["sheet_obj", "view_obj1"]])
+
+        result = _view_names(adapter, drawing)
+
+        assert result == []
+
+
+class TestComponentTransformsHelper:
+    def test_skips_component_that_is_none(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        monkeypatch.setattr(
+            "solidworks_mcp.adapters.solidworks.io._dynamic",
+            SimpleNamespace(Dispatch=lambda obj: None),
+        )
+        assembly = MagicMock()
+        assembly.GetComponents.return_value = [object()]
+
+        result = _component_transforms(adapter, assembly)
+
+        assert result == {}
+
+    def test_skips_non_list_transform_data(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        monkeypatch.setattr(
+            "solidworks_mcp.adapters.solidworks.io._dynamic",
+            SimpleNamespace(Dispatch=lambda obj: obj),
+        )
+        component = SimpleNamespace(
+            Name2="part-1", Transform2=SimpleNamespace(ArrayData="not-a-list")
+        )
+        assembly = MagicMock()
+        assembly.GetComponents.return_value = [component]
+
+        result = _component_transforms(adapter, assembly)
+
+        assert result == {}
+
+    def test_skips_transform_with_unconvertible_values(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        monkeypatch.setattr(
+            "solidworks_mcp.adapters.solidworks.io._dynamic",
+            SimpleNamespace(Dispatch=lambda obj: obj),
+        )
+        component = SimpleNamespace(
+            Name2="part-1",
+            Transform2=SimpleNamespace(ArrayData=["not-a-number"] * 16),
+        )
+        assembly = MagicMock()
+        assembly.GetComponents.return_value = [component]
+
+        result = _component_transforms(adapter, assembly)
+
+        assert result == {}
+
+
+class TestInterferenceDetailsHelper:
+    def test_skips_unwrappable_interference(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        monkeypatch.setattr(
+            "solidworks_mcp.adapters.solidworks.io._dynamic",
+            SimpleNamespace(Dispatch=lambda obj: None),
+        )
+
+        result = _interference_details(adapter, [object()])
+
+        assert result == []
+
+    def test_volume_conversion_failure_reports_none(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        monkeypatch.setattr(
+            "solidworks_mcp.adapters.solidworks.io._dynamic",
+            SimpleNamespace(Dispatch=lambda obj: obj),
+        )
+        item = SimpleNamespace(
+            Volume="not-a-number", GetComponentCount=lambda: 2, Components=[]
+        )
+
+        result = _interference_details(adapter, [item])
+
+        assert result[0]["volume_mm3"] is None
+
+    def test_skips_unwrappable_nested_component(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        monkeypatch.setattr(
+            "solidworks_mcp.adapters.solidworks.io._dynamic",
+            SimpleNamespace(
+                Dispatch=lambda obj: None if isinstance(obj, str) else obj
+            ),
+        )
+        item = SimpleNamespace(
+            Volume=1e-6, GetComponentCount=lambda: 1, Components=["raw-string"]
+        )
+
+        result = _interference_details(adapter, [item])
+
+        assert result[0]["components"] == []
+
+
+class TestComponentPairsHelper:
+    def test_unwrappable_component_reported_as_unnamed(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        monkeypatch.setattr(
+            "solidworks_mcp.adapters.solidworks.io._dynamic",
+            SimpleNamespace(Dispatch=lambda obj: None),
+        )
+        assembly = MagicMock()
+        assembly.GetComponents.return_value = [object()]
+
+        result = _component_pairs(adapter, assembly)
+
+        assert result == [("<unnamed>", None)]
+
+    def test_falls_back_to_get_path_name_when_name2_empty(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        monkeypatch.setattr(
+            "solidworks_mcp.adapters.solidworks.io._dynamic",
+            SimpleNamespace(Dispatch=lambda obj: obj),
+        )
+        component = SimpleNamespace(Name2="", GetPathName=lambda: "C:/parts/a.sldprt")
+        assembly = MagicMock()
+        assembly.GetComponents.return_value = [component]
+
+        result = _component_pairs(adapter, assembly)
+
+        assert result == [("C:/parts/a.sldprt", component)]
+
+
+# ---------------------------------------------------------------------------
+# io.py: insert_component / list_components
+# ---------------------------------------------------------------------------
+
+
+class TestInsertComponentMoreErrors:
+    @pytest.mark.asyncio
+    async def test_errors_when_no_active_model(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = None
+        result = await adapter.insert_component("C:/parts/a.sldprt", 0, 0, 0)
+        assert result.is_error
+        assert "No active model" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_errors_when_file_not_found(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        result = await adapter.insert_component(
+            "C:/definitely/not/real.sldprt", 0, 0, 0
+        )
+        assert result.is_error
+        assert "Component file not found" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_errors_when_not_an_assembly(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 1
+
+        result = await adapter.insert_component(__file__, 0, 0, 0)
+
+        assert result.is_error
+        assert "requires an assembly document" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_errors_when_opendoc6_returns_nothing(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 2
+        adapter.swApp = MagicMock()
+        adapter.swApp.OpenDoc6.return_value = None
+
+        result = await adapter.insert_component(__file__, 0, 0, 0)
+
+        assert result.is_error
+        assert "OpenDoc6 returned nothing" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_add_component5_and_still_fails(
+        self, monkeypatch
+    ) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 2
+        adapter.currentModel.GetComponents.return_value = []
+        adapter.swApp = MagicMock()
+        adapter.swApp.OpenDoc6.return_value = MagicMock()
+        adapter.currentModel.AddComponent4.return_value = None
+        adapter.currentModel.AddComponent5.return_value = None
+
+        result = await adapter.insert_component(__file__, 0, 0, 0)
+
+        assert result.is_error
+        adapter.currentModel.AddComponent5.assert_called_once()
+        assert "Component was not inserted" in (result.error or "")
+
+
+class TestListComponentsMoreErrors:
+    @pytest.mark.asyncio
+    async def test_errors_when_no_active_model(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = None
+        result = await adapter.list_components()
+        assert result.is_error
+        assert "No active model" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_errors_when_not_an_assembly(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 1
+
+        result = await adapter.list_components()
+
+        assert result.is_error
+        assert "requires an assembly document" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# io.py: _place_view / create_drawing_view / add_drawing_view
+# ---------------------------------------------------------------------------
+
+
+class TestPlaceViewMoreErrors:
+    @pytest.mark.asyncio
+    async def test_guard_passthrough_when_no_active_model(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = None
+        result = await adapter.create_drawing_view({"model_path": __file__})
+        assert result.is_error
+        assert "No active model" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_scale_parse_failure_is_absorbed_not_raised(
+        self, monkeypatch
+    ) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 3
+        adapter.currentModel.GetViews.return_value = None
+
+        # "1:1" cannot convert via float() - if the except branch (1794-1798)
+        # did not absorb it, this would raise ValueError instead of
+        # returning a normal AdapterResult.
+        result = await adapter.create_drawing_view(
+            {"model_path": __file__, "scale": "1:1"}
+        )
+
+        assert result.is_error  # a normal error result, not an exception
+
+    @pytest.mark.asyncio
+    async def test_errors_when_view_count_unchanged(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 3
+        adapter.swApp = MagicMock()
+        adapter.swApp.OpenDoc6.return_value = MagicMock()
+        adapter.currentModel.GetViews.return_value = None
+
+        result = await adapter.create_drawing_view({"model_path": __file__})
+
+        assert result.is_error
+        assert "View was not created" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_applies_scale_when_view_is_created(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 3
+        adapter.swApp = MagicMock()
+        adapter.swApp.OpenDoc6.return_value = MagicMock()
+        monkeypatch.setattr(
+            "solidworks_mcp.adapters.solidworks.io._dynamic",
+            SimpleNamespace(Dispatch=lambda obj: obj),
+        )
+        view_names_calls = iter([[], ["Drawing View1"]])
+        monkeypatch.setattr(
+            "solidworks_mcp.adapters.solidworks.io._view_names",
+            lambda adapter, drawing: next(view_names_calls),
+        )
+        adapter.currentModel.CreateDrawViewFromModelView3.return_value = (
+            SimpleNamespace()
+        )
+
+        result = await adapter.create_drawing_view(
+            {"model_path": __file__, "scale": "2.0"}
+        )
+
+        assert result.is_success
+        assert result.data["name"] == "Drawing View1"
+
+
+class TestAddDrawingViewDelegates:
+    @pytest.mark.asyncio
+    async def test_add_drawing_view_reaches_place_view(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = None
+
+        result = await adapter.add_drawing_view({"model_path": __file__})
+
+        assert result.is_error
+        assert "No active model" in (result.error or "")
+
+
+class TestCreateTechnicalDrawingMoreErrors:
+    @pytest.mark.asyncio
+    async def test_guard_passthrough_when_no_active_model(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = None
+        result = await adapter.create_technical_drawing({"model_path": __file__})
+        assert result.is_error
+        assert "No active model" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_errors_when_model_path_missing(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 3
+
+        result = await adapter.create_technical_drawing({})
+
+        assert result.is_error
+        assert "A model path is required" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_errors_when_model_file_not_found(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 3
+
+        result = await adapter.create_technical_drawing(
+            {"model_path": "C:/definitely/not/real.sldprt"}
+        )
+
+        assert result.is_error
+        assert "Model file not found" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_first_angle_projection_calls_the_first_angle_overload(
+        self, monkeypatch
+    ) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 3
+        adapter.currentModel.GetViews.return_value = None
+
+        result = await adapter.create_technical_drawing(
+            {"model_path": __file__, "projection": "first_angle"}
+        )
+
+        assert result.is_error  # no views appear either way; that's fine here
+        adapter.currentModel.Create1stAngleViews2.assert_called_once()
+        adapter.currentModel.Create3rdAngleViews2.assert_not_called()
+
+
+class TestAddNoteMoreErrors:
+    @pytest.mark.asyncio
+    async def test_errors_when_text_missing(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 3
+
+        result = await adapter.add_note({})
+
+        assert result.is_error
+        assert "add_note requires text" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_accepts_an_explicit_position_list(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 3
+        adapter.currentModel.InsertNote.return_value = None
+
+        result = await adapter.add_note({"text": "hi", "position": [10.0, 20.0]})
+
+        assert result.is_error
+        assert "InsertNote returned nothing" in (result.error or "")
+
+
+class TestListDrawingViewsGuard:
+    @pytest.mark.asyncio
+    async def test_guard_passthrough_when_no_active_model(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = None
+        result = await adapter.list_drawing_views()
+        assert result.is_error
+        assert "No active model" in (result.error or "")
+
+
+class TestCheckInterferenceMoreErrors:
+    @pytest.mark.asyncio
+    async def test_errors_when_no_active_model(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = None
+        result = await adapter.check_interference()
+        assert result.is_error
+        assert "No active model" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_filters_by_wanted_component_names(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 2
+        monkeypatch.setattr(
+            "solidworks_mcp.adapters.solidworks.io._dynamic",
+            SimpleNamespace(Dispatch=lambda obj: obj),
+        )
+        manager = MagicMock()
+        manager.GetInterferenceCount.return_value = 1
+        item = SimpleNamespace(
+            Volume=1e-6,
+            GetComponentCount=lambda: 2,
+            Components=[
+                SimpleNamespace(Name2="part-1"),
+                SimpleNamespace(Name2="part-2"),
+            ],
+        )
+        manager.GetInterferences.return_value = [item]
+        adapter.currentModel.InterferenceDetectionManager = manager
+
+        result = await adapter.check_interference({"components": ["part-1"]})
+
+        assert result.is_success
+        assert result.data["interference_found"] is True
+        assert result.data["scope"] == ["part-1"]

--- a/tests/solidworks_mcp/test_solidworks_mixins_coverage.py
+++ b/tests/solidworks_mcp/test_solidworks_mixins_coverage.py
@@ -676,11 +676,13 @@ class TestPlaceViewErrors:
         assert "A model path is required" in (result.error or "")
 
     @pytest.mark.asyncio
-    async def test_errors_when_model_file_not_found(self, monkeypatch) -> None:
+    async def test_errors_when_model_file_not_found(
+        self, monkeypatch, tmp_path
+    ) -> None:
         adapter = self._drawing_adapter(monkeypatch)
 
         result = await adapter.create_drawing_view(
-            {"model_path": "C:/definitely/does/not/exist.sldprt"}
+            {"model_path": str(tmp_path / "does-not-exist.sldprt")}
         )
 
         assert result.is_error
@@ -1536,11 +1538,11 @@ class TestInsertComponentMoreErrors:
         assert "No active model" in (result.error or "")
 
     @pytest.mark.asyncio
-    async def test_errors_when_file_not_found(self, monkeypatch) -> None:
+    async def test_errors_when_file_not_found(self, monkeypatch, tmp_path) -> None:
         adapter = _build_adapter(monkeypatch)
         adapter.currentModel = MagicMock()
         result = await adapter.insert_component(
-            "C:/definitely/not/real.sldprt", 0, 0, 0
+            str(tmp_path / "does-not-exist.sldprt"), 0, 0, 0
         )
         assert result.is_error
         assert "Component file not found" in (result.error or "")
@@ -1717,13 +1719,15 @@ class TestCreateTechnicalDrawingMoreErrors:
         assert "A model path is required" in (result.error or "")
 
     @pytest.mark.asyncio
-    async def test_errors_when_model_file_not_found(self, monkeypatch) -> None:
+    async def test_errors_when_model_file_not_found(
+        self, monkeypatch, tmp_path
+    ) -> None:
         adapter = _build_adapter(monkeypatch)
         adapter.currentModel = MagicMock()
         adapter.currentModel.GetType.return_value = 3
 
         result = await adapter.create_technical_drawing(
-            {"model_path": "C:/definitely/not/real.sldprt"}
+            {"model_path": str(tmp_path / "does-not-exist.sldprt")}
         )
 
         assert result.is_error

--- a/tests/solidworks_mcp/test_solidworks_mixins_coverage.py
+++ b/tests/solidworks_mcp/test_solidworks_mixins_coverage.py
@@ -610,6 +610,14 @@ class TestPayloadCoercionFallbacks:
         result = _payload_dict(_Obj())
         assert result == {"coincident": True}
 
+    def test_payload_dict_passes_through_a_plain_dict(self) -> None:
+        given = {"coincident": True}
+        assert _payload_dict(given) is given
+
+    def test_payload_dict_uses_model_dump_for_pydantic_style_objects(self) -> None:
+        model = SimpleNamespace(model_dump=lambda: {"coincident": False})
+        assert _payload_dict(model) == {"coincident": False}
+
 
 class TestRequireDrawingGuard:
     """Cover ``SolidWorksIOMixin._require_drawing``'s two error branches."""
@@ -679,6 +687,33 @@ class TestPlaceViewErrors:
 
         assert result.is_error
         assert "Unknown orientation" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_accepts_an_explicit_position_list_and_a_raw_star_view_name(
+        self, monkeypatch
+    ) -> None:
+        """An explicit [x, y] position and a raw '*Name' orientation both parse.
+
+        Doesn't assert success - reaching the raw-name branch means the call
+        proceeds to a real (mocked) OpenDoc6, which this bare MagicMock
+        currentModel can't satisfy. What matters here is that both parsing
+        branches (position-as-list, and the '*'-prefixed raw view name) run
+        without raising, rather than falling into their "not given" defaults.
+        """
+        adapter = self._drawing_adapter(monkeypatch)
+
+        result = await adapter.create_drawing_view(
+            {
+                "model_path": __file__,
+                "position": [200.0, 75.0],
+                "orientation": "*CustomView1",
+            }
+        )
+
+        # However it resolves, it must have gotten past both the
+        # "model path required" and "Unknown orientation" checks.
+        assert "Unknown orientation" not in (result.error or "")
+        assert "A model path is required" not in (result.error or "")
 
 
 class TestCreateTechnicalDrawingNoViewsCreated:

--- a/tests/solidworks_mcp/test_solidworks_mixins_coverage.py
+++ b/tests/solidworks_mcp/test_solidworks_mixins_coverage.py
@@ -825,6 +825,183 @@ class TestByrefFallback:
         assert result.value == 0
 
 
+class TestAddMateErrorBranches:
+    """Cover ``add_mate``'s remaining error branches - pre-existing PR #56
+    code, not one of the 7 new-capability PRs this coverage sprint targeted,
+    but closed anyway since the technique generalizes directly.
+
+    ``_as_com`` wraps every component/feature through the real
+    ``win32com.client.dynamic.Dispatch`` before flagging it, which raises on
+    a plain test double (it expects a real COM PyIDispatch). Monkeypatching
+    io.py's module-level ``_dynamic`` alias to an identity passthrough
+    (mirroring its own non-Windows fallback shape, ``SimpleNamespace(Dispatch=...)``)
+    lets ``SimpleNamespace`` components flow through unchanged, the same way
+    the real object would after wrapping.
+    """
+
+    @staticmethod
+    def _identity_dynamic(monkeypatch) -> None:
+        monkeypatch.setattr(
+            "solidworks_mcp.adapters.solidworks.io._dynamic",
+            SimpleNamespace(Dispatch=lambda obj: obj),
+        )
+
+    @staticmethod
+    def _assembly_adapter(monkeypatch) -> PyWin32Adapter:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 2  # Assembly
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_errors_when_not_an_assembly_document(self, monkeypatch) -> None:
+        adapter = _build_adapter(monkeypatch)
+        adapter.currentModel = MagicMock()
+        adapter.currentModel.GetType.return_value = 1  # Part, not an assembly
+
+        result = await adapter.add_mate("part-1", "part-2")
+
+        assert result.is_error
+        assert "requires an assembly document" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_errors_on_unknown_mate_type(self, monkeypatch) -> None:
+        adapter = self._assembly_adapter(monkeypatch)
+
+        result = await adapter.add_mate("part-1", "part-2", mate_type="not_a_type")
+
+        assert result.is_error
+        assert "Unknown mate type" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_errors_on_unknown_alignment(self, monkeypatch) -> None:
+        adapter = self._assembly_adapter(monkeypatch)
+
+        result = await adapter.add_mate("part-1", "part-2", alignment="not_an_alignment")
+
+        assert result.is_error
+        assert "Unknown alignment" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_errors_when_components_unreadable(self, monkeypatch) -> None:
+        adapter = self._assembly_adapter(monkeypatch)
+        adapter.currentModel.GetComponents.return_value = None
+
+        result = await adapter.add_mate("part-1", "part-2")
+
+        assert result.is_error
+        assert "Could not read the assembly's components" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_errors_when_every_component_fails_to_wrap(
+        self, monkeypatch
+    ) -> None:
+        """Exercises both the per-component 'continue' and the resulting
+        'not found' raise: nothing wraps, so nothing can ever match."""
+        adapter = self._assembly_adapter(monkeypatch)
+        monkeypatch.setattr(
+            "solidworks_mcp.adapters.solidworks.io._dynamic",
+            SimpleNamespace(Dispatch=lambda obj: None),
+        )
+        adapter.currentModel.GetComponents.return_value = [object(), object()]
+
+        result = await adapter.add_mate("part-1", "part-2")
+
+        assert result.is_error
+        assert "Component(s) not found" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_errors_when_named_components_are_not_in_the_assembly(
+        self, monkeypatch
+    ) -> None:
+        adapter = self._assembly_adapter(monkeypatch)
+        self._identity_dynamic(monkeypatch)
+        adapter.currentModel.GetComponents.return_value = [
+            SimpleNamespace(Name2="other-part-1"),
+            SimpleNamespace(Name2="other-part-2"),
+        ]
+
+        result = await adapter.add_mate("part-1", "part-2")
+
+        assert result.is_error
+        assert "Component(s) not found: part-1, part-2" in (result.error or "")
+        assert "other-part-1" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_errors_when_entity_not_found_on_component(
+        self, monkeypatch
+    ) -> None:
+        adapter = self._assembly_adapter(monkeypatch)
+        self._identity_dynamic(monkeypatch)
+        adapter.currentModel.GetComponents.return_value = [
+            SimpleNamespace(Name2="part-1", FeatureByName=lambda e: None),
+            SimpleNamespace(Name2="part-2", FeatureByName=lambda e: None),
+        ]
+
+        result = await adapter.add_mate("part-1", "part-2")
+
+        assert result.is_error
+        assert "not found on part-1" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_errors_when_entity_selection_fails(self, monkeypatch) -> None:
+        adapter = self._assembly_adapter(monkeypatch)
+        self._identity_dynamic(monkeypatch)
+        feature = SimpleNamespace(Select2=lambda append, mark: False)
+        adapter.currentModel.GetComponents.return_value = [
+            SimpleNamespace(Name2="part-1", FeatureByName=lambda e: feature),
+            SimpleNamespace(Name2="part-2", FeatureByName=lambda e: feature),
+        ]
+
+        result = await adapter.add_mate("part-1", "part-2")
+
+        assert result.is_error
+        assert "Failed to select" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_errors_when_selected_count_is_not_two(self, monkeypatch) -> None:
+        adapter = self._assembly_adapter(monkeypatch)
+        self._identity_dynamic(monkeypatch)
+        feature = SimpleNamespace(Select2=lambda append, mark: True)
+        adapter.currentModel.GetComponents.return_value = [
+            SimpleNamespace(Name2="part-1", FeatureByName=lambda e: feature),
+            SimpleNamespace(Name2="part-2", FeatureByName=lambda e: feature),
+        ]
+        adapter.currentModel.SelectionManager.GetSelectedObjectCount2.return_value = 1
+
+        result = await adapter.add_mate("part-1", "part-2")
+
+        assert result.is_error
+        assert "Expected 2 selected entities" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_errors_when_solidworks_rejects_the_mate(self, monkeypatch) -> None:
+        """error_status=2 mirrors the documented real measurement: this build
+        reports 1 for success, so anything else (including a successful-looking
+        object with an unhelpful status) is treated as a rejection."""
+        adapter = self._assembly_adapter(monkeypatch)
+        self._identity_dynamic(monkeypatch)
+        feature = SimpleNamespace(Select2=lambda append, mark: True)
+        adapter.currentModel.GetComponents.return_value = [
+            SimpleNamespace(Name2="part-1", FeatureByName=lambda e: feature),
+            SimpleNamespace(Name2="part-2", FeatureByName=lambda e: feature),
+        ]
+        adapter.currentModel.SelectionManager.GetSelectedObjectCount2.return_value = 2
+        adapter.currentModel.AddMate5.return_value = SimpleNamespace()
+
+        def fake_byref_int():
+            return SimpleNamespace(value=2)  # not 1 == success per the docstring
+
+        monkeypatch.setattr(
+            "solidworks_mcp.adapters.solidworks.io._byref_int", fake_byref_int
+        )
+
+        result = await adapter.add_mate("part-1", "part-2")
+
+        assert result.is_error
+        assert "SolidWorks rejected the coincident mate" in (result.error or "")
+
+
 class TestSaveFileLegacyFallback:
     """Cover ``save_file``'s legacy ``Save()`` fallback and unwritten-file raise."""
 

--- a/tests/solidworks_mcp/test_solidworks_mixins_coverage.py
+++ b/tests/solidworks_mcp/test_solidworks_mixins_coverage.py
@@ -25,6 +25,8 @@ from solidworks_mcp.adapters.solidworks.features import (
 )
 from solidworks_mcp.adapters.solidworks.io import (
     SolidWorksIOMixin,
+    _byref_int,
+    _ByrefFallback,
     _payload,
     _payload_dict,
 )
@@ -782,6 +784,45 @@ class TestCreateDrawingNoTemplateConfigured:
 
         assert result.is_error
         assert "No drawing template configured" in (result.error or "")
+
+
+class TestByrefFallback:
+    """Cover ``_ByrefFallback``'s dunder methods directly.
+
+    Earlier assessment (mine, inherited from an automated survey) called
+    this "dead code on Windows+pywin32". That was wrong: it's a plain
+    Python class, reachable any time ``win32com.client.VARIANT`` is
+    unavailable - the exact same monkeypatch already used a few classes up
+    in this file (``test_open_model_uses_int_errors_when_variant_ctor_missing``).
+    No mocking is even needed to cover the dunders themselves.
+    """
+
+    def test_equality_against_seeded_value_and_another_instance(self) -> None:
+        holder = _ByrefFallback(1)
+        assert holder == 1
+        assert holder == _ByrefFallback(1)
+        assert holder != 2
+        assert holder != _ByrefFallback(2)
+
+    def test_hash_and_bool_follow_the_seeded_value(self) -> None:
+        assert hash(_ByrefFallback(5)) == hash(5)
+        assert bool(_ByrefFallback(0)) is False
+        assert bool(_ByrefFallback(1)) is True
+
+    def test_repr_shows_the_seeded_value(self) -> None:
+        assert repr(_ByrefFallback(3)) == "_ByrefFallback(3)"
+
+    def test_byref_int_falls_back_when_variant_ctor_unavailable(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            "solidworks_mcp.adapters.solidworks.io.win32com",
+            SimpleNamespace(client=SimpleNamespace(VARIANT=None)),
+            raising=False,
+        )
+        result = _byref_int()
+        assert isinstance(result, _ByrefFallback)
+        assert result.value == 0
 
 
 class TestSaveFileLegacyFallback:

--- a/tests/solidworks_mcp/tools/test_modeling.py
+++ b/tests/solidworks_mcp/tools/test_modeling.py
@@ -4,22 +4,30 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
+from solidworks_mcp.adapters.base import ExtrusionParameters
 from solidworks_mcp.tools.modeling import (
     AddFilletInput,
     AddMateInput,
     CloseModelInput,
     CreateAssemblyInput,
+    CreateAxisInput,
     CreateCutExtrudeInput,
     CreateDrawingInput,
     CreateExtrusionInput,
     CreateLoftInput,
     CreatePartInput,
+    CreateReferencePlaneInput,
     CreateRevolveInput,
     CreateSweepInput,
+    DeleteFeatureInput,
     GetDimensionInput,
     InsertComponentInput,
+    MirrorFeatureInput,
     OpenModelInput,
+    PatternCircularInput,
     SetDimensionInput,
+    SuppressFeatureInput,
+    UndoInput,
     _result_value,
     register_modeling_tools,
 )
@@ -843,4 +851,468 @@ class TestAssemblyTools:
         result = await tool_func()
 
         assert result["status"] == "error"
-        assert "not an assembly document" in result["message"]
+
+
+class TestFeatureEditingTools:
+    """Test suite for delete_feature / suppress_feature / undo tools."""
+
+    async def _part_with_extrusion(self, mock_adapter) -> str:
+        """Create a part with one extrusion feature; return the feature name."""
+        await mock_adapter.create_part()
+        result = await mock_adapter.create_extrusion(ExtrusionParameters(depth=10.0))
+        return result.data.name
+
+    @pytest.mark.asyncio
+    async def test_delete_feature_success(self, mcp_server, mock_adapter, mock_config):
+        """delete_feature removes the named feature and reports it."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        name = await self._part_with_extrusion(mock_adapter)
+
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "delete_feature"
+        )
+        result = await tool_func(DeleteFeatureInput(name=name))
+
+        assert result["status"] == "success"
+        assert name in result["message"]
+        assert result["data"]["deleted"] == name
+        assert "execution_time" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_feature_error_when_adapter_lacks_capability(
+        self, mcp_server, mock_config
+    ):
+        """A bare object() adapter has no delete_feature - report error, not a fabrication."""
+        await register_modeling_tools(mcp_server, object(), mock_config)
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "delete_feature"
+        )
+        result = await tool_func(DeleteFeatureInput(name="Boss-Extrude1"))
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_delete_feature_surfaces_adapter_error(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """A failed adapter result surfaces the adapter's own error message."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        mock_adapter.delete_feature = AsyncMock(
+            return_value=Mock(is_success=False, error="Feature not found: Ghost1")
+        )
+
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "delete_feature"
+        )
+        result = await tool_func(DeleteFeatureInput(name="Ghost1"))
+
+        assert result["status"] == "error"
+        assert "Feature not found: Ghost1" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_suppress_feature_success(self, mcp_server, mock_adapter, mock_config):
+        """suppress_feature suppresses a known feature and reports the verb used."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        name = await self._part_with_extrusion(mock_adapter)
+
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "suppress_feature"
+        )
+        result = await tool_func(SuppressFeatureInput(name=name, suppress=True))
+
+        assert result["status"] == "success"
+        assert result["message"] == f"Suppressed {name}"
+        assert result["data"]["suppressed"] is True
+
+    @pytest.mark.asyncio
+    async def test_unsuppress_feature_success_reports_unsuppress_verb(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """suppress_feature(suppress=False) reports 'Unsuppressed', not 'Suppressed'."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        name = await self._part_with_extrusion(mock_adapter)
+
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "suppress_feature"
+        )
+        result = await tool_func(SuppressFeatureInput(name=name, suppress=False))
+
+        assert result["status"] == "success"
+        assert result["message"] == f"Unsuppressed {name}"
+
+    @pytest.mark.asyncio
+    async def test_suppress_feature_reports_when_state_unreadable(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """A None 'suppressed' readback appends the disclosure to the message."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        mock_adapter.suppress_feature = AsyncMock(
+            return_value=Mock(
+                is_success=True,
+                data={"feature": "Fillet1", "suppressed": None},
+                execution_time=0.1,
+            )
+        )
+
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "suppress_feature"
+        )
+        result = await tool_func(SuppressFeatureInput(name="Fillet1"))
+
+        assert result["status"] == "success"
+        assert "state could not be read back" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_suppress_feature_error_when_adapter_lacks_capability(
+        self, mcp_server, mock_config
+    ):
+        """A bare object() adapter has no suppress_feature - report error, not a fabrication."""
+        await register_modeling_tools(mcp_server, object(), mock_config)
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "suppress_feature"
+        )
+        result = await tool_func(SuppressFeatureInput(name="Fillet1"))
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_suppress_feature_surfaces_adapter_error(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """A failed adapter result surfaces the adapter's own error message."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        mock_adapter.suppress_feature = AsyncMock(
+            return_value=Mock(is_success=False, error="Feature not found: Ghost1")
+        )
+
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "suppress_feature"
+        )
+        result = await tool_func(SuppressFeatureInput(name="Ghost1"))
+
+        assert result["status"] == "error"
+        assert "Feature not found: Ghost1" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_undo_success_reports_steps_undone(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """undo removes the last feature and reports the step count."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        await self._part_with_extrusion(mock_adapter)
+
+        tool_func = next(t.fn for t in await mcp_server.list_tools() if t.name == "undo")
+        result = await tool_func(UndoInput(count=1))
+
+        assert result["status"] == "success"
+        assert result["message"] == "Undid 1 step(s)"
+        assert result["data"]["tree_changed"] is True
+
+    @pytest.mark.asyncio
+    async def test_undo_with_nothing_to_undo_reports_unchanged_tree(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """undo on an empty feature tree succeeds but reports nothing changed."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        await mock_adapter.create_part()
+
+        tool_func = next(t.fn for t in await mcp_server.list_tools() if t.name == "undo")
+        result = await tool_func(UndoInput(count=1))
+
+        assert result["status"] == "success"
+        assert "nothing to undo" in result["message"]
+        assert result["data"]["tree_changed"] is False
+
+    @pytest.mark.asyncio
+    async def test_undo_defaults_to_one_step_when_no_input_given(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """undo() with no input_data still works, defaulting count to 1."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        await self._part_with_extrusion(mock_adapter)
+
+        tool_func = next(t.fn for t in await mcp_server.list_tools() if t.name == "undo")
+        result = await tool_func(None)
+
+        assert result["status"] == "success"
+        assert result["data"]["requested_steps"] == 1
+
+    @pytest.mark.asyncio
+    async def test_undo_error_when_adapter_lacks_capability(
+        self, mcp_server, mock_config
+    ):
+        """A bare object() adapter has no undo - report error, not a fabrication."""
+        await register_modeling_tools(mcp_server, object(), mock_config)
+        tool_func = next(t.fn for t in await mcp_server.list_tools() if t.name == "undo")
+        result = await tool_func(UndoInput())
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_undo_surfaces_adapter_error(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """A failed adapter result surfaces the adapter's own error message."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        mock_adapter.undo = AsyncMock(
+            return_value=Mock(is_success=False, error="nothing to undo here")
+        )
+
+        tool_func = next(t.fn for t in await mcp_server.list_tools() if t.name == "undo")
+        result = await tool_func(UndoInput())
+
+        assert result["status"] == "error"
+        assert "nothing to undo here" in result["message"]
+
+
+class TestReferenceGeometryTools:
+    """Test suite for create_reference_plane / create_axis tools."""
+
+    @pytest.mark.asyncio
+    async def test_create_reference_plane_success(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """create_reference_plane returns the new plane's details."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        await mock_adapter.create_part()
+
+        tool_func = next(
+            t.fn
+            for t in await mcp_server.list_tools()
+            if t.name == "create_reference_plane"
+        )
+        result = await tool_func(
+            CreateReferencePlaneInput(reference="Front Plane", offset=76.2)
+        )
+
+        assert result["status"] == "success"
+        assert result["plane"]["name"] == "Plane1"
+        assert result["plane"]["offset"] == 76.2
+        assert "Plane1" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_create_reference_plane_error_when_adapter_lacks_capability(
+        self, mcp_server, mock_config
+    ):
+        """A bare object() adapter has no create_reference_plane - report error."""
+        await register_modeling_tools(mcp_server, object(), mock_config)
+        tool_func = next(
+            t.fn
+            for t in await mcp_server.list_tools()
+            if t.name == "create_reference_plane"
+        )
+        result = await tool_func(
+            CreateReferencePlaneInput(reference="Front Plane", offset=10.0)
+        )
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_create_reference_plane_surfaces_adapter_error(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """A failed adapter result (e.g. zero offset) surfaces the adapter's own error."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        await mock_adapter.create_part()
+
+        tool_func = next(
+            t.fn
+            for t in await mcp_server.list_tools()
+            if t.name == "create_reference_plane"
+        )
+        result = await tool_func(
+            CreateReferencePlaneInput(reference="Front Plane", offset=0.0)
+        )
+
+        assert result["status"] == "error"
+        assert "non-zero offset" in result["message"]
+
+    def test_create_reference_plane_input_rejects_blank_reference(self):
+        """CreateReferencePlaneInput.model_post_init rejects a blank reference."""
+        with pytest.raises(ValueError, match="reference is required"):
+            CreateReferencePlaneInput(reference="   ", offset=10.0)
+
+    @pytest.mark.asyncio
+    async def test_create_axis_success(self, mcp_server, mock_adapter, mock_config):
+        """create_axis returns the new axis's plane pair."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        await mock_adapter.create_part()
+
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "create_axis"
+        )
+        result = await tool_func(CreateAxisInput(reference="z"))
+
+        assert result["status"] == "success"
+        assert result["axis"]["name"] == "Axis1"
+        assert result["axis"]["planes"] == ["Top Plane", "Right Plane"]
+        assert "z axis" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_create_axis_error_when_adapter_lacks_capability(
+        self, mcp_server, mock_config
+    ):
+        """A bare object() adapter has no create_axis - report error, not a fabrication."""
+        await register_modeling_tools(mcp_server, object(), mock_config)
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "create_axis"
+        )
+        result = await tool_func(CreateAxisInput(reference="x"))
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_create_axis_surfaces_adapter_error(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """An unknown axis reference surfaces the adapter's own error message."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        await mock_adapter.create_part()
+
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "create_axis"
+        )
+        result = await tool_func(CreateAxisInput(reference="w"))
+
+        assert result["status"] == "error"
+        assert "Unknown axis reference" in result["message"]
+
+    def test_create_axis_input_rejects_blank_reference(self):
+        """CreateAxisInput.model_post_init rejects a blank reference."""
+        with pytest.raises(ValueError, match="reference is required"):
+            CreateAxisInput(reference="   ")
+
+
+class TestMirrorAndPatternTools:
+    """Test suite for mirror_feature / pattern_circular tools."""
+
+    @pytest.mark.asyncio
+    async def test_mirror_feature_success(self, mcp_server, mock_adapter, mock_config):
+        """mirror_feature mirrors a known body about a built-in plane."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        await mock_adapter.create_part()
+        extruded = await mock_adapter.create_extrusion(ExtrusionParameters(depth=10.0))
+
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "mirror_feature"
+        )
+        result = await tool_func(
+            MirrorFeatureInput(
+                features=[extruded.data.name], mirror_plane="Right Plane"
+            )
+        )
+
+        assert result["status"] == "success"
+        assert result["mirror"]["mirror_plane"] == "Right Plane"
+        assert result["mirror"]["volume_ratio"] == pytest.approx(2.0)
+        assert extruded.data.name in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_mirror_feature_error_when_adapter_lacks_capability(
+        self, mcp_server, mock_config
+    ):
+        """A bare object() adapter has no mirror_feature - report error, not a fabrication."""
+        await register_modeling_tools(mcp_server, object(), mock_config)
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "mirror_feature"
+        )
+        result = await tool_func(
+            MirrorFeatureInput(features=["Loft1"], mirror_plane="Right Plane")
+        )
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_mirror_feature_surfaces_adapter_error(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """An unknown source name surfaces the adapter's own error message."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        await mock_adapter.create_part()
+
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "mirror_feature"
+        )
+        result = await tool_func(
+            MirrorFeatureInput(features=["Ghost1"], mirror_plane="Right Plane")
+        )
+
+        assert result["status"] == "error"
+        assert "Failed to select" in result["message"]
+
+    def test_mirror_feature_input_rejects_empty_features(self):
+        """MirrorFeatureInput.model_post_init rejects an empty features list."""
+        with pytest.raises(ValueError, match="features must contain at least one name"):
+            MirrorFeatureInput(features=[], mirror_plane="Right Plane")
+
+    def test_mirror_feature_input_rejects_blank_mirror_plane(self):
+        """MirrorFeatureInput.model_post_init rejects a blank mirror_plane."""
+        with pytest.raises(ValueError, match="mirror_plane is required"):
+            MirrorFeatureInput(features=["Loft1"], mirror_plane="   ")
+
+    @pytest.mark.asyncio
+    async def test_pattern_circular_success(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """pattern_circular patterns a feature around a known axis."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        await mock_adapter.create_part()
+        extruded = await mock_adapter.create_extrusion(ExtrusionParameters(depth=10.0))
+        axis = await mock_adapter.create_axis("z")
+
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "pattern_circular"
+        )
+        result = await tool_func(
+            PatternCircularInput(
+                features=[extruded.data.name], axis=axis.data["name"], count=4
+            )
+        )
+
+        assert result["status"] == "success"
+        assert result["pattern"]["axis"] == axis.data["name"]
+        assert result["pattern"]["count"] == 4
+        assert "4 instances" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_pattern_circular_error_when_adapter_lacks_capability(
+        self, mcp_server, mock_config
+    ):
+        """A bare object() adapter has no pattern_circular - report error, not a fabrication."""
+        await register_modeling_tools(mcp_server, object(), mock_config)
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "pattern_circular"
+        )
+        result = await tool_func(
+            PatternCircularInput(features=["Boss-Extrude1"], axis="Axis1", count=4)
+        )
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_pattern_circular_surfaces_adapter_error(
+        self, mcp_server, mock_adapter, mock_config
+    ):
+        """An unknown axis name surfaces the adapter's own error message."""
+        await register_modeling_tools(mcp_server, mock_adapter, mock_config)
+        await mock_adapter.create_part()
+
+        tool_func = next(
+            t.fn for t in await mcp_server.list_tools() if t.name == "pattern_circular"
+        )
+        result = await tool_func(
+            PatternCircularInput(
+                features=["Boss-Extrude1"], axis="NoSuchAxis", count=4
+            )
+        )
+
+        assert result["status"] == "error"
+        assert "Failed to select axis" in result["message"]
+
+    def test_pattern_circular_input_rejects_empty_features(self):
+        """PatternCircularInput.model_post_init rejects an empty features list."""
+        with pytest.raises(ValueError, match="features must contain at least one name"):
+            PatternCircularInput(features=[], axis="Axis1", count=4)
+
+    def test_pattern_circular_input_rejects_blank_axis(self):
+        """PatternCircularInput.model_post_init rejects a blank axis."""
+        with pytest.raises(ValueError, match="axis is required"):
+            PatternCircularInput(features=["Boss-Extrude1"], axis="   ", count=4)
+
+    def test_pattern_circular_input_rejects_count_below_two(self):
+        """PatternCircularInput.model_post_init rejects a count under 2."""
+        with pytest.raises(ValueError, match="count must be at least 2"):
+            PatternCircularInput(features=["Boss-Extrude1"], axis="Axis1", count=1)

--- a/tests/test_coverage_pywin32_adapter_ext.py
+++ b/tests/test_coverage_pywin32_adapter_ext.py
@@ -207,7 +207,10 @@ class TestPyWin32AdapterMockCOM:
                 from solidworks_mcp.adapters.pywin32_adapter import PyWin32Adapter
 
                 # Mock pythoncom and win32com
-                with patch("solidworks_mcp.adapters.pywin32_adapter.pythoncom"):
+                with patch("solidworks_mcp.adapters.pywin32_adapter.pythoncom"), patch(
+                    "solidworks_mcp.adapters.pywin32_adapter.asyncio.sleep",
+                    new=AsyncMock(),
+                ):
                     with patch(
                         "solidworks_mcp.adapters.pywin32_adapter.win32com.client"
                     ) as mock_client:
@@ -216,15 +219,26 @@ class TestPyWin32AdapterMockCOM:
                         mock_client.GetObject.return_value = mock_app
                         mock_client.Dispatch.return_value = mock_app
 
-                        adapter = PyWin32Adapter({"timeout": 30})
+                        # acquire_solidworks_application() late-binds through
+                        # the module-level _dynamic_module reference, not
+                        # win32com.client - unless this is stubbed too, it
+                        # falls through to the *real* pywin32
+                        # dynamic.Dispatch("SldWorks.Application") on any
+                        # dev box with real SolidWorks installed.
+                        with patch(
+                            "solidworks_mcp.adapters.pywin32_adapter._dynamic_module"
+                        ) as mock_dynamic:
+                            mock_dynamic.Dispatch.return_value = mock_app
 
-                        # Mock the COM model
-                        mock_model = MagicMock()
-                        mock_app.OpenDoc6.return_value = mock_model
+                            adapter = PyWin32Adapter({"timeout": 30})
 
-                        # Try to connect (might fail but should reach COM calls)
-                        try:
-                            await adapter.connect()
-                        except Exception:
-                            # Expected to fail without real SolidWorks
-                            pass
+                            # Mock the COM model
+                            mock_model = MagicMock()
+                            mock_app.OpenDoc6.return_value = mock_model
+
+                            # Try to connect (might fail but should reach COM calls)
+                            try:
+                                await adapter.connect()
+                            except Exception:
+                                # Expected to fail without real SolidWorks
+                                pass


### PR DESCRIPTION
## Summary
- Closed the tool-layer coverage gap for all 7 new PR #65-71 capabilities (`delete_feature`, `suppress_feature`, `undo`, `create_reference_plane`, `create_axis`, `mirror_feature`, `pattern_circular`) - the adapter logic was already real-SW tested, but nothing exercised input validation or response formatting.
- Added a `dev-test-combined` command to `dev-commands.ps1`: runs the mock suite in parallel and the real-SolidWorks suite serially as two separate coverage sessions, then merges them with `coverage combine` into one true report - so a line only reachable via real COM isn't misreported as "uncovered" just because it's invisible to a mock-only run.
- Using that combined view, went through every remaining line in `src/solidworks_mcp/adapters/solidworks/features.py` and `io.py` one by one and closed all of them. **Both files are now at 100% combined coverage** (mock + real-SolidWorks).
- Fixed a real OOM bug: `-n auto` on pytest-xdist spawns a worker per logical CPU (24 on this dev machine), starving available RAM once VSCode + SolidWorks are running. Capped at `-n 4` for both `dev-test` and `dev-test-combined`.
- Fixed 14 instances of mojibake-corrupted em-dashes in `features.py` docstrings (UTF-8 bytes mis-decoded during an earlier merge).
- Corrected an earlier (incorrect) claim that `_ByrefFallback` was dead code - it's reachable via the same monkeypatch technique already used elsewhere in the suite, so it's now tested directly instead of documented as unreachable.

## Test plan
- [x] Full mock suite: 2223 passed, 0 failed (`-m "not solidworks_only"`)
- [x] Full real-SolidWorks suite: 82 passed, 0 failed (`-m "solidworks_only"`, live SW required)
- [x] Combined coverage (`coverage combine` of both runs): `features.py` 100%, `io.py` 100%, whole-repo TOTAL 99%
- [x] `dev-test-combined` validated end-to-end as an actual PowerShell command, not just the equivalent manual steps